### PR TITLE
Disable logging when using the programmatic interface (closes #126)

### DIFF
--- a/cmd/stratus/main.go
+++ b/cmd/stratus/main.go
@@ -3,6 +3,8 @@ package main
 import (
 	_ "github.com/datadog/stratus-red-team/internal/attacktechniques"
 	"github.com/spf13/cobra"
+	"log"
+	"os"
 )
 
 var rootCmd = &cobra.Command{
@@ -10,6 +12,8 @@ var rootCmd = &cobra.Command{
 }
 
 func init() {
+	setupLogging()
+
 	listCmd := buildListCmd()
 	showCmd := buildShowCmd()
 	warmupCmd := buildWarmupCmd()
@@ -27,6 +31,10 @@ func init() {
 	rootCmd.AddCommand(statusCmd)
 	rootCmd.AddCommand(cleanupCmd)
 	rootCmd.AddCommand(versionCmd)
+}
+
+func setupLogging() {
+	log.SetOutput(os.Stdout)
 }
 
 func main() {

--- a/pkg/stratus/loader/main.go
+++ b/pkg/stratus/loader/main.go
@@ -2,4 +2,11 @@ package loader
 
 import (
 	_ "github.com/datadog/stratus-red-team/internal/attacktechniques" // Required for programmatic usage
+	"io"
+	"log"
 )
+
+func init() {
+	// Disable logging for programmatic usage
+	log.SetOutput(io.Discard)
+}


### PR DESCRIPTION
When using the programmatic interface, the logging shouldn't be displayed to stdout to avoid polluting the output of the application using it.

Logging was exclusively designed for usage in CLI mode