### PR TITLE
New technique : aws.discovery.ec2-get-user-data

### DIFF
--- a/internal/attacktechniques/aws/discovery/ec2-get-user-data/main.go
+++ b/internal/attacktechniques/aws/discovery/ec2-get-user-data/main.go
@@ -35,7 +35,7 @@ See:
 
 Warm-up: 
 
-- Create an IAM role with permissions to run ec2:DescribeInstanceAttribute
+- Create an IAM role without permissions to run ec2:DescribeInstanceAttribute
 
 Detonation: 
 

--- a/internal/attacktechniques/aws/discovery/ec2-get-user-data/main.go
+++ b/internal/attacktechniques/aws/discovery/ec2-get-user-data/main.go
@@ -9,6 +9,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/credentials/stscreds"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	"github.com/aws/aws-sdk-go-v2/service/sts"
 
 	"github.com/datadog/stratus-red-team/internal/utils"
@@ -73,7 +74,7 @@ func detonate(params map[string]string) error {
 		// Call DescribeInstanceAttribute to retrieve the userData attribute
 		// Expected Client.UnauthorizedOperation
 		ec2Client.DescribeInstanceAttribute(context.Background(), &ec2.DescribeInstanceAttributeInput{
-			Attribute:  "userData",
+			Attribute:  types.InstanceAttributeNameUserData,
 			InstanceId: &instanceId,
 		})
 

--- a/internal/attacktechniques/aws/discovery/ec2-get-user-data/main.go
+++ b/internal/attacktechniques/aws/discovery/ec2-get-user-data/main.go
@@ -77,12 +77,6 @@ func detonate(params map[string]string) error {
 			InstanceId: &instanceId,
 		})
 
-		ec2Client.DescribeInstanceAttribute(context.Background(), &ec2.DescribeInstanceAttributeInput{
-			Attribute:  "",
-			InstanceId: new(string),
-			DryRun:     new(bool),
-		})
-
 		log.Println("Running ec2:DescribeInstanceAttribute to retrieve userData on " + instanceId)
 	}
 

--- a/internal/attacktechniques/aws/discovery/ec2-get-user-data/main.go
+++ b/internal/attacktechniques/aws/discovery/ec2-get-user-data/main.go
@@ -1,0 +1,89 @@
+package aws
+
+import (
+	"context"
+	_ "embed"
+	"log"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/credentials/stscreds"
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	"github.com/aws/aws-sdk-go-v2/service/sts"
+
+	"github.com/datadog/stratus-red-team/internal/utils"
+	"github.com/datadog/stratus-red-team/pkg/stratus"
+	"github.com/datadog/stratus-red-team/pkg/stratus/mitreattack"
+)
+
+//go:embed main.tf
+var tf []byte
+
+func init() {
+	stratus.GetRegistry().RegisterAttackTechnique(&stratus.AttackTechnique{
+		ID:           "aws.exfiltration.ec2-download-user-data",
+		FriendlyName: "Download EC2 Instance User Data",
+		Description: `
+Runs ec2:DescribeInstanceAttribute on several instances. This simulates an attacker attempting to
+retrieve Instance User Data that may include installation scripts and hard-coded secrets for deployment.
+
+See: 
+
+- https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html
+- https://hackingthe.cloud/aws/general-knowledge/introduction_user_data/
+- https://github.com/RhinoSecurityLabs/pacu/blob/master/pacu/modules/ec2__download_userdata/main.py
+
+Warm-up: 
+
+- Create an IAM role with permissions to run ec2:DescribeInstanceAttribute
+
+Detonation: 
+
+- Run ec2:DescribeInstanceAttribute on multiple fake instances
+`,
+		/* Detection: `
+
+		Through CloudTrail's <code>DescribeInstanceAttribute</code> event.
+
+		See:
+		* [Associated Sigma rule](https://github.com/SigmaHQ/sigma/blob/master/rules/cloud/aws/aws_ec2_download_userdata.yml)`, */
+		Platform:                   stratus.AWS,
+		IsIdempotent:               true,
+		MitreAttackTactics:         []mitreattack.Tactic{mitreattack.Discovery},
+		PrerequisitesTerraformCode: tf,
+		Detonate:                   detonate,
+	})
+}
+
+const numCalls = 15
+
+func detonate(params map[string]string) error {
+	roleArn := params["role_arn"]
+
+	cfg, _ := config.LoadDefaultConfig(context.Background())
+	stsClient := sts.NewFromConfig(cfg)
+	cfg.Credentials = aws.NewCredentialsCache(stscreds.NewAssumeRoleProvider(stsClient, roleArn))
+	ec2Client := ec2.NewFromConfig(cfg)
+
+	for i := 0; i < numCalls; i++ {
+		// Generate a fake, real-looking instance ID
+		instanceId := "i-" + utils.RandomHexString(8)
+
+		// Call DescribeInstanceAttribute to retrieve the userData attribute
+		// Expected Client.UnauthorizedOperation
+		ec2Client.DescribeInstanceAttribute(context.Background(), &ec2.DescribeInstanceAttributeInput{
+			Attribute:  "userData",
+			InstanceId: &instanceId,
+		})
+
+		ec2Client.DescribeInstanceAttribute(context.Background(), &ec2.DescribeInstanceAttributeInput{
+			Attribute:  "",
+			InstanceId: new(string),
+			DryRun:     new(bool),
+		})
+
+		log.Println("Running ec2:DescribeInstanceAttribute to retrieve userData on " + instanceId)
+	}
+
+	return nil
+}

