### PR TITLE
Inject a unique detonation ID in the user-agent of K8s and AWS requests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/aws/smithy-go v1.10.0
 	github.com/fatih/color v1.13.0
 	github.com/golang-jwt/jwt v3.2.2+incompatible
+	github.com/google/uuid v1.3.0
 	github.com/hashicorp/terraform-exec v0.15.0
 	github.com/jedib0t/go-pretty/v6 v6.2.4
 	github.com/spf13/cobra v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -324,6 +324,8 @@ github.com/google/pprof v0.0.0-20210609004039-a478d1d731e9/go.mod h1:kpwsk12EmLe
 github.com/google/pprof v0.0.0-20210720184732-4bb14d4b1be1/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
+github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=
 github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5mhpdKc/us6bOk=
 github.com/googleapis/gax-go/v2 v2.1.0/go.mod h1:Q3nei7sK6ybPYH7twZdmQpAd1MKb7pfu6SK+H1/DsU0=

--- a/internal/providers/aws.go
+++ b/internal/providers/aws.go
@@ -13,7 +13,7 @@ import (
 )
 
 var awsProvider = AWSProvider{
-	UniqueCorrelationId: uuid.New(),
+	UniqueCorrelationId: UniqueExecutionId,
 }
 
 func AWS() *AWSProvider {

--- a/internal/providers/kubernetes.go
+++ b/internal/providers/kubernetes.go
@@ -26,7 +26,7 @@ type K8sProvider struct {
 }
 
 var (
-	k8sProvider               = K8sProvider{UniqueCorrelationId: uuid.New()}
+	k8sProvider               = K8sProvider{UniqueCorrelationId: UniqueExecutionId}
 	kubeConfigPath            string
 	kubeConfigPathWasResolved bool
 )

--- a/internal/providers/main.go
+++ b/internal/providers/main.go
@@ -3,9 +3,12 @@ package providers
 import (
 	"errors"
 	"github.com/datadog/stratus-red-team/pkg/stratus"
+	"github.com/google/uuid"
 )
 
 const StratusUserAgent = "stratus-red-team"
+
+var UniqueExecutionId = uuid.New()
 
 // EnsureAuthenticated ensures that the current user is properly authenticated against a specific platform
 func EnsureAuthenticated(platform stratus.Platform) error {

--- a/pkg/stratus/runner/runner.go
+++ b/pkg/stratus/runner/runner.go
@@ -2,6 +2,7 @@ package runner
 
 import (
 	"errors"
+	"github.com/datadog/stratus-red-team/internal/providers"
 	"log"
 	"path/filepath"
 	"strings"
@@ -192,6 +193,11 @@ func (m *Runner) setState(state stratus.AttackTechniqueState) {
 		log.Println("Warning: unable to set technique state: " + err.Error())
 	}
 	m.TechniqueState = state
+}
+
+// GetUniqueExecutionId returns an unique execution ID, unique per run of Stratus Red Team (not for each TTP detonated)
+func (m *Runner) GetUniqueExecutionId() string {
+	return providers.UniqueExecutionId.String()
 }
 
 // Utility function to display better error messages than the Terraform ones


### PR DESCRIPTION
This allows for correlating alerts in external tools (such as Datadog) with a specific detonation. Sample PoC ugly code for Datadog:

```go
// Note: Doesn't handle cases where 1 detonation triggers multiple signals
package main

import (
	"bytes"
	"context"
	"encoding/json"
	"fmt"
	"github.com/DataDog/datadog-api-client-go/api/v2/datadog"
	"github.com/datadog/stratus-red-team/pkg/stratus"
	_ "github.com/datadog/stratus-red-team/pkg/stratus/loader" // Note: This import is needed
	stratusrunner "github.com/datadog/stratus-red-team/pkg/stratus/runner"
	"log"
	"net/http"
	"os"
	"strconv"
	"strings"
	"time"
)

func detonate() string {
	ttp := stratus.GetRegistry().GetAttackTechniqueByName("k8s.persistence.create-admin-clusterrole")
	stratusRunner := stratusrunner.NewRunner(ttp, stratusrunner.StratusRunnerNoForce)
	_, err := stratusRunner.WarmUp()
	defer stratusRunner.CleanUp()
	if err != nil {
		fmt.Println("Could not warm up TTP: " + err.Error())
		panic("exiting")
	}
	fmt.Println("TTP is warm! Press enter to detonate it")
	fmt.Scanln()
	err = stratusRunner.Detonate()
	if err != nil {
		fmt.Println("Could not detonate TTP: " + err.Error())
	}
	log.Println("Detonated TTP, run UUID = " + stratusRunner.GetUniqueExecutionId())
	return stratusRunner.GetUniqueExecutionId()
}

func archiveSignal(signalId string) {
	payload, _ := json.Marshal(map[string]interface{}{
		"state": "archived",
	})

	req, err := http.NewRequest(
		http.MethodPatch,
		"https://api.datadoghq.com"+fmt.Sprintf("/api/v1/security_analytics/signals/%s/state", signalId),
		bytes.NewBuffer(payload))

	if err != nil {
		panic(err)
	}
	req.Header.Set("Content-Type", "application/json")
	req.Header.Set("DD-API-KEY", os.Getenv("DD_API_KEY"))
	req.Header.Set("DD-APPLICATION-KEY", os.Getenv("DD_APP_KEY"))

	client := &http.Client{}
	res, err := client.Do(req)
	if err != nil {
		panic(err)
	}
	if res.StatusCode != 200 {
		panic("unable to archive")
	}
	log.Println("Signal archived!")
}

func findSignal(alertName string, executionUid string) *string {
	ctx := context.WithValue(context.Background(), datadog.ContextAPIKeys, map[string]datadog.APIKey{
		"apiKeyAuth": {Key: os.Getenv("DD_API_KEY")},
		"appKeyAuth": {Key: os.Getenv("DD_APP_KEY")},
	})
	cfg := datadog.NewConfiguration()
	cfg.SetUnstableOperationEnabled("SearchSecurityMonitoringSignals", true)
	apiClient := datadog.NewAPIClient(cfg)

	params := datadog.NewSearchSecurityMonitoringSignalsOptionalParameters().WithBody(datadog.SecurityMonitoringSignalListRequest{
		Filter: &datadog.SecurityMonitoringSignalListRequestFilter{
			From:  datadog.PtrTime(time.Now().Add(-1 * time.Hour)),
			Query: datadog.PtrString("@workflow.triage.state:open @workflow.rule.name:\"" + alertName + "\""),
		},
		Page: &datadog.SecurityMonitoringSignalListRequestPage{Limit: datadog.PtrInt32(1000)},
		Sort: datadog.SECURITYMONITORINGSIGNALSSORT_TIMESTAMP_DESCENDING.Ptr(),
	})
	signals, _, err := apiClient.SecurityMonitoringApi.SearchSecurityMonitoringSignals(ctx, *params)
	if err != nil {
		panic("unable to list signals: " + err.Error())
	}

	numSignals := len(*signals.Data)
	fmt.Println("Found " + strconv.Itoa(numSignals) + " signals")

	if numSignals == 0 {
		return nil
	}

	for i := range *signals.Data {
		matchingEvents := (*signals.Data)[i].Attributes.Attributes["samples"].([]interface{})
		fmt.Println(strconv.Itoa(len(matchingEvents)) + " samples found for this signal")
		for j := range matchingEvents {
			matchingEvent := matchingEvents[j].(map[string]interface{})["content"]
			rawMatchingEvent, _ := json.Marshal(matchingEvent)
			if strings.Contains(string(rawMatchingEvent), "stratus-red-team_"+executionUid) {
				return (*signals.Data)[i].Id
			}
		}
	}

	return nil
}

func main() {
	uid := detonate()
	for {
		fmt.Println("Analyzing signals...")
		if signalId := findSignal("A cluster-wide K8s role was created", uid); signalId != nil {
			fmt.Println("Found corresponding signal " + *signalId)
			archiveSignal(*signalId)
			return
		}
		time.Sleep(10 * time.Second)
	}
}
```