### PR TITLE
New attack technique: GCP Service Accounts impersonation

### DIFF
--- a/docs/attack-techniques/GCP/gcp.privilege-escalation.impersonate-service-accounts.md
+++ b/docs/attack-techniques/GCP/gcp.privilege-escalation.impersonate-service-accounts.md
@@ -30,6 +30,13 @@ temporary credentials allowing to act as a service account.
 - Attempt to impersonate each of the service accounts
 - One impersonation request will succeed, simulating a successful privilege escalation
 
+
+!!! info
+
+    GCP takes a few seconds to propagate the new <code>roles/iam.serviceAccountTokenCreator</code> role binding to the current user.
+
+    It is recommended to first warm up this attack technique (<code>stratus warmup ...</code>), wait for 30 seconds, then detonate it.
+
 References:
 
 - https://about.gitlab.com/blog/2020/02/12/plundering-gcp-escalating-privileges-in-google-cloud-platform/

--- a/docs/attack-techniques/GCP/gcp.privilege-escalation.impersonate-service-accounts.md
+++ b/docs/attack-techniques/GCP/gcp.privilege-escalation.impersonate-service-accounts.md
@@ -1,0 +1,148 @@
+---
+title: Impersonate GCP Service Accounts
+---
+
+# Impersonate GCP Service Accounts
+
+
+ <span class="smallcaps w3-badge w3-blue w3-round w3-text-white" title="This attack technique can be detonated multiple times">idempotent</span> 
+
+Platform: GCP
+
+## MITRE ATT&CK Tactics
+
+
+- Privilege Escalation
+
+## Description
+
+
+Attempts to impersonate several GCP service accounts. Service account impersonation in GCP allows to retrieve
+temporary credentials allowing to act as a service account.
+
+<span style="font-variant: small-caps;">Warm-up</span>:
+
+- Create 10 GCP service accounts
+- Grant the current user <code>roles/iam.serviceAccountTokenCreator</code> on one of these service accounts
+
+<span style="font-variant: small-caps;">Detonation</span>:
+
+- Attempt to impersonate each of the service accounts
+- One impersonation request will succeed, simulating a successful privilege escalation
+
+References:
+
+- https://about.gitlab.com/blog/2020/02/12/plundering-gcp-escalating-privileges-in-google-cloud-platform/
+- https://cloud.google.com/iam/docs/impersonating-service-accounts
+
+
+## Instructions
+
+```bash title="Detonate with Stratus Red Team"
+stratus detonate gcp.privilege-escalation.impersonate-service-accounts
+```
+## Detection
+
+
+Using GCP Admin Activity audit logs event <code>GenerateAccessToken</code>.
+
+Sample successful event (shortened for clarity):
+
+```json hl_lines="12 21"
+{
+  "protoPayload": {
+    "@type": "type.googleapis.com/google.cloud.audit.AuditLog",
+    "authenticationInfo": {
+      "principalEmail": "user@domain.tld",
+      "principalSubject": "user:user@domain.tld"
+    },
+    "requestMetadata": {
+      "callerIp": "(calling IP)",
+    },
+    "serviceName": "iamcredentials.googleapis.com",
+    "methodName": "GenerateAccessToken",
+    "authorizationInfo": [
+      {
+        "permission": "iam.serviceAccounts.getAccessToken",
+        "granted": true,
+        "resourceAttributes": {}
+      }
+    ],
+    "request": {
+      "name": "projects/-/serviceAccounts/impersonated-service-account@project-id.iam.gserviceaccount.com",
+      "@type": "type.googleapis.com/google.iam.credentials.v1.GenerateAccessTokenRequest"
+    }
+  },
+  "resource": {
+    "type": "service_account",
+    "labels": {
+      "unique_id": "105711361070066902665",
+      "email_id": "impersonated-service-account@project-id.iam.gserviceaccount.com",
+      "project_id": "project-id"
+    }
+  },
+  "severity": "INFO",
+  "logName": "projects/project-id/logs/cloudaudit.googleapis.com%2Fdata_access"
+}
+```
+
+
+When impersonation fails, the generated event **does not contain** the identity of the caller, as explained in the
+[GCP documentation](https://cloud.google.com/logging/docs/audit#user-id):
+
+> For privacy reasons, the caller's principal email address is redacted from an audit log if the operation is 
+> read-only and fails with a "permission denied" error. The only exception is when the caller is a service 
+> account in the Google Cloud organization associated with the resource; in this case, the email address isn't redacted.
+
+Sample **unsuccessful** event (shortened for clarity):
+
+```json hl_lines="5 6 13 38"
+{
+  "protoPayload": {
+    "@type": "type.googleapis.com/google.cloud.audit.AuditLog",
+    "status": {
+      "code": 7,
+      "message": "PERMISSION_DENIED"
+    },
+    "authenticationInfo": {},
+    "requestMetadata": {
+      "callerIp": "(calling IP)"
+    },
+    "serviceName": "iamcredentials.googleapis.com",
+    "methodName": "GenerateAccessToken",
+    "authorizationInfo": [
+      {
+        "permission": "iam.serviceAccounts.getAccessToken",
+        "resourceAttributes": {}
+      }
+    ],
+    "resourceName": "projects/-/serviceAccounts/103566171230474107362",
+    "request": {
+      "@type": "type.googleapis.com/google.iam.credentials.v1.GenerateAccessTokenRequest",
+      "name": "projects/-/serviceAccounts/target-service-account@project-id.iam.gserviceaccount.com"
+    },
+    "metadata": {
+      "identityDelegationChain": [
+        "projects/-/serviceAccounts/target-service-account@project-id.iam.gserviceaccount.com"
+      ]
+    }
+  },
+  "resource": {
+    "type": "service_account",
+    "labels": {
+      "email_id": "target-service-account@project-id.iam.gserviceaccount.com",
+      "project_id": "project-id"
+    }
+  },
+  "severity": "ERROR",
+  "logName": "projects/project-id/logs/cloudaudit.googleapis.com%2Fdata_access"
+}
+```
+
+Some detection strategies may include:
+
+* Alerting on unsuccessful impersonation attempts
+* Alerting when the same IP address / user-agent attempts to impersonate several service accounts in a 
+short amount of time (successfully or not)
+
+

--- a/docs/attack-techniques/GCP/index.md
+++ b/docs/attack-techniques/GCP/index.md
@@ -17,3 +17,5 @@ Note that some Stratus attack techniques may correspond to more than a single AT
 
 - [Create a GCP Service Account Key](./gcp.persistence.create-service-account-key.md)
 
+- [Impersonate GCP Service Accounts](./gcp.privilege-escalation.impersonate-service-accounts.md)
+

--- a/docs/attack-techniques/list.md
+++ b/docs/attack-techniques/list.md
@@ -41,6 +41,7 @@ This page contains the list of all Stratus Attack Techniques.
 | [Export Disk Through SAS URL](./azure/azure.exfiltration.disk-export.md) | [Azure](./azure/index.md) | Exfiltration |
 | [Create an Admin GCP Service Account](./GCP/gcp.persistence.create-admin-service-account.md) | [GCP](./GCP/index.md) | Persistence, Privilege Escalation |
 | [Create a GCP Service Account Key](./GCP/gcp.persistence.create-service-account-key.md) | [GCP](./GCP/index.md) | Persistence, Privilege Escalation |
+| [Impersonate GCP Service Accounts](./GCP/gcp.privilege-escalation.impersonate-service-accounts.md) | [GCP](./GCP/index.md) | Privilege Escalation |
 | [Dump All Secrets](./kubernetes/k8s.credential-access.dump-secrets.md) | [Kubernetes](./kubernetes/index.md) | Credential Access |
 | [Steal Pod Service Account Token](./kubernetes/k8s.credential-access.steal-serviceaccount-token.md) | [Kubernetes](./kubernetes/index.md) | Credential Access |
 | [Create Admin ClusterRole](./kubernetes/k8s.persistence.create-admin-clusterrole.md) | [Kubernetes](./kubernetes/index.md) | Persistence, Privilege Escalation |

--- a/v2/internal/attacktechniques/gcp/privilege-escalation/impersonate-service-accounts/main.go
+++ b/v2/internal/attacktechniques/gcp/privilege-escalation/impersonate-service-accounts/main.go
@@ -1,0 +1,206 @@
+package gcp
+
+import (
+	"context"
+	_ "embed"
+	"fmt"
+	"github.com/datadog/stratus-red-team/v2/internal/providers"
+	"github.com/datadog/stratus-red-team/v2/pkg/stratus"
+	"github.com/datadog/stratus-red-team/v2/pkg/stratus/mitreattack"
+	"google.golang.org/api/iamcredentials/v1"
+	"log"
+	"strconv"
+	"strings"
+)
+
+//go:embed main.tf
+var tf []byte
+
+func init() {
+	const codeBlock = "```"
+	stratus.GetRegistry().RegisterAttackTechnique(&stratus.AttackTechnique{
+		ID:           "gcp.privilege-escalation.impersonate-service-accounts",
+		FriendlyName: "Impersonate GCP Service Accounts",
+		Description: `
+Attempts to impersonate several GCP service accounts. Service account impersonation in GCP allows to retrieve
+temporary credentials allowing to act as a service account.
+
+Warm-up:
+
+- Create 10 GCP service accounts
+- Grant the current user <code>roles/iam.serviceAccountTokenCreator</code> on one of these service accounts
+
+Detonation:
+
+- Attempt to impersonate each of the service accounts
+- One impersonation request will succeed, simulating a successful privilege escalation
+
+References:
+
+- https://about.gitlab.com/blog/2020/02/12/plundering-gcp-escalating-privileges-in-google-cloud-platform/
+- https://cloud.google.com/iam/docs/impersonating-service-accounts
+`,
+		Detection: `
+Using GCP Admin Activity audit logs event <code>GenerateAccessToken</code>.
+
+Sample successful event (shortened for clarity):
+
+` + codeBlock + `json hl_lines="12 21"
+{
+  "protoPayload": {
+    "@type": "type.googleapis.com/google.cloud.audit.AuditLog",
+    "authenticationInfo": {
+      "principalEmail": "user@domain.tld",
+      "principalSubject": "user:user@domain.tld"
+    },
+    "requestMetadata": {
+      "callerIp": "(calling IP)",
+    },
+    "serviceName": "iamcredentials.googleapis.com",
+    "methodName": "GenerateAccessToken",
+    "authorizationInfo": [
+      {
+        "permission": "iam.serviceAccounts.getAccessToken",
+        "granted": true,
+        "resourceAttributes": {}
+      }
+    ],
+    "request": {
+      "name": "projects/-/serviceAccounts/impersonated-service-account@project-id.iam.gserviceaccount.com",
+      "@type": "type.googleapis.com/google.iam.credentials.v1.GenerateAccessTokenRequest"
+    }
+  },
+  "resource": {
+    "type": "service_account",
+    "labels": {
+      "unique_id": "105711361070066902665",
+      "email_id": "impersonated-service-account@project-id.iam.gserviceaccount.com",
+      "project_id": "project-id"
+    }
+  },
+  "severity": "INFO",
+  "logName": "projects/project-id/logs/cloudaudit.googleapis.com%2Fdata_access"
+}
+` + codeBlock + `
+
+
+When impersonation fails, the generated event **does not contain** the identity of the caller, as explained in the
+[GCP documentation](https://cloud.google.com/logging/docs/audit#user-id):
+
+> For privacy reasons, the caller's principal email address is redacted from an audit log if the operation is 
+> read-only and fails with a "permission denied" error. The only exception is when the caller is a service 
+> account in the Google Cloud organization associated with the resource; in this case, the email address isn't redacted.
+
+Sample **unsuccessful** event (shortened for clarity):
+
+` + codeBlock + `json hl_lines="5 6 13 38"
+{
+  "protoPayload": {
+    "@type": "type.googleapis.com/google.cloud.audit.AuditLog",
+    "status": {
+      "code": 7,
+      "message": "PERMISSION_DENIED"
+    },
+    "authenticationInfo": {},
+    "requestMetadata": {
+      "callerIp": "(calling IP)"
+    },
+    "serviceName": "iamcredentials.googleapis.com",
+    "methodName": "GenerateAccessToken",
+    "authorizationInfo": [
+      {
+        "permission": "iam.serviceAccounts.getAccessToken",
+        "resourceAttributes": {}
+      }
+    ],
+    "resourceName": "projects/-/serviceAccounts/103566171230474107362",
+    "request": {
+      "@type": "type.googleapis.com/google.iam.credentials.v1.GenerateAccessTokenRequest",
+      "name": "projects/-/serviceAccounts/target-service-account@project-id.iam.gserviceaccount.com"
+    },
+    "metadata": {
+      "identityDelegationChain": [
+        "projects/-/serviceAccounts/target-service-account@project-id.iam.gserviceaccount.com"
+      ]
+    }
+  },
+  "resource": {
+    "type": "service_account",
+    "labels": {
+      "email_id": "target-service-account@project-id.iam.gserviceaccount.com",
+      "project_id": "project-id"
+    }
+  },
+  "severity": "ERROR",
+  "logName": "projects/project-id/logs/cloudaudit.googleapis.com%2Fdata_access"
+}
+` + codeBlock + `
+
+Some detection strategies may include:
+
+* Alerting on unsuccessful impersonation attempts
+* Alerting when the same IP address / user-agent attempts to impersonate several service accounts in a 
+short amount of time (successfully or not)
+`,
+		Platform:                   stratus.GCP,
+		IsIdempotent:               true,
+		MitreAttackTactics:         []mitreattack.Tactic{mitreattack.PrivilegeEscalation},
+		PrerequisitesTerraformCode: tf,
+		Detonate:                   detonate,
+	})
+}
+
+func detonate(params map[string]string) error {
+	serviceAccountEmails := strings.Split(params["service_account_emails"], ",")
+	numServiceAccounts := len(serviceAccountEmails)
+
+	iamCredentialsClient, err := iamcredentials.NewService(context.Background(), providers.GCP().Options())
+	if err != nil {
+		return fmt.Errorf("unable to instantiate GCP IAM client: %v", err)
+	}
+
+	log.Println("Attempting to impersonate each of the " + strconv.Itoa(numServiceAccounts) + " service accounts")
+
+	for _, serviceAccountEmail := range serviceAccountEmails {
+		accessToken, err := impersonateServiceAccount(iamCredentialsClient, serviceAccountEmail)
+		if err != nil {
+			if isPermissionDeniedError(err) {
+				log.Println("Attempting to impersonate " + serviceAccountEmail + " yielded an 'access denied' error, as expected")
+			} else {
+				return fmt.Errorf("unexpected error while attempting to impersonate a service account: %v", err)
+			}
+		} else {
+			log.Printf("Successfully retrieved an access token for %s: \n  %s\n", serviceAccountEmail, getPrintableAccessToken(accessToken))
+		}
+	}
+	return nil
+}
+
+// Simulates the impersonation of a service account
+func impersonateServiceAccount(iamCredentialsClient *iamcredentials.Service, serviceAccountEmail string) (string, error) {
+	// see also: https://cloud.google.com/iam/docs/create-short-lived-credentials-direct#sa-credentials-oauth
+	serviceAccountName := fmt.Sprintf("projects/-/serviceAccounts/%s", serviceAccountEmail)
+	response, err := iamCredentialsClient.Projects.ServiceAccounts.GenerateAccessToken(serviceAccountName, &iamcredentials.GenerateAccessTokenRequest{
+		Scope:    []string{"https://www.googleapis.com/auth/cloud-platform"},
+		Lifetime: "43200s", // 12 hours, the maximum allowed lifetime
+	}).Do()
+
+	if err != nil {
+		return "", err
+	}
+
+	return response.AccessToken, nil
+}
+
+// Checks if an error returned by `GenerateAccessToken` corresponds to an (expected) access denied error
+func isPermissionDeniedError(err error) bool {
+	return strings.Contains(err.Error(), "403: The caller does not have permission")
+}
+
+// For some reason, the access tokens are padded with dots, which isn't pretty to display
+func getPrintableAccessToken(accessToken string) string {
+	var i int
+	for i = len(accessToken) - 1; accessToken[i] == '.'; i-- {
+	}
+	return accessToken[:i+1]
+}

--- a/v2/internal/attacktechniques/gcp/privilege-escalation/impersonate-service-accounts/main.tf
+++ b/v2/internal/attacktechniques/gcp/privilege-escalation/impersonate-service-accounts/main.tf
@@ -1,0 +1,60 @@
+terraform {
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 4.28.0"
+    }
+  }
+}
+
+data "google_client_openid_userinfo" "whoami" {}
+
+locals {
+  num-service-accounts = 10
+}
+
+resource "random_string" "suffix" {
+  count = local.num-service-accounts
+  length      = 8
+  special     = false
+  min_lower   = 4
+  min_numeric = 4
+}
+
+// Create N service accounts
+resource "google_service_account" "service_account" {
+  count = local.num-service-accounts
+  account_id = format("stratus-red-team-%s", random_string.suffix[count.index].result)
+  description = "Service account used by Stratus Red Team for gcp.privilege-escalation.impersonate-service-accounts"
+}
+
+
+// Allow the current user to impersonate a single of the created service accounts
+resource "google_service_account_iam_policy" "iam_policy" {
+  service_account_id = google_service_account.service_account[local.num-service-accounts - 1].name
+  policy_data = data.google_iam_policy.allow-impersonation.policy_data
+}
+
+data "google_iam_policy" "allow-impersonation" {
+  binding {
+    role = "roles/iam.serviceAccountUser"
+    members = [
+      format("user:%s", data.google_client_openid_userinfo.whoami.email)
+    ]
+  }
+
+  binding {
+    role = "roles/iam.serviceAccountTokenCreator"
+    members = [
+      format("user:%s", data.google_client_openid_userinfo.whoami.email)
+    ]
+  }
+}
+
+output "service_account_emails" {
+  value = join(",", google_service_account.service_account[*].email)
+}
+
+output "display" {
+  value = format("%d service accounts created and ready:\n  - %s", local.num-service-accounts, join("\n  - ", google_service_account.service_account[*].email))
+}