--- a/internal/attacktechniques/aws/discovery/ec2-get-user-data/main.go
+++ b/internal/attacktechniques/aws/discovery/ec2-get-user-data/main.go
@@ -43,12 +43,12 @@ Detonation:
 - Run ec2:DescribeInstanceAttribute on multiple fictitious instance IDs
 - These calls will result in access denied errors
 `,
-		/* Detection: `
+		Detection: `
 
 		Through CloudTrail's <code>DescribeInstanceAttribute</code> event.
 
 		See:
-		* [Associated Sigma rule](https://github.com/SigmaHQ/sigma/blob/master/rules/cloud/aws/aws_ec2_download_userdata.yml)`, */
+		* [Associated Sigma rule](https://github.com/SigmaHQ/sigma/blob/master/rules/cloud/aws/aws_ec2_download_userdata.yml)`,
 		Platform:                   stratus.AWS,
 		IsIdempotent:               true,
 		MitreAttackTactics:         []mitreattack.Tactic{mitreattack.Discovery},

--- a/internal/attacktechniques/aws/discovery/ec2-get-user-data/main.go
+++ b/internal/attacktechniques/aws/discovery/ec2-get-user-data/main.go
@@ -39,7 +39,8 @@ Warm-up:
 
 Detonation: 
 
-- Run ec2:DescribeInstanceAttribute on multiple fake instances
+- Run ec2:DescribeInstanceAttribute on multiple fictitious instance IDs
+- These calls will result in access denied errors
 `,
 		/* Detection: `
 

--- a/internal/attacktechniques/aws/discovery/ec2-get-user-data/main.go
+++ b/internal/attacktechniques/aws/discovery/ec2-get-user-data/main.go
@@ -21,7 +21,7 @@ var tf []byte
 
 func init() {
 	stratus.GetRegistry().RegisterAttackTechnique(&stratus.AttackTechnique{
-		ID:           "aws.exfiltration.ec2-download-user-data",
+		ID:           "aws.discovery.ec2-download-user-data",
 		FriendlyName: "Download EC2 Instance User Data",
 		Description: `
 Runs ec2:DescribeInstanceAttribute on several instances. This simulates an attacker attempting to

--- a/internal/attacktechniques/aws/discovery/ec2-get-user-data/main.tf
+++ b/internal/attacktechniques/aws/discovery/ec2-get-user-data/main.tf
@@ -1,0 +1,56 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 3.71.0"
+    }
+  }
+}
+provider "aws" {
+  skip_region_validation      = true
+  skip_credentials_validation = true
+  skip_get_ec2_platforms      = true
+  skip_metadata_api_check     = true
+  default_tags {
+    tags = {
+      StratusRedTeam = true
+    }
+  }
+}
+
+data "aws_caller_identity" "current" {}
+
+resource "aws_iam_role" "role" {
+  name = "sample-role-used-by-stratus"
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = "sts:AssumeRole"
+        Effect = "Allow"
+        Sid    = ""
+        Principal = {
+          AWS = data.aws_caller_identity.current.account_id
+        }
+      },
+    ]
+  })
+
+  inline_policy {
+    name = "inline-policy"
+    policy = jsonencode({
+      Version = "2012-10-17"
+      Statement = [
+        {
+          Action   = ["ec2:DescribeInstances"]
+          Effect   = "Allow"
+          Resource = "*"
+        },
+      ]
+    })
+  }
+}
+
+output "role_arn" {
+  value = aws_iam_role.role.arn
+}

--- a/internal/attacktechniques/main.go
+++ b/internal/attacktechniques/main.go
@@ -12,6 +12,7 @@ import (
 	_ "github.com/datadog/stratus-red-team/internal/attacktechniques/aws/defense-evasion/organizations-leave"
 	_ "github.com/datadog/stratus-red-team/internal/attacktechniques/aws/defense-evasion/vpc-remove-flow-logs"
 	_ "github.com/datadog/stratus-red-team/internal/attacktechniques/aws/discovery/ec2-enumerate-from-instance"
+	_ "github.com/datadog/stratus-red-team/internal/attacktechniques/aws/discovery/ec2-get-user-data"
 	_ "github.com/datadog/stratus-red-team/internal/attacktechniques/aws/execution/ec2-user-data"
 	_ "github.com/datadog/stratus-red-team/internal/attacktechniques/aws/exfiltration/ec2-security-group-open-port-22-ingress"
 	_ "github.com/datadog/stratus-red-team/internal/attacktechniques/aws/exfiltration/ec2-share-ami"

--- a/internal/utils/functions.go
+++ b/internal/utils/functions.go
@@ -22,3 +22,12 @@ func RandomString(length int) string {
 	}
 	return string(b)
 }
+
+func RandomHexString(length int) string {
+	const letterBytes = "abcdef0123456789"
+	b := make([]byte, length)
+	for i := range b {
+		b[i] = letterBytes[rand.Intn(len(letterBytes))]
+	}
+	return string(b)
+}


### PR DESCRIPTION
Implements the technique described in #62.

aws.exfiltration.ec2-download-user-data

Runs ec2:DescribeInstanceAttribute on several instances (non-existent, and unauthorized). This simulates an attacker attempting to retrieve Instance User Data that may include installation scripts and hard-coded secrets for deployment.

References:
- https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html
- https://hackingthe.cloud/aws/general-knowledge/introduction_user_data/
- https://github.com/RhinoSecurityLabs/pacu/blob/master/pacu/modules/ec2__download_userdata/main.py

I added a detection comment for https://github.com/DataDog/stratus-red-team/pull/81