### PR TITLE
Exfiltration of EBS snapshots and AMIs: Handle error when EBS encryption by default is enabled (closes #109)

### DIFF
--- a/internal/attacktechniques/aws/exfiltration/ec2-share-ami/main.go
+++ b/internal/attacktechniques/aws/exfiltration/ec2-share-ami/main.go
@@ -8,6 +8,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
 	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	"github.com/datadog/stratus-red-team/internal/providers"
+	"github.com/datadog/stratus-red-team/internal/utils"
 	"github.com/datadog/stratus-red-team/pkg/stratus"
 	"github.com/datadog/stratus-red-team/pkg/stratus/mitreattack"
 	"log"
@@ -72,6 +73,13 @@ func detonate(params map[string]string) error {
 			Add: amiPermissions,
 		},
 	})
+
+	if err != nil && utils.IsErrorDueToEBSEncryptionByDefault(err) {
+		log.Println("Note: Stratus detonated the attack, but the sharing was unsuccessful. " +
+			"This is likely because EBS default encryption is enabled in the region. " +
+			"Nonetheless, it did simulate a plausible attacker action.")
+		return nil
+	}
 
 	if err != nil {
 		return errors.New("Unable to share AMI with external AWS account: " + err.Error())

--- a/internal/attacktechniques/aws/exfiltration/ec2-share-ebs-snapshot/main.go
+++ b/internal/attacktechniques/aws/exfiltration/ec2-share-ebs-snapshot/main.go
@@ -6,6 +6,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
 	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	"github.com/datadog/stratus-red-team/internal/providers"
+	"github.com/datadog/stratus-red-team/internal/utils"
 	"github.com/datadog/stratus-red-team/pkg/stratus"
 	"github.com/datadog/stratus-red-team/pkg/stratus/mitreattack"
 	"log"
@@ -73,6 +74,14 @@ func detonate(params map[string]string) error {
 			Add: []types.CreateVolumePermission{{UserId: &ShareWithAccountId}},
 		},
 	})
+
+	if err != nil && utils.IsErrorDueToEBSEncryptionByDefault(err) {
+		log.Println("Note: Stratus detonated the attack, but the sharing was unsuccessful. " +
+			"This is likely because EBS default encryption is enabled in the region. " +
+			"Nonetheless, it did simulate a plausible attacker action.")
+		return nil
+	}
+	
 	return err
 }
 

--- a/internal/utils/aws_utils_test.go
+++ b/internal/utils/aws_utils_test.go
@@ -1,0 +1,20 @@
+package utils
+
+import (
+	"errors"
+	"github.com/aws/aws-sdk-go-v2/service/cloudtrail/types"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestIsErrorRelatedToEbsEncryptionByDefault(t *testing.T) {
+	assert.False(t, IsErrorDueToEBSEncryptionByDefault(nil))
+	assert.False(t, IsErrorDueToEBSEncryptionByDefault(errors.New("foo")))
+	assert.False(t, IsErrorDueToEBSEncryptionByDefault(&types.OperationNotPermittedException{}))
+	assert.True(t, IsErrorDueToEBSEncryptionByDefault(
+		errors.New("operation error EC2: ModifySnapshotAttribute, https response error StatusCode: 400, RequestID: 12f44aeb-7b3b-4488-ac46-a432d20cc7a9, api error OperationNotPermitted: Encrypted snapshots with EBS default key cannot be shared"),
+	))
+	assert.True(t, IsErrorDueToEBSEncryptionByDefault(
+		errors.New("operation error EC2: ModifyImageAttribute, https response error StatusCode: 400, RequestID: 85f85eff-4114-4861-a659-f9aeea48d78b, api error InvalidParameter: Snapshots encrypted with the AWS Managed CMK can't be shared. Specify another snapshot"),
+	))
+}


### PR DESCRIPTION

New output:

```
2022/03/30 18:48:19 Checking your authentication against AWS
2022/03/30 18:48:20 Warming up aws.exfiltration.ec2-share-ebs-snapshot
2022/03/30 18:48:20 Initializing Terraform to spin up technique prerequisites
2022/03/30 18:50:16 Applying Terraform to spin up technique prerequisites
2022/03/30 18:50:43 Snapshot snap-0f22b58c34517e0a7 of vol-0c8e25f1f6706e29b ready
2022/03/30 18:50:43 Sharing the volume snapshot snap-0f22b58c34517e0a7 with an external AWS account...
2022/03/30 18:50:45 Note: Stratus detonated the attack, but the sharing was unsuccessful. This is likely because EBS default encryption is enabled in the region. Nonetheless, it did simulate a plausible attacker action.
```