### PR TITLE
[bugfix] handle platform authentication checks more smoothly

### DIFF
--- a/cmd/stratus/detonate_cmd.go
+++ b/cmd/stratus/detonate_cmd.go
@@ -49,6 +49,7 @@ func buildDetonateCmd() *cobra.Command {
 	return detonateCmd
 }
 func doDetonateCmd(techniques []*stratus.AttackTechnique, cleanup bool) {
+	VerifyPlatformRequirements(techniques)
 	workerCount := len(techniques)
 	techniquesChan := make(chan *stratus.AttackTechnique, workerCount)
 	errorsChan := make(chan error, workerCount)

--- a/cmd/stratus/revert_cmd.go
+++ b/cmd/stratus/revert_cmd.go
@@ -42,6 +42,7 @@ func buildRevertCmd() *cobra.Command {
 }
 
 func doRevertCmd(techniques []*stratus.AttackTechnique) {
+	VerifyPlatformRequirements(techniques)
 	workerCount := len(techniques)
 	techniquesChan := make(chan *stratus.AttackTechnique, workerCount)
 	errorsChan := make(chan error, workerCount)

--- a/cmd/stratus/util.go
+++ b/cmd/stratus/util.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"errors"
+	"github.com/datadog/stratus-red-team/internal/providers"
 	"github.com/datadog/stratus-red-team/pkg/stratus"
 	"github.com/jedib0t/go-pretty/v6/table"
 	"log"
@@ -38,4 +39,21 @@ func handleErrorsChannel(errors <-chan error, jobsCount int) bool {
 	}
 
 	return hasError
+}
+
+// VerifyPlatformRequirements ensures that the user is properly authenticated against all platforms
+// of a list of attack techniques
+func VerifyPlatformRequirements(attackTechniques []*stratus.AttackTechnique) {
+	platforms := map[stratus.Platform]bool{}
+	for i := range attackTechniques {
+		currentPlatform := attackTechniques[i].Platform
+		if _, checked := platforms[currentPlatform]; !checked {
+			log.Println("Checking your authentication against " + string(currentPlatform))
+			err := providers.EnsureAuthenticated(currentPlatform)
+			if err != nil {
+				log.Fatalf(err.Error())
+			}
+			platforms[currentPlatform] = true
+		}
+	}
 }

--- a/cmd/stratus/warmup_cmd.go
+++ b/cmd/stratus/warmup_cmd.go
@@ -41,6 +41,7 @@ func buildWarmupCmd() *cobra.Command {
 }
 
 func doWarmupCmd(techniques []*stratus.AttackTechnique) {
+	VerifyPlatformRequirements(techniques)
 	workerCount := len(techniques)
 	techniquesChan := make(chan *stratus.AttackTechnique, workerCount)
 	errorsChan := make(chan error, workerCount)

--- a/internal/providers/main.go
+++ b/internal/providers/main.go
@@ -1,3 +1,29 @@
 package providers
 
+import (
+	"errors"
+	"github.com/datadog/stratus-red-team/pkg/stratus"
+)
+
 const StratusUserAgent = "stratus-red-team"
+
+// EnsureAuthenticated ensures that the current user is properly authenticated against a specific platform
+func EnsureAuthenticated(platform stratus.Platform) error {
+	switch platform {
+	case stratus.AWS:
+		if !AWS().IsAuthenticatedAgainstAWS() {
+			return errors.New("you are not authenticated against AWS, or you have not set your region. " +
+				"Make sure you are authenticated against AWS, and you have a default region set in your AWS config " +
+				"or environment (export AWS_DEFAULT_REGION=us-east-1)")
+		}
+	case stratus.Kubernetes:
+		if !K8s().IsAuthenticated() {
+			return errors.New("You do not have a kubeconfig set up, or you do not have proper permissions for " +
+				"this cluster. Make sure you have proper credentials set in " + GetKubeConfigPath())
+		}
+	default:
+		return errors.New("unhandled platform " + string(platform))
+	}
+
+	return nil
+}

--- a/pkg/stratus/runner/runner.go
+++ b/pkg/stratus/runner/runner.go
@@ -6,7 +6,6 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/datadog/stratus-red-team/internal/providers"
 	"github.com/datadog/stratus-red-team/internal/state"
 	"github.com/datadog/stratus-red-team/internal/utils"
 	"github.com/datadog/stratus-red-team/pkg/stratus"
@@ -38,7 +37,6 @@ func NewRunner(technique *stratus.AttackTechnique, force bool) Runner {
 }
 
 func (m *Runner) initialize() {
-	m.ValidatePlatformRequirements()
 	m.TerraformDir = filepath.Join(m.StateManager.GetRootDirectory(), m.Technique.ID)
 	m.TechniqueState = m.StateManager.GetTechniqueState()
 	if m.TechniqueState == "" {
@@ -186,24 +184,6 @@ func (m *Runner) CleanUp() error {
 	}
 
 	return utils.CoalesceErr(techniqueRevertErr, prerequisitesCleanupErr, err)
-}
-
-func (m *Runner) ValidatePlatformRequirements() {
-	switch m.Technique.Platform {
-	case stratus.AWS:
-		log.Println("Checking your authentication against the AWS API")
-		if !providers.AWS().IsAuthenticatedAgainstAWS() {
-			log.Fatal("You are not authenticated against AWS, or you have not set your region. " +
-				"Make sure you are authenticated against AWS, and you have a default region set in your AWS config or environment" +
-				" (export AWS_DEFAULT_REGION=us-east-1)")
-		}
-	case stratus.Kubernetes:
-		log.Println("Checking your authentication against Kubernetes")
-		if !providers.K8s().IsAuthenticated() {
-			log.Fatalf("You do not have a kubeconfig set up, or you do not have proper permissions for this cluster. "+
-				"Make sure you have proper credentials set in %s", providers.GetKubeConfigPath())
-		}
-	}
 }
 
 func (m *Runner) GetState() stratus.AttackTechniqueState {


### PR DESCRIPTION
Now, **instead of:** Check for authentication against the right API (AWS, K8s) for each attack technique

We do:
- First, get the set of platforms for which a set of techniques is applicable
- Perform the check only once per platform

For `cleanup --all`, we don't handle these checks and we let the cleanup command fail if the user isn't properly authenticated. This is because the logic of "knowing we call `runner.CleanUp()`, do we cleanup depending on the current technique state" is in the runner, and it's better not to entangle the logic.

4c67121 also fixes the cleanup error propagation to avoid a situation where `revert` fails and the TTP is still marked as "cleaned up"