### PR TITLE
Customize K8s user-agent

### DIFF
--- a/internal/providers/aws.go
+++ b/internal/providers/aws.go
@@ -47,8 +47,6 @@ func (m *AWSProvider) IsAuthenticatedAgainstAWS() bool {
 // Functions below are related to customization of the user-agent header
 // Code taken from https://github.com/aws/aws-sdk-go-v2/issues/1432
 
-const StratusUserAgent = "stratus-red-team"
-
 var customUserAgentApiOptions = config.WithAPIOptions(func() (v []func(stack *middleware.Stack) error) {
 	v = append(v, attachCustomMiddleware)
 	return v

--- a/internal/providers/kubernetes.go
+++ b/internal/providers/kubernetes.go
@@ -72,6 +72,7 @@ func (m *K8sProvider) GetClient() *kubernetes.Clientset {
 	if err != nil {
 		log.Fatalf("unable to build kube config: %v", err)
 	}
+	config.UserAgent = StratusUserAgent
 	m.k8sClient, err = kubernetes.NewForConfig(config)
 	if err != nil {
 		log.Fatalf("unable to create kube client: %v", err)

--- a/internal/providers/main.go
+++ b/internal/providers/main.go
@@ -1,0 +1,3 @@
+package providers
+
+const StratusUserAgent = "stratus-red-team"


### PR DESCRIPTION
### What does this PR do?

Use a custom user-agent when interacting with the Kubernetes API server

### Motivation

- Make Stratus Red Team requests more visible

### Testing

Before:

![image](https://user-images.githubusercontent.com/136675/152789334-9d108a06-d85d-4b30-b3b8-c3fd00028dc1.png)


After:

![image](https://user-images.githubusercontent.com/136675/152789366-955a773a-cac3-4ff2-b6f2-a5f14329798f.png)
