### PR TITLE
Add execution UUID to Terraform user-agent

### DIFF
--- a/pkg/stratus/runner/terraform.go
+++ b/pkg/stratus/runner/terraform.go
@@ -3,6 +3,7 @@ package runner
 import (
 	"context"
 	"errors"
+	"github.com/datadog/stratus-red-team/internal/providers"
 	"github.com/datadog/stratus-red-team/internal/utils"
 	"github.com/hashicorp/go-version"
 	"github.com/hashicorp/hc-install/product"
@@ -59,7 +60,7 @@ func (m *TerraformManagerImpl) TerraformInitAndApply(directory string) (map[stri
 		return map[string]string{}, errors.New("unable to instantiate Terraform: " + err.Error())
 	}
 
-	err = terraform.SetAppendUserAgent("stratus-red-team")
+	err = terraform.SetAppendUserAgent(providers.GetStratusUserAgent())
 	if err != nil {
 		return map[string]string{}, errors.New("unable to configure Terraform: " + err.Error())
 	}


### PR DESCRIPTION
**Context**: This unique user-agent is currently injected in the AWS / Azure / K8s SDK.

**This PR**: Adds the same user-agent for Terraform (warm-up). It allows to identify any alert / log event created by the warm-up process easily