### PR TITLE
Add dynamic autocomplete for techniques

### DIFF
--- a/cmd/stratus/cleanup_cmd.go
+++ b/cmd/stratus/cleanup_cmd.go
@@ -32,6 +32,9 @@ func buildCleanupCmd() *cobra.Command {
 
 			return err
 		},
+		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return getTechniquesCompletion(toComplete), cobra.ShellCompDirectiveNoFileComp
+		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) > 0 {
 				techniques, _ := resolveTechniques(args)

--- a/cmd/stratus/detonate_cmd.go
+++ b/cmd/stratus/detonate_cmd.go
@@ -37,6 +37,9 @@ func buildDetonateCmd() *cobra.Command {
 			_, err := resolveTechniques(args)
 			return err
 		},
+		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return getTechniquesCompletion(toComplete), cobra.ShellCompDirectiveNoFileComp
+		},
 		Run: func(cmd *cobra.Command, args []string) {
 			techniques, _ := resolveTechniques(args)
 			doDetonateCmd(techniques, detonateCleanup)

--- a/cmd/stratus/revert_cmd.go
+++ b/cmd/stratus/revert_cmd.go
@@ -32,6 +32,9 @@ func buildRevertCmd() *cobra.Command {
 			_, err := resolveTechniques(args)
 			return err
 		},
+		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return getTechniquesCompletion(toComplete), cobra.ShellCompDirectiveNoFileComp
+		},
 		Run: func(cmd *cobra.Command, args []string) {
 			techniques, _ := resolveTechniques(args)
 			doRevertCmd(techniques)

--- a/cmd/stratus/show_cmd.go
+++ b/cmd/stratus/show_cmd.go
@@ -18,6 +18,9 @@ func buildShowCmd() *cobra.Command {
 			_, err := resolveTechniques(args)
 			return err
 		},
+		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return getTechniquesCompletion(toComplete), cobra.ShellCompDirectiveNoFileComp
+		},
 		Run: func(cmd *cobra.Command, args []string) {
 			techniques, _ := resolveTechniques(args)
 			doShowCmd(techniques)

--- a/cmd/stratus/util.go
+++ b/cmd/stratus/util.go
@@ -6,6 +6,7 @@ import (
 	"github.com/jedib0t/go-pretty/v6/table"
 	"log"
 	"os"
+	"strings"
 )
 
 func GetDisplayTable() table.Writer {
@@ -55,4 +56,15 @@ func VerifyPlatformRequirements(attackTechniques []*stratus.AttackTechnique) {
 			platforms[currentPlatform] = true
 		}
 	}
+}
+
+func getTechniquesCompletion(completionPrefix string) []string {
+	attackTechniques := stratus.GetRegistry().GetAttackTechniques(&stratus.AttackTechniqueFilter{})
+	var matchingTechniques []string
+	for _, technique := range attackTechniques {
+		if strings.HasPrefix(technique.ID, completionPrefix) {
+			matchingTechniques = append(matchingTechniques, technique.ID)
+		}
+	}
+	return matchingTechniques
 }

--- a/cmd/stratus/warmup_cmd.go
+++ b/cmd/stratus/warmup_cmd.go
@@ -2,11 +2,10 @@ package main
 
 import (
 	"errors"
-	"os"
-
 	"github.com/datadog/stratus-red-team/pkg/stratus"
 	"github.com/datadog/stratus-red-team/pkg/stratus/runner"
 	"github.com/spf13/cobra"
+	"os"
 )
 
 var forceWarmup bool
@@ -30,6 +29,9 @@ func buildWarmupCmd() *cobra.Command {
 			}
 			_, err := resolveTechniques(args)
 			return err
