### PR TITLE
Network interfaces not attached to ec2 instances

### DIFF
--- a/internal/attacktechniques/aws/credential-access/ec2-steal-instance-credentials/main.tf
+++ b/internal/attacktechniques/aws/credential-access/ec2-steal-instance-credentials/main.tf
@@ -6,6 +6,7 @@ terraform {
     }
   }
 }
+
 provider "aws" {
   skip_region_validation      = true
   skip_credentials_validation = true
@@ -17,7 +18,6 @@ provider "aws" {
     }
   }
 }
-
 
 data "aws_availability_zones" "available" {
   state = "available"
@@ -55,6 +55,7 @@ resource "aws_network_interface" "iface" {
   subnet_id   = module.vpc.private_subnets[0]
   private_ips = ["10.0.1.10"]
 }
+
 resource "aws_iam_role" "instance-role" {
   name = "stratus-ec2-credentials-instance-role"
   path = "/"
@@ -90,10 +91,12 @@ EOF
 EOF
   }
 }
+
 resource "aws_iam_role_policy_attachment" "rolepolicy" {
   role       = aws_iam_role.instance-role.name
   policy_arn = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
 }
+
 resource "aws_iam_instance_profile" "instance" {
   name = "stratus-ec2-credentials-instance"
   role = aws_iam_role.instance-role.name
@@ -103,6 +106,10 @@ resource "aws_instance" "instance" {
   ami                  = data.aws_ami.amazon-2.id
   instance_type        = "t3.micro"
   iam_instance_profile = aws_iam_instance_profile.instance.name
+  network_interface {
+    device_index = 0
+    network_interface_id = aws_network_interface.iface.id
+  }
 }
 
 output "instance_id" {

--- a/internal/attacktechniques/aws/discovery/ec2-enumerate-from-instance/main.tf
+++ b/internal/attacktechniques/aws/discovery/ec2-enumerate-from-instance/main.tf
@@ -6,6 +6,7 @@ terraform {
     }
   }
 }
+
 provider "aws" {
   skip_region_validation      = true
   skip_credentials_validation = true
@@ -17,7 +18,6 @@ provider "aws" {
     }
   }
 }
-
 
 data "aws_availability_zones" "available" {
   state = "available"
@@ -55,6 +55,7 @@ resource "aws_network_interface" "iface" {
   subnet_id   = module.vpc.private_subnets[0]
   private_ips = ["10.0.1.10"]
 }
+
 resource "aws_iam_role" "instance-role" {
   name = "stratus-discovery-instance-role"
   path = "/"
@@ -75,10 +76,12 @@ resource "aws_iam_role" "instance-role" {
 }
 EOF
 }
+
 resource "aws_iam_role_policy_attachment" "rolepolicy" {
   role       = aws_iam_role.instance-role.name
   policy_arn = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
 }
+
 resource "aws_iam_instance_profile" "instance" {
   name = "stratus-discovery-instance"
   role = aws_iam_role.instance-role.name
@@ -88,6 +91,10 @@ resource "aws_instance" "dev" {
   ami                  = data.aws_ami.amazon-2.id
   instance_type        = "t3.micro"
   iam_instance_profile = aws_iam_instance_profile.instance.name
+  network_interface {
+    device_index = 0
+    network_interface_id = aws_network_interface.iface.id
+  }
 }
 
 output "instance_id" {

--- a/internal/attacktechniques/aws/execution/ec2-user-data/main.tf
+++ b/internal/attacktechniques/aws/execution/ec2-user-data/main.tf
@@ -6,6 +6,7 @@ terraform {
     }
   }
 }
+
 provider "aws" {
   skip_region_validation      = true
   skip_credentials_validation = true
@@ -55,6 +56,7 @@ resource "aws_network_interface" "iface" {
   subnet_id   = module.vpc.private_subnets[0]
   private_ips = ["10.0.1.10"]
 }
+
 resource "aws_iam_role" "instance-role" {
   name = "stratus-ec2-privilege-escalation-instance-role"
   path = "/"
@@ -75,10 +77,12 @@ resource "aws_iam_role" "instance-role" {
 }
 EOF
 }
+
 resource "aws_iam_role_policy_attachment" "rolepolicy" {
   role       = aws_iam_role.instance-role.name
   policy_arn = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
 }
+
 resource "aws_iam_instance_profile" "instance" {
   name = "stratus-ec2-privilege-escalation-instance"
   role = aws_iam_role.instance-role.name
@@ -89,6 +93,10 @@ resource "aws_instance" "instance" {
   instance_type        = "t3.micro"
   iam_instance_profile = aws_iam_instance_profile.instance.name
   user_data            = "echo 'Legitimate user data'"
+  network_interface {
+    device_index = 0
+    network_interface_id = aws_network_interface.iface.id
+  }
 }
 
 output "instance_id" {


### PR DESCRIPTION
### What does this PR do?

* Bug fix

### Motivation

Terrform scripts for multiple techniques creates a static IP for ec2 instances using aws_network_interface. The interface is never attached to the ec2 instances, therefore instances are launched into the region's default VPC instead of one created with stratus.

This was discovered because AWS account was setup using recommended control [[EC2.2] The VPC default security group should not allow inbound and outbound traffic](https://docs.aws.amazon.com/securityhub/latest/userguide/securityhub-standards-fsbp-controls.html#fsbp-ec2-2)

The PR fix attaches the network interfaces to the instances for each technique that were broken.

### Checklist

