### PR TITLE
Update Azure technique docs to link to Azure Threat Research Matrix

### DIFF
--- a/docs/attack-techniques/azure/azure.execution.vm-custom-script-extension.md
+++ b/docs/attack-techniques/azure/azure.execution.vm-custom-script-extension.md
@@ -22,7 +22,7 @@ By utilizing the 'CustomScriptExtension' extension on a Virtual Machine, an atta
 References:
 
 - https://docs.microsoft.com/en-us/azure/virtual-machines/extensions/custom-script-windows
-- https://github.com/hausec/Azure-Attack-Matrix/blob/main/Execution/AZT201/AZT201-2.md
+- https://microsoft.github.io/Azure-Threat-Research-Matrix/Execution/AZT301/AZT301-2/
 
 <span style="font-variant: small-caps;">Warm-up</span>: 
 

--- a/docs/attack-techniques/azure/azure.execution.vm-run-command.md
+++ b/docs/attack-techniques/azure/azure.execution.vm-run-command.md
@@ -26,7 +26,7 @@ References:
 
 - https://docs.microsoft.com/en-us/azure/virtual-machines/windows/run-command
 - https://docs.microsoft.com/en-us/azure/virtual-machines/linux/run-command
-- https://github.com/hausec/Azure-Attack-Matrix/blob/main/Execution/AZT201/AZT201-1.md
+- https://microsoft.github.io/Azure-Threat-Research-Matrix/Execution/AZT301/AZT301-1/
 
 <span style="font-variant: small-caps;">Warm-up</span>: 
 

--- a/v2/internal/attacktechniques/azure/execution/vm-custom-script-extension/main.go
+++ b/v2/internal/attacktechniques/azure/execution/vm-custom-script-extension/main.go
@@ -29,7 +29,7 @@ By utilizing the 'CustomScriptExtension' extension on a Virtual Machine, an atta
 References:
 
 - https://docs.microsoft.com/en-us/azure/virtual-machines/extensions/custom-script-windows
-- https://github.com/hausec/Azure-Attack-Matrix/blob/main/Execution/AZT201/AZT201-2.md
+- https://microsoft.github.io/Azure-Threat-Research-Matrix/Execution/AZT301/AZT301-2/
 
 Warm-up: 
 

--- a/v2/internal/attacktechniques/azure/execution/vm-run-command/main.go
+++ b/v2/internal/attacktechniques/azure/execution/vm-run-command/main.go
@@ -32,7 +32,7 @@ References:
 
 - https://docs.microsoft.com/en-us/azure/virtual-machines/windows/run-command
 - https://docs.microsoft.com/en-us/azure/virtual-machines/linux/run-command
-- https://github.com/hausec/Azure-Attack-Matrix/blob/main/Execution/AZT201/AZT201-1.md
+- https://microsoft.github.io/Azure-Threat-Research-Matrix/Execution/AZT301/AZT301-1/
 
 Warm-up: 
 


### PR DESCRIPTION
### What does this PR do?

* Update documentation for Azure techniques to reference the recently released [Azure Threat Research Matrix](https://techcommunity.microsoft.com/t5/security-compliance-and-identity/introducing-the-azure-threat-research-matrix/ba-p/3584976). The original links were pointing to a draft version of the project.

### Motivation

* Dead links are bad.
* The ATRM is an excellent resource was already the intended reference for the techniques