+		},
+		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return getTechniquesCompletion(toComplete), cobra.ShellCompDirectiveNoFileComp
 		},
 		Run: func(cmd *cobra.Command, args []string) {
 			techniques, _ := resolveTechniques(args)

--- a/docs/user-guide/commands/autocompletion.md
+++ b/docs/user-guide/commands/autocompletion.md
@@ -8,21 +8,45 @@ Stratus Red Team uses [cobra](https://github.com/spf13/cobra)'s built-in support
 
 ## Setup
 
-* bash: TODO
 
-* zsh: 
+Ensure you have [bash-completion](https://github.com/scop/bash-completion) installed (`brew install bash-completion`  / `apt install bash-completion`), then run:
 
-```bash
-echo "autoload -U compinit; compinit" >> ~/.zshrc
-source ~/.zshrc
-stratus completion zsh > "${fpath[1]}/_stratus"
-```
+=== "bash"
 
-* fish:
+    === "Mac OS"
 
-```bash
-stratus completion fish > ~/.config/fish/completions/stratus.fish
-```
+        ```bash
+        # Install bash-completion if necessary
+        brew install bash-completion
+
+        stratus completion bash > /usr/local/etc/bash_completion.d/stratus
+        echo "source /usr/local/etc/bash_completion" >> ~/.bashrc
+        ```
+
+    === "Linux"
+    
+        ```bash
+        # Install bash-completion if necessary
+        sudo apt install bash-completion
+        
+        mkdir -p /etc/bash_completion.d
+        stratus completion bash > /etc/bash_completion.d/stratus
+        echo "source /etc/bash_completion" >> ~/.bashrc
+        ```
+
+=== "zsh"
+
+    ```bash
+    echo "autoload -U compinit; compinit" >> ~/.zshrc
+    source ~/.zshrc
+    stratus completion zsh > "${fpath[1]}/_stratus"
+    ```
+
+=== "fish"
+
+    ```bash
+    stratus completion fish > ~/.config/fish/completions/stratus.fish
+    ```
 
 ## Sample usage
 

--- a/docs/user-guide/commands/autocompletion.md
+++ b/docs/user-guide/commands/autocompletion.md
@@ -1,0 +1,32 @@
+---
+title: CLI autocompletion
+---
+
+# Autocompletion
+
+Stratus Red Team uses [cobra](https://github.com/spf13/cobra)'s built-in support to add autocompletions when working with the CLI.
+
+## Setup
+
+* bash: TODO
+
+* zsh: 
+
+```bash
+echo "autoload -U compinit; compinit" >> ~/.zshrc
+source ~/.zshrc
+stratus completion zsh > "${fpath[1]}/_stratus"
+```
+
+* fish:
+
+```bash
+stratus completion fish > ~/.config/fish/completions/stratus.fish
+```
+
+## Sample usage
+
+```bash
+stratus deton[tab]
+stratus detonate aws[tab][tab]
+```

--- a/docs/user-guide/commands/index.md
+++ b/docs/user-guide/commands/index.md
@@ -1,5 +1,6 @@
 # Commands reference
 
+- [Autocompletion](./autocompletion)
 - [list](./list)
 - [status](./status)
 - [show](./show)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -84,6 +84,7 @@ nav:
       - Examples: user-guide/examples.md
       - Usage: user-guide/usage.md
       - Command Reference:
+          - CLI Autocompletion: user-guide/commands/autocompletion.md
           - list: user-guide/commands/list.md
           - status: user-guide/commands/status.md
           - show: user-guide/commands/show.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -57,6 +57,8 @@ markdown_extensions:
   - admonition
   - pymdownx.details
   - footnotes
+  - pymdownx.tabbed:
+      alternate_style: true 
 
 
 extra_javascript:


### PR DESCRIPTION
### What does this PR do?

* Enhancement:  Add dynamic command line completion for available techniques (see [link](https://github.com/spf13/cobra/blob/master/shell_completions.md#dynamic-completion-of-nouns))

Add to `cmd` where felt it makes (most) sense i.e cleanup, detonate, revert, show, warmup

### Motivation

* What inspired you to submit this pull request?
Easier / more convenient to use.

E.g. :
`stratus warmup aws.exec[tab][tab]`  --> will autocomplete to  `stratus warmup aws.execution.ec2-user-data`
or
`stratus warmup aws.persist[tab]` --> will autocomplete to  `stratus warmup aws.persistence.` with another `[tab]` possible option (=techniques) are listed
```sh
$ stratus warmup aws.persistence.[tab]
aws.persistence.iam-backdoor-role              aws.persistence.iam-create-admin-user
aws.persistence.lambda-backdoor-function     ...
```

### Checklist

Not applicable as not a  new attack techniques
