### PR TITLE
Add CMK to EBS exfil techniques

### DIFF
--- a/internal/attacktechniques/aws/exfiltration/ec2-share-ami/main.tf
+++ b/internal/attacktechniques/aws/exfiltration/ec2-share-ami/main.tf
@@ -22,9 +22,16 @@ data "aws_availability_zones" "available" {
   state = "available"
 }
 
+resource "aws_kms_key" "cmk" {
+  description = "Stratus Red Team CMK for AMI encryption"
+  deletion_window_in_days = 7
+}
+
 resource "aws_ebs_volume" "volume" {
   availability_zone = data.aws_availability_zones.available.names[0]
   size              = 1
+  encrypted         = true
+  aws_kms_key       = aws_kms_key.cmk.arn
 
   tags = {
     Name = "StratusRedTeamVolumeForAmi"

--- a/internal/attacktechniques/aws/exfiltration/ec2-share-ebs-snapshot/main.tf
+++ b/internal/attacktechniques/aws/exfiltration/ec2-share-ebs-snapshot/main.tf
@@ -22,9 +22,16 @@ data "aws_availability_zones" "available" {
   state = "available"
 }
 
+resource "aws_kms_key" "cmk" {
+  description = "Stratus Red Team CMK for EBS encryption"
+  deletion_window_in_days = 7
+}
+
 resource "aws_ebs_volume" "volume" {
   availability_zone = data.aws_availability_zones.available.names[0]
   size              = 1
+  encrypted         = true
+  aws_kms_key       = aws_kms_key.cmk.arn
 
   tags = {
     Name = "StratusRedTeamVolume"


### PR DESCRIPTION
### What does this PR do?

* Bug fix

### Motivation

Proposed fix for #109 by adding a CMK to the EBS volumes. This will then allow the EBS exfil techniques to work when account has EBS default encryption enabled.

The CMK are set to expire in the shortest possible time allowed in AWS.

### Checklist
