### PR TITLE
Quick fix detection doc for aws.discovery.ec2-get-user-data

### DIFF
--- a/internal/attacktechniques/aws/discovery/ec2-get-user-data/main.go
+++ b/internal/attacktechniques/aws/discovery/ec2-get-user-data/main.go
@@ -44,11 +44,11 @@ Detonation:
 - These calls will result in access denied errors
 `,
 		Detection: `
+Through CloudTrail's <code>DescribeInstanceAttribute</code> event.
 
-		Through CloudTrail's <code>DescribeInstanceAttribute</code> event.
+See:
 
-		See:
-		* [Associated Sigma rule](https://github.com/SigmaHQ/sigma/blob/master/rules/cloud/aws/aws_ec2_download_userdata.yml)`,
+* [Associated Sigma rule](https://github.com/SigmaHQ/sigma/blob/master/rules/cloud/aws/aws_ec2_download_userdata.yml)`,
 		Platform:                   stratus.AWS,
 		IsIdempotent:               true,
 		MitreAttackTactics:         []mitreattack.Tactic{mitreattack.Discovery},


### PR DESCRIPTION
Fixing this by deleting the indentation:
![image](https://user-images.githubusercontent.com/83589789/152316002-3d4be143-b778-4e35-82b7-b2d22176712b.png)