--- a/v2/internal/attacktechniques/gcp/privilege-escalation/impersonate-service-accounts/main.tf
+++ b/v2/internal/attacktechniques/gcp/privilege-escalation/impersonate-service-accounts/main.tf
@@ -14,7 +14,7 @@ locals {
 }
 
 resource "random_string" "suffix" {
-  count = local.num-service-accounts
+  count       = local.num-service-accounts
   length      = 8
   special     = false
   min_lower   = 4
@@ -23,8 +23,8 @@ resource "random_string" "suffix" {
 
 // Create N service accounts
 resource "google_service_account" "service_account" {
-  count = local.num-service-accounts
-  account_id = format("stratus-red-team-%s", random_string.suffix[count.index].result)
+  count       = local.num-service-accounts
+  account_id  = format("stratus-red-team-%s", random_string.suffix[count.index].result)
   description = "Service account used by Stratus Red Team for gcp.privilege-escalation.impersonate-service-accounts"
 }
 
@@ -32,7 +32,7 @@ resource "google_service_account" "service_account" {
 // Allow the current user to impersonate a single of the created service accounts
 resource "google_service_account_iam_policy" "iam_policy" {
   service_account_id = google_service_account.service_account[local.num-service-accounts - 1].name
-  policy_data = data.google_iam_policy.allow-impersonation.policy_data
+  policy_data        = data.google_iam_policy.allow-impersonation.policy_data
 }
 
 data "google_iam_policy" "allow-impersonation" {

--- a/v2/internal/attacktechniques/gcp/privilege-escalation/impersonate-service-accounts/main.tf
+++ b/v2/internal/attacktechniques/gcp/privilege-escalation/impersonate-service-accounts/main.tf
@@ -37,13 +37,6 @@ resource "google_service_account_iam_policy" "iam_policy" {
 
 data "google_iam_policy" "allow-impersonation" {
   binding {
-    role = "roles/iam.serviceAccountUser"
-    members = [
-      format("user:%s", data.google_client_openid_userinfo.whoami.email)
-    ]
-  }
-
-  binding {
     role = "roles/iam.serviceAccountTokenCreator"
     members = [
       format("user:%s", data.google_client_openid_userinfo.whoami.email)

--- a/v2/internal/attacktechniques/main.go
+++ b/v2/internal/attacktechniques/main.go
@@ -33,6 +33,7 @@ import (
 	_ "github.com/datadog/stratus-red-team/v2/internal/attacktechniques/azure/exfiltration/disk-export"
 	_ "github.com/datadog/stratus-red-team/v2/internal/attacktechniques/gcp/persistence/create-admin-service-account"
 	_ "github.com/datadog/stratus-red-team/v2/internal/attacktechniques/gcp/persistence/create-service-account-key"
+	_ "github.com/datadog/stratus-red-team/v2/internal/attacktechniques/gcp/privilege-escalation/impersonate-service-accounts"
 	_ "github.com/datadog/stratus-red-team/v2/internal/attacktechniques/k8s/credential-access/dump-secrets"
 	_ "github.com/datadog/stratus-red-team/v2/internal/attacktechniques/k8s/credential-access/steal-serviceaccount-token"
 	_ "github.com/datadog/stratus-red-team/v2/internal/attacktechniques/k8s/persistence/create-admin-clusterrole"

--- a/v2/pkg/stratus/runner/runner.go
+++ b/v2/pkg/stratus/runner/runner.go
@@ -84,6 +84,7 @@ func (m *Runner) WarmUp() (map[string]string, error) {
 	m.setState(stratus.AttackTechniqueStatusWarm)
 
 	if display, ok := outputs["display"]; ok {
+		display := strings.ReplaceAll(display, "\\n", "\n")
 		log.Println(display)
 	}
 	return outputs, err


### PR DESCRIPTION
### What does this PR do?

New attack technique to simulate a situation where an attacker attempts to impersonate several GCP service accounts, and successfully manages for one. (#152)

Output (warmup):

```
$ stratus warmup gcp.privilege-escalation.impersonate-service-accounts
2022/08/04 11:46:10 Checking your authentication against GCP
2022/08/04 11:46:10 Warming up gcp.privilege-escalation.impersonate-service-accounts
2022/08/04 11:46:10 Initializing Terraform to spin up technique prerequisites
2022/08/04 11:46:18 Applying Terraform to spin up technique prerequisites
2022/08/04 11:46:24 10 service accounts created and ready:
  - stratus-red-team-m2062fam@datadog-sandbox.iam.gserviceaccount.com
  - stratus-red-team-5l21ck9g@datadog-sandbox.iam.gserviceaccount.com
  - stratus-red-team-u0qu98r0@datadog-sandbox.iam.gserviceaccount.com
  - stratus-red-team-61yj2f3j@datadog-sandbox.iam.gserviceaccount.com
  - stratus-red-team-24i1vfx4@datadog-sandbox.iam.gserviceaccount.com
  - stratus-red-team-wb240im3@datadog-sandbox.iam.gserviceaccount.com
  - stratus-red-team-sxae6789@datadog-sandbox.iam.gserviceaccount.com
  - stratus-red-team-0a48uo3q@datadog-sandbox.iam.gserviceaccount.com
  - stratus-red-team-u1ev928m@datadog-sandbox.iam.gserviceaccount.com
  - stratus-red-team-dw1344zb@datadog-sandbox.iam.gserviceaccount.com
```

Output (detonation):

```
$ stratus detonate gcp.privilege-escalation.impersonate-service-accounts
2022/08/04 11:47:20 Checking your authentication against GCP
2022/08/04 11:47:20 Attempting to impersonate each of the 10 service accounts
2022/08/04 11:47:22 Attempting to impersonate stratus-red-team-m2062fam@datadog-sandbox.iam.gserviceaccount.com yielded an 'access denied' error, as expected
2022/08/04 11:47:22 Attempting to impersonate stratus-red-team-5l21ck9g@datadog-sandbox.iam.gserviceaccount.com yielded an 'access denied' error, as expected
2022/08/04 11:47:22 Attempting to impersonate stratus-red-team-u0qu98r0@datadog-sandbox.iam.gserviceaccount.com yielded an 'access denied' error, as expected
2022/08/04 11:47:22 Attempting to impersonate stratus-red-team-61yj2f3j@datadog-sandbox.iam.gserviceaccount.com yielded an 'access denied' error, as expected
2022/08/04 11:47:22 Attempting to impersonate stratus-red-team-24i1vfx4@datadog-sandbox.iam.gserviceaccount.com yielded an 'access denied' error, as expected
2022/08/04 11:47:22 Attempting to impersonate stratus-red-team-wb240im3@datadog-sandbox.iam.gserviceaccount.com yielded an 'access denied' error, as expected
2022/08/04 11:47:22 Attempting to impersonate stratus-red-team-sxae6789@datadog-sandbox.iam.gserviceaccount.com yielded an 'access denied' error, as expected
2022/08/04 11:47:22 Attempting to impersonate stratus-red-team-0a48uo3q@datadog-sandbox.iam.gserviceaccount.com yielded an 'access denied' error, as expected
2022/08/04 11:47:22 Attempting to impersonate stratus-red-team-u1ev928m@datadog-sandbox.iam.gserviceaccount.com yielded an 'access denied' error, as expected
2022/08/04 11:47:22 Successfully retrieved an access token for stratus-red-team-dw1344zb@datadog-sandbox.iam.gserviceaccount.com:
  ya29.c.b0AXv0zTPYUD6cJh4US2tbHypAFF0kTu7FjjcR1qLBeLbif0cwL8b_26Ror03QbYcuosVFgPqxZd4Uo7w2Xg2Qx-IsKdpkNVtFxE...9NVN9k
```

Docs:

![image](https://user-images.githubusercontent.com/136675/182817356-6d4b4ccf-427d-49a8-8d47-6b22128fc683.png)
