### PR TITLE
Enables `make docs` to generate a yaml file with all techniques and their metadata. Fixes #172

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ build:
 	cd v2 && go build -ldflags="-X main.BuildVersion=$(BUILD_VERSION)" -o ../bin/stratus cmd/stratus/*.go
 
 docs:
-	cd v2 && go run tools/generate-techniques-documentation.go ../docs
+	cd v2 && go run ./tools/ ../docs
 
 test:
 	cd v2 && go test ./... -v

--- a/docs/index.yaml
+++ b/docs/index.yaml
@@ -2,377 +2,377 @@ AWS:
     Credential Access:
         - id: aws.credential-access.ec2-get-password-data
           name: Retrieve EC2 Password Data
-          slow: false
-          mitre-attack-tactic:
+          isSlow: false
+          mitreAttackTactics:
             - Credential Access
           platform: AWS
-          idempotent: true
+          isIdempotent: true
         - id: aws.credential-access.ec2-steal-instance-credentials
           name: Steal EC2 Instance Credentials
-          slow: true
-          mitre-attack-tactic:
+          isSlow: true
+          mitreAttackTactics:
             - Credential Access
           platform: AWS
-          idempotent: true
+          isIdempotent: true
         - id: aws.credential-access.secretsmanager-retrieve-secrets
           name: Retrieve a High Number of Secrets Manager secrets
-          slow: false
-          mitre-attack-tactic:
+          isSlow: false
+          mitreAttackTactics:
             - Credential Access
           platform: AWS
-          idempotent: true
+          isIdempotent: true
         - id: aws.credential-access.ssm-retrieve-securestring-parameters
           name: Retrieve And Decrypt SSM Parameters
-          slow: false
-          mitre-attack-tactic:
+          isSlow: false
+          mitreAttackTactics:
             - Credential Access
           platform: AWS
-          idempotent: true
+          isIdempotent: true
     Defense Evasion:
         - id: aws.defense-evasion.cloudtrail-delete
           name: Delete CloudTrail Trail
-          slow: false
-          mitre-attack-tactic:
+          isSlow: false
+          mitreAttackTactics:
             - Defense Evasion
           platform: AWS
-          idempotent: false
+          isIdempotent: false
         - id: aws.defense-evasion.cloudtrail-event-selectors
           name: Disable CloudTrail Logging Through Event Selectors
-          slow: false
-          mitre-attack-tactic:
+          isSlow: false
+          mitreAttackTactics:
             - Defense Evasion
           platform: AWS
-          idempotent: true
+          isIdempotent: true
         - id: aws.defense-evasion.cloudtrail-lifecycle-rule
           name: CloudTrail Logs Impairment Through S3 Lifecycle Rule
-          slow: false
-          mitre-attack-tactic:
+          isSlow: false
+          mitreAttackTactics:
             - Defense Evasion
           platform: AWS
-          idempotent: false
+          isIdempotent: false
         - id: aws.defense-evasion.cloudtrail-stop
           name: Stop CloudTrail Trail
-          slow: false
-          mitre-attack-tactic:
+          isSlow: false
+          mitreAttackTactics:
             - Defense Evasion
           platform: AWS
-          idempotent: true
+          isIdempotent: true
         - id: aws.defense-evasion.organizations-leave
           name: Attempt to Leave the AWS Organization
-          slow: false
-          mitre-attack-tactic:
+          isSlow: false
+          mitreAttackTactics:
             - Defense Evasion
           platform: AWS
-          idempotent: true
+          isIdempotent: true
         - id: aws.defense-evasion.vpc-remove-flow-logs
           name: Remove VPC Flow Logs
-          slow: false
-          mitre-attack-tactic:
+          isSlow: false
+          mitreAttackTactics:
             - Defense Evasion
           platform: AWS
-          idempotent: false
+          isIdempotent: false
     Discovery:
         - id: aws.discovery.ec2-enumerate-from-instance
           name: Execute Discovery Commands on an EC2 Instance
-          slow: true
-          mitre-attack-tactic:
+          isSlow: true
+          mitreAttackTactics:
             - Discovery
           platform: AWS
-          idempotent: true
+          isIdempotent: true
         - id: aws.discovery.ec2-download-user-data
           name: Download EC2 Instance User Data
-          slow: false
-          mitre-attack-tactic:
+          isSlow: false
+          mitreAttackTactics:
             - Discovery
           platform: AWS
-          idempotent: true
+          isIdempotent: true
     Execution:
         - id: aws.execution.ec2-launch-unusual-instances
           name: Launch Unusual EC2 instances
-          slow: false
-          mitre-attack-tactic:
+          isSlow: false
+          mitreAttackTactics:
             - Execution
           platform: AWS
-          idempotent: true
+          isIdempotent: true
         - id: aws.execution.ec2-user-data
           name: Execute Commands on EC2 Instance via User Data
-          slow: true
-          mitre-attack-tactic:
+          isSlow: true
+          mitreAttackTactics:
             - Execution
             - Privilege Escalation
           platform: AWS
-          idempotent: true
+          isIdempotent: true
     Exfiltration:
         - id: aws.exfiltration.ec2-security-group-open-port-22-ingress
           name: Open Ingress Port 22 on a Security Group
-          slow: false
-          mitre-attack-tactic:
+          isSlow: false
+          mitreAttackTactics:
             - Exfiltration
           platform: AWS
-          idempotent: false
+          isIdempotent: false
         - id: aws.exfiltration.ec2-share-ami
           name: Exfiltrate an AMI by Sharing It
-          slow: false
-          mitre-attack-tactic:
+          isSlow: false
+          mitreAttackTactics:
             - Exfiltration
           platform: AWS
-          idempotent: true
+          isIdempotent: true
         - id: aws.exfiltration.ec2-share-ebs-snapshot
           name: Exfiltrate EBS Snapshot by Sharing It
-          slow: false
-          mitre-attack-tactic:
+          isSlow: false
+          mitreAttackTactics:
             - Exfiltration
           platform: AWS
-          idempotent: true
+          isIdempotent: true
         - id: aws.exfiltration.rds-share-snapshot
           name: Exfiltrate RDS Snapshot by Sharing
-          slow: true
-          mitre-attack-tactic:
+          isSlow: true
+          mitreAttackTactics:
             - Exfiltration
           platform: AWS
-          idempotent: true
+          isIdempotent: true
         - id: aws.exfiltration.s3-backdoor-bucket-policy
           name: Backdoor an S3 Bucket via its Bucket Policy
-          slow: false
-          mitre-attack-tactic:
+          isSlow: false
+          mitreAttackTactics:
             - Exfiltration
           platform: AWS
-          idempotent: true
+          isIdempotent: true
     Initial Access:
         - id: aws.initial-access.console-login-without-mfa
           name: Console Login without MFA
-          slow: false
-          mitre-attack-tactic:
+          isSlow: false
+          mitreAttackTactics:
             - Initial Access
           platform: AWS
-          idempotent: true
+          isIdempotent: true
     Persistence:
         - id: aws.persistence.iam-backdoor-role
           name: Backdoor an IAM Role
-          slow: false
-          mitre-attack-tactic:
+          isSlow: false
+          mitreAttackTactics:
             - Persistence
           platform: AWS
-          idempotent: true
+          isIdempotent: true
         - id: aws.persistence.iam-backdoor-user
           name: Create an Access Key on an IAM User
-          slow: false
-          mitre-attack-tactic:
+          isSlow: false
+          mitreAttackTactics:
             - Persistence
             - Privilege Escalation
           platform: AWS
-          idempotent: false
+          isIdempotent: false
         - id: aws.persistence.iam-create-admin-user
           name: Create an administrative IAM User
-          slow: false
-          mitre-attack-tactic:
+          isSlow: false
+          mitreAttackTactics:
             - Persistence
             - Privilege Escalation
           platform: AWS
-          idempotent: false
+          isIdempotent: false
         - id: aws.persistence.iam-create-user-login-profile
           name: Create a Login Profile on an IAM User
-          slow: false
-          mitre-attack-tactic:
+          isSlow: false
+          mitreAttackTactics:
             - Persistence
             - Privilege Escalation
           platform: AWS
-          idempotent: false
+          isIdempotent: false
         - id: aws.persistence.lambda-backdoor-function
           name: Backdoor Lambda Function Through Resource-Based Policy
-          slow: false
-          mitre-attack-tactic:
+          isSlow: false
+          mitreAttackTactics:
             - Persistence
           platform: AWS
-          idempotent: false
+          isIdempotent: false
         - id: aws.persistence.lambda-overwrite-code
           name: Overwrite Lambda Function Code
-          slow: false
-          mitre-attack-tactic:
+          isSlow: false
+          mitreAttackTactics:
             - Persistence
           platform: AWS
-          idempotent: true
+          isIdempotent: true
         - id: aws.persistence.rolesanywhere-create-trust-anchor
           name: Create an IAM Roles Anywhere trust anchor
-          slow: false
-          mitre-attack-tactic:
+          isSlow: false
+          mitreAttackTactics:
             - Persistence
             - Privilege Escalation
           platform: AWS
-          idempotent: false
+          isIdempotent: false
     Privilege Escalation:
         - id: aws.execution.ec2-user-data
           name: Execute Commands on EC2 Instance via User Data
-          slow: true
-          mitre-attack-tactic:
+          isSlow: true
+          mitreAttackTactics:
             - Execution
             - Privilege Escalation
           platform: AWS
-          idempotent: true
+          isIdempotent: true
         - id: aws.persistence.iam-backdoor-user
           name: Create an Access Key on an IAM User
-          slow: false
-          mitre-attack-tactic:
+          isSlow: false
+          mitreAttackTactics:
             - Persistence
             - Privilege Escalation
           platform: AWS
-          idempotent: false
+          isIdempotent: false
         - id: aws.persistence.iam-create-admin-user
           name: Create an administrative IAM User
-          slow: false
-          mitre-attack-tactic:
+          isSlow: false
+          mitreAttackTactics:
             - Persistence
             - Privilege Escalation
           platform: AWS
-          idempotent: false
+          isIdempotent: false
         - id: aws.persistence.iam-create-user-login-profile
           name: Create a Login Profile on an IAM User
-          slow: false
-          mitre-attack-tactic:
+          isSlow: false
+          mitreAttackTactics:
             - Persistence
             - Privilege Escalation
           platform: AWS
-          idempotent: false
+          isIdempotent: false
         - id: aws.persistence.rolesanywhere-create-trust-anchor
           name: Create an IAM Roles Anywhere trust anchor
-          slow: false
-          mitre-attack-tactic:
+          isSlow: false
+          mitreAttackTactics:
             - Persistence
             - Privilege Escalation
           platform: AWS
-          idempotent: false
+          isIdempotent: false
 GCP:
     Persistence:
         - id: gcp.persistence.create-admin-service-account
           name: Create an Admin GCP Service Account
-          slow: false
-          mitre-attack-tactic:
+          isSlow: false
+          mitreAttackTactics:
             - Persistence
             - Privilege Escalation
           platform: GCP
-          idempotent: false
+          isIdempotent: false
         - id: gcp.persistence.create-service-account-key
           name: Create a GCP Service Account Key
-          slow: false
-          mitre-attack-tactic:
+          isSlow: false
+          mitreAttackTactics:
             - Persistence
             - Privilege Escalation
           platform: GCP
-          idempotent: false
+          isIdempotent: false
     Privilege Escalation:
         - id: gcp.persistence.create-admin-service-account
           name: Create an Admin GCP Service Account
-          slow: false
-          mitre-attack-tactic:
+          isSlow: false
+          mitreAttackTactics:
             - Persistence
             - Privilege Escalation
           platform: GCP
-          idempotent: false
+          isIdempotent: false
         - id: gcp.persistence.create-service-account-key
           name: Create a GCP Service Account Key
-          slow: false
-          mitre-attack-tactic:
+          isSlow: false
+          mitreAttackTactics:
             - Persistence
             - Privilege Escalation
           platform: GCP
-          idempotent: false
+          isIdempotent: false
         - id: gcp.privilege-escalation.impersonate-service-accounts
           name: Impersonate GCP Service Accounts
-          slow: false
-          mitre-attack-tactic:
+          isSlow: false
+          mitreAttackTactics:
             - Privilege Escalation
           platform: GCP
-          idempotent: true
+          isIdempotent: true
 Azure:
     Execution:
         - id: azure.execution.vm-custom-script-extension
           name: Execute Command on Virtual Machine using Custom Script Extension
-          slow: true
-          mitre-attack-tactic:
+          isSlow: true
+          mitreAttackTactics:
             - Execution
           platform: Azure
-          idempotent: false
+          isIdempotent: false
         - id: azure.execution.vm-run-command
           name: Execute Commands on Virtual Machine using Run Command
-          slow: true
-          mitre-attack-tactic:
+          isSlow: true
+          mitreAttackTactics:
             - Execution
           platform: Azure
-          idempotent: true
+          isIdempotent: true
     Exfiltration:
         - id: azure.exfiltration.disk-export
           name: Export Disk Through SAS URL
-          slow: false
-          mitre-attack-tactic:
+          isSlow: false
+          mitreAttackTactics:
             - Exfiltration
           platform: Azure
-          idempotent: true
+          isIdempotent: true
 Kubernetes:
     Credential Access:
         - id: k8s.credential-access.dump-secrets
           name: Dump All Secrets
-          slow: false
-          mitre-attack-tactic:
+          isSlow: false
+          mitreAttackTactics:
             - Credential Access
           platform: Kubernetes
-          idempotent: true
+          isIdempotent: true
         - id: k8s.credential-access.steal-serviceaccount-token
           name: Steal Pod Service Account Token
-          slow: false
-          mitre-attack-tactic:
+          isSlow: false
+          mitreAttackTactics:
             - Credential Access
           platform: Kubernetes
-          idempotent: true
+          isIdempotent: true
     Persistence:
         - id: k8s.persistence.create-admin-clusterrole
           name: Create Admin ClusterRole
-          slow: false
-          mitre-attack-tactic:
+          isSlow: false
+          mitreAttackTactics:
             - Persistence
             - Privilege Escalation
           platform: Kubernetes
-          idempotent: false
+          isIdempotent: false
         - id: k8s.persistence.create-client-certificate
           name: Create Client Certificate Credential
-          slow: false
-          mitre-attack-tactic:
+          isSlow: false
+          mitreAttackTactics:
             - Persistence
           platform: Kubernetes
-          idempotent: true
+          isIdempotent: true
         - id: k8s.persistence.create-token
           name: Create Long-Lived Token
-          slow: false
-          mitre-attack-tactic:
+          isSlow: false
+          mitreAttackTactics:
             - Persistence
           platform: Kubernetes
-          idempotent: true
+          isIdempotent: true
     Privilege Escalation:
         - id: k8s.persistence.create-admin-clusterrole
           name: Create Admin ClusterRole
-          slow: false
-          mitre-attack-tactic:
+          isSlow: false
+          mitreAttackTactics:
             - Persistence
             - Privilege Escalation
           platform: Kubernetes
-          idempotent: false
+          isIdempotent: false
         - id: k8s.privilege-escalation.hostpath-volume
           name: Container breakout via hostPath volume mount
-          slow: false
-          mitre-attack-tactic:
+          isSlow: false
+          mitreAttackTactics:
             - Privilege Escalation
           platform: Kubernetes
-          idempotent: false
+          isIdempotent: false
         - id: k8s.privilege-escalation.nodes-proxy
           name: Privilege escalation through node/proxy permissions
-          slow: false
-          mitre-attack-tactic:
+          isSlow: false
+          mitreAttackTactics:
             - Privilege Escalation
           platform: Kubernetes
-          idempotent: true
+          isIdempotent: true
         - id: k8s.privilege-escalation.privileged-pod
           name: Run a Privileged Pod
-          slow: false
-          mitre-attack-tactic:
+          isSlow: false
+          mitreAttackTactics:
             - Privilege Escalation
           platform: Kubernetes
-          idempotent: false
+          isIdempotent: false

--- a/docs/index.yaml
+++ b/docs/index.yaml
@@ -1,0 +1,378 @@
+AWS:
+    Credential Access:
+        - id: aws.credential-access.ec2-get-password-data
+          name: Retrieve EC2 Password Data
+          slow: false
+          mitre-attack-tactic:
+            - Credential Access
+          platform: AWS
+          idempotent: true
+        - id: aws.credential-access.ec2-steal-instance-credentials
+          name: Steal EC2 Instance Credentials
+          slow: true
+          mitre-attack-tactic:
+            - Credential Access
+          platform: AWS
+          idempotent: true
+        - id: aws.credential-access.secretsmanager-retrieve-secrets
+          name: Retrieve a High Number of Secrets Manager secrets
+          slow: false
+          mitre-attack-tactic:
+            - Credential Access
+          platform: AWS
+          idempotent: true
+        - id: aws.credential-access.ssm-retrieve-securestring-parameters
+          name: Retrieve And Decrypt SSM Parameters
+          slow: false
+          mitre-attack-tactic:
+            - Credential Access
+          platform: AWS
+          idempotent: true
+    Defense Evasion:
+        - id: aws.defense-evasion.cloudtrail-delete
+          name: Delete CloudTrail Trail
+          slow: false
+          mitre-attack-tactic:
+            - Defense Evasion
+          platform: AWS
+          idempotent: false
+        - id: aws.defense-evasion.cloudtrail-event-selectors
+          name: Disable CloudTrail Logging Through Event Selectors
+          slow: false
+          mitre-attack-tactic:
+            - Defense Evasion
+          platform: AWS
+          idempotent: true
+        - id: aws.defense-evasion.cloudtrail-lifecycle-rule
+          name: CloudTrail Logs Impairment Through S3 Lifecycle Rule
+          slow: false
+          mitre-attack-tactic:
+            - Defense Evasion
+          platform: AWS
+          idempotent: false
+        - id: aws.defense-evasion.cloudtrail-stop
+          name: Stop CloudTrail Trail
+          slow: false
+          mitre-attack-tactic:
+            - Defense Evasion
+          platform: AWS
+          idempotent: true
+        - id: aws.defense-evasion.organizations-leave
+          name: Attempt to Leave the AWS Organization
+          slow: false
+          mitre-attack-tactic:
+            - Defense Evasion
+          platform: AWS
+          idempotent: true
+        - id: aws.defense-evasion.vpc-remove-flow-logs
+          name: Remove VPC Flow Logs
+          slow: false
+          mitre-attack-tactic:
+            - Defense Evasion
+          platform: AWS
+          idempotent: false
+    Discovery:
+        - id: aws.discovery.ec2-enumerate-from-instance
+          name: Execute Discovery Commands on an EC2 Instance
+          slow: true
+          mitre-attack-tactic:
+            - Discovery
+          platform: AWS
+          idempotent: true
+        - id: aws.discovery.ec2-download-user-data
+          name: Download EC2 Instance User Data
+          slow: false
+          mitre-attack-tactic:
+            - Discovery
+          platform: AWS
+          idempotent: true
+    Execution:
+        - id: aws.execution.ec2-launch-unusual-instances
+          name: Launch Unusual EC2 instances
+          slow: false
+          mitre-attack-tactic:
+            - Execution
+          platform: AWS
+          idempotent: true
+        - id: aws.execution.ec2-user-data
+          name: Execute Commands on EC2 Instance via User Data
+          slow: true
+          mitre-attack-tactic:
+            - Execution
+            - Privilege Escalation
+          platform: AWS
+          idempotent: true
+    Exfiltration:
+        - id: aws.exfiltration.ec2-security-group-open-port-22-ingress
+          name: Open Ingress Port 22 on a Security Group
+          slow: false
+          mitre-attack-tactic:
+            - Exfiltration
+          platform: AWS
+          idempotent: false
+        - id: aws.exfiltration.ec2-share-ami
+          name: Exfiltrate an AMI by Sharing It
+          slow: false
+          mitre-attack-tactic:
+            - Exfiltration
+          platform: AWS
+          idempotent: true
+        - id: aws.exfiltration.ec2-share-ebs-snapshot
+          name: Exfiltrate EBS Snapshot by Sharing It
+          slow: false
+          mitre-attack-tactic:
+            - Exfiltration
+          platform: AWS
+          idempotent: true
+        - id: aws.exfiltration.rds-share-snapshot
+          name: Exfiltrate RDS Snapshot by Sharing
+          slow: true
+          mitre-attack-tactic:
+            - Exfiltration
+          platform: AWS
+          idempotent: true
+        - id: aws.exfiltration.s3-backdoor-bucket-policy
+          name: Backdoor an S3 Bucket via its Bucket Policy
+          slow: false
+          mitre-attack-tactic:
+            - Exfiltration
+          platform: AWS
+          idempotent: true
+    Initial Access:
+        - id: aws.initial-access.console-login-without-mfa
+          name: Console Login without MFA
+          slow: false
+          mitre-attack-tactic:
+            - Initial Access
+          platform: AWS
+          idempotent: true
+    Persistence:
+        - id: aws.persistence.iam-backdoor-role
+          name: Backdoor an IAM Role
+          slow: false
+          mitre-attack-tactic:
+            - Persistence
+          platform: AWS
+          idempotent: true
+        - id: aws.persistence.iam-backdoor-user
+          name: Create an Access Key on an IAM User
+          slow: false
+          mitre-attack-tactic:
+            - Persistence
+            - Privilege Escalation
+          platform: AWS
+          idempotent: false
+        - id: aws.persistence.iam-create-admin-user
+          name: Create an administrative IAM User
+          slow: false
+          mitre-attack-tactic:
+            - Persistence
+            - Privilege Escalation
+          platform: AWS
+          idempotent: false
+        - id: aws.persistence.iam-create-user-login-profile
+          name: Create a Login Profile on an IAM User
+          slow: false
+          mitre-attack-tactic:
+            - Persistence
+            - Privilege Escalation
+          platform: AWS
+          idempotent: false
+        - id: aws.persistence.lambda-backdoor-function
+          name: Backdoor Lambda Function Through Resource-Based Policy
+          slow: false
+          mitre-attack-tactic:
+            - Persistence
+          platform: AWS
+          idempotent: false
+        - id: aws.persistence.lambda-overwrite-code
+          name: Overwrite Lambda Function Code
+          slow: false
+          mitre-attack-tactic:
+            - Persistence
+          platform: AWS
+          idempotent: true
+        - id: aws.persistence.rolesanywhere-create-trust-anchor
+          name: Create an IAM Roles Anywhere trust anchor
+          slow: false
+          mitre-attack-tactic:
+            - Persistence
+            - Privilege Escalation
+          platform: AWS
+          idempotent: false
+    Privilege Escalation:
+        - id: aws.execution.ec2-user-data
+          name: Execute Commands on EC2 Instance via User Data
+          slow: true
+          mitre-attack-tactic:
+            - Execution
+            - Privilege Escalation
+          platform: AWS
+          idempotent: true
+        - id: aws.persistence.iam-backdoor-user
+          name: Create an Access Key on an IAM User
+          slow: false
+          mitre-attack-tactic:
+            - Persistence
+            - Privilege Escalation
+          platform: AWS
+          idempotent: false
+        - id: aws.persistence.iam-create-admin-user
+          name: Create an administrative IAM User
+          slow: false
+          mitre-attack-tactic:
+            - Persistence
+            - Privilege Escalation
+          platform: AWS
+          idempotent: false
+        - id: aws.persistence.iam-create-user-login-profile
+          name: Create a Login Profile on an IAM User
+          slow: false
+          mitre-attack-tactic:
+            - Persistence
+            - Privilege Escalation
+          platform: AWS
+          idempotent: false
+        - id: aws.persistence.rolesanywhere-create-trust-anchor
+          name: Create an IAM Roles Anywhere trust anchor
+          slow: false
+          mitre-attack-tactic:
+            - Persistence
+            - Privilege Escalation
+          platform: AWS
+          idempotent: false
+GCP:
+    Persistence:
+        - id: gcp.persistence.create-admin-service-account
+          name: Create an Admin GCP Service Account
+          slow: false
+          mitre-attack-tactic:
+            - Persistence
+            - Privilege Escalation
+          platform: GCP
+          idempotent: false
+        - id: gcp.persistence.create-service-account-key
+          name: Create a GCP Service Account Key
+          slow: false
+          mitre-attack-tactic:
+            - Persistence
+            - Privilege Escalation
+          platform: GCP
+          idempotent: false
+    Privilege Escalation:
+        - id: gcp.persistence.create-admin-service-account
+          name: Create an Admin GCP Service Account
+          slow: false
+          mitre-attack-tactic:
+            - Persistence
+            - Privilege Escalation
+          platform: GCP
+          idempotent: false
+        - id: gcp.persistence.create-service-account-key
+          name: Create a GCP Service Account Key
+          slow: false
+          mitre-attack-tactic:
+            - Persistence
+            - Privilege Escalation
+          platform: GCP
+          idempotent: false
+        - id: gcp.privilege-escalation.impersonate-service-accounts
+          name: Impersonate GCP Service Accounts
+          slow: false
+          mitre-attack-tactic:
+            - Privilege Escalation
+          platform: GCP
+          idempotent: true
+Azure:
+    Execution:
+        - id: azure.execution.vm-custom-script-extension
+          name: Execute Command on Virtual Machine using Custom Script Extension
+          slow: true
+          mitre-attack-tactic:
+            - Execution
+          platform: Azure
+          idempotent: false
+        - id: azure.execution.vm-run-command
+          name: Execute Commands on Virtual Machine using Run Command
+          slow: true
+          mitre-attack-tactic:
+            - Execution
+          platform: Azure
+          idempotent: true
+    Exfiltration:
+        - id: azure.exfiltration.disk-export
+          name: Export Disk Through SAS URL
+          slow: false
+          mitre-attack-tactic:
+            - Exfiltration
+          platform: Azure
+          idempotent: true
+Kubernetes:
+    Credential Access:
+        - id: k8s.credential-access.dump-secrets
+          name: Dump All Secrets
+          slow: false
+          mitre-attack-tactic:
+            - Credential Access
+          platform: Kubernetes
+          idempotent: true
+        - id: k8s.credential-access.steal-serviceaccount-token
+          name: Steal Pod Service Account Token
+          slow: false
+          mitre-attack-tactic:
+            - Credential Access
+          platform: Kubernetes
+          idempotent: true
+    Persistence:
+        - id: k8s.persistence.create-admin-clusterrole
+          name: Create Admin ClusterRole
+          slow: false
+          mitre-attack-tactic:
+            - Persistence
+            - Privilege Escalation
+          platform: Kubernetes
+          idempotent: false
+        - id: k8s.persistence.create-client-certificate
+          name: Create Client Certificate Credential
+          slow: false
+          mitre-attack-tactic:
+            - Persistence
+          platform: Kubernetes
+          idempotent: true
+        - id: k8s.persistence.create-token
+          name: Create Long-Lived Token
+          slow: false
+          mitre-attack-tactic:
+            - Persistence
+          platform: Kubernetes
+          idempotent: true
+    Privilege Escalation:
+        - id: k8s.persistence.create-admin-clusterrole
+          name: Create Admin ClusterRole
+          slow: false
+          mitre-attack-tactic:
+            - Persistence
+            - Privilege Escalation
+          platform: Kubernetes
+          idempotent: false
+        - id: k8s.privilege-escalation.hostpath-volume
+          name: Container breakout via hostPath volume mount
+          slow: false
+          mitre-attack-tactic:
+            - Privilege Escalation
+          platform: Kubernetes
+          idempotent: false
+        - id: k8s.privilege-escalation.nodes-proxy
+          name: Privilege escalation through node/proxy permissions
+          slow: false
+          mitre-attack-tactic:
+            - Privilege Escalation
+          platform: Kubernetes
+          idempotent: true
+        - id: k8s.privilege-escalation.privileged-pod
+          name: Run a Privileged Pod
+          slow: false
+          mitre-attack-tactic:
+            - Privilege Escalation
+          platform: Kubernetes
+          idempotent: false

--- a/v2/pkg/stratus/attack_technique.go
+++ b/v2/pkg/stratus/attack_technique.go
@@ -22,7 +22,7 @@ type AttackTechnique struct {
 
 	// MITRE ATT&CK Tactics to which this technique maps
 	// see https://attack.mitre.org/techniques/enterprise/
-	MitreAttackTactics []mitreattack.Tactic `yaml:"mitre-attack-tactic"`
+	MitreAttackTactics []mitreattack.Tactic `yaml:"mitre-attack-tactics"`
 
 	// The platform of the technique, e.g. AWS
 	Platform Platform `yaml:"platform"`

--- a/v2/pkg/stratus/attack_technique.go
+++ b/v2/pkg/stratus/attack_technique.go
@@ -6,39 +6,39 @@ import (
 
 type AttackTechnique struct {
 	// Short identifier, e.g. aws.persistence.create-iam-user
-	ID string
+	ID string `yaml:"id"`
 
 	// Friendly-looking short name
-	FriendlyName string
+	FriendlyName string `yaml:"name"`
 
 	// Full description (multi-line)
-	Description string
+	Description string `yaml:"-"`
 
 	// Pointer and leads for detection opportunities (multi-line)
-	Detection string
+	Detection string `yaml:"-"`
 
 	// Indicates if the technique is expected to be slow to warm-up or detonate
-	IsSlow bool
+	IsSlow bool `yaml:"slow"`
 
 	// MITRE ATT&CK Tactics to which this technique maps
 	// see https://attack.mitre.org/techniques/enterprise/
-	MitreAttackTactics []mitreattack.Tactic
+	MitreAttackTactics []mitreattack.Tactic `yaml:"mitre-attack-tactic"`
 
 	// The platform of the technique, e.g. AWS
-	Platform Platform
+	Platform Platform `yaml:"platform"`
 
 	// Terraform code to apply to create the necessary prerequisites for the technique to be detonated
-	PrerequisitesTerraformCode []byte
+	PrerequisitesTerraformCode []byte `yaml:"-"`
 
 	// Detonation function
 	// Parameters are the Terraform outputs
-	Detonate func(params map[string]string) error
+	Detonate func(params map[string]string) error `yaml:"-"`
 
 	// Indicates if the detonation function is idempotent, i.e. if it can be run multiple times without reverting it
-	IsIdempotent bool
+	IsIdempotent bool `yaml:"idempotent"`
 
 	// Reversion function, to revert the side effects of a detonation
-	Revert func(params map[string]string) error
+	Revert func(params map[string]string) error `yaml:"-"`
 }
 
 func (m AttackTechnique) String() string {

--- a/v2/pkg/stratus/attack_technique.go
+++ b/v2/pkg/stratus/attack_technique.go
@@ -18,11 +18,11 @@ type AttackTechnique struct {
 	Detection string `yaml:"-"`
 
 	// Indicates if the technique is expected to be slow to warm-up or detonate
-	IsSlow bool `yaml:"slow"`
+	IsSlow bool `yaml:"isSlow"`
 
 	// MITRE ATT&CK Tactics to which this technique maps
 	// see https://attack.mitre.org/techniques/enterprise/
-	MitreAttackTactics []mitreattack.Tactic `yaml:"mitre-attack-tactics"`
+	MitreAttackTactics []mitreattack.Tactic `yaml:"mitreAttackTactics"`
 
 	// The platform of the technique, e.g. AWS
 	Platform Platform `yaml:"platform"`
@@ -35,7 +35,7 @@ type AttackTechnique struct {
 	Detonate func(params map[string]string) error `yaml:"-"`
 
 	// Indicates if the detonation function is idempotent, i.e. if it can be run multiple times without reverting it
-	IsIdempotent bool `yaml:"idempotent"`
+	IsIdempotent bool `yaml:"isIdempotent"`
 
 	// Reversion function, to revert the side effects of a detonation
 	Revert func(params map[string]string) error `yaml:"-"`

--- a/v2/pkg/stratus/mitreattack/tactics.go
+++ b/v2/pkg/stratus/mitreattack/tactics.go
@@ -48,3 +48,9 @@ func AttackTacticFromString(name string) (Tactic, error) {
 func AttackTacticToString(tactic Tactic) string {
 	return tactics[tactic]
 }
+
+// MarshalYAML implements the Marshaler interface from "gopkg.in/yaml.v3".
+// This method makes Tactic type to return a string rather than an int when marshalling to YAML.
+func (t Tactic) MarshalYAML() (interface{}, error) {
+	return tactics[t], nil
+}

--- a/v2/pkg/stratus/mitreattack/tactics.go
+++ b/v2/pkg/stratus/mitreattack/tactics.go
@@ -3,6 +3,8 @@ package mitreattack
 import (
 	"errors"
 	"strings"
+
+	"gopkg.in/yaml.v3"
 )
 
 type Tactic int
@@ -53,4 +55,13 @@ func AttackTacticToString(tactic Tactic) string {
 // This method makes Tactic type to return a string rather than an int when marshalling to YAML.
 func (t Tactic) MarshalYAML() (interface{}, error) {
 	return tactics[t], nil
+}
+
+// UnmarshalYAML implements the Marshaler interface from "gopkg.in/yaml.v3".
+// This method moes the reverse of MarshalYAML, it gets a string with the tactic name mutates into an int.
+func (t Tactic) UnmarshalYAML(node *yaml.Node) error {
+	value := node.Value
+	//lint:ignore SA4006 this is mutating the value of t rather than using it later.
+	t, err := AttackTacticFromString(value)
+	return err
 }

--- a/v2/pkg/stratus/platform.go
+++ b/v2/pkg/stratus/platform.go
@@ -3,6 +3,8 @@ package stratus
 import (
 	"errors"
 	"strings"
+
+	"gopkg.in/yaml.v3"
 )
 
 type Platform string
@@ -45,7 +47,15 @@ func (p Platform) FormatName() (string, error) {
 }
 
 // MarshalYAML implements the Marshaler interface from "gopkg.in/yaml.v3".
-// It uses the formatted name when marshalling to YAML. "Azure" instead of "azure", etc.
+// It uses the formatted name when marshalling to YAML. From "azure" to "Azure", etc.
 func (p Platform) MarshalYAML() (interface{}, error) {
 	return p.FormatName()
+}
+
+// UnmarshalYAML implements the Marshaler interface from "gopkg.in/yaml.v3".
+// It does the reverse operation defined on MarshalYAML. It mutates Platform from "Azure" to "azure".
+func (p Platform) UnmarshalYAML(node *yaml.Node) error {
+	//lint:ignore SA4006 this is mutating the value of p rather than using it later.
+	p, err := PlatformFromString(node.Value)
+	return err
 }

--- a/v2/pkg/stratus/platform.go
+++ b/v2/pkg/stratus/platform.go
@@ -28,3 +28,24 @@ func PlatformFromString(name string) (Platform, error) {
 		return "", errors.New("unknown platform: " + name)
 	}
 }
+
+func (p Platform) FormatName() (string, error) {
+	switch p {
+	case AWS:
+		return "AWS", nil
+	case Azure:
+		return "Azure", nil
+	case GCP:
+		return "GCP", nil
+	case Kubernetes:
+		return "Kubernetes", nil
+	default:
+		return "", errors.New("platform name not formatted")
+	}
+}
+
+// MarshalYAML implements the Marshaler interface from "gopkg.in/yaml.v3".
+// It uses the formatted name when marshalling to YAML. "Azure" instead of "azure", etc.
+func (p Platform) MarshalYAML() (interface{}, error) {
+	return p.FormatName()
+}

--- a/v2/tools/generate-docs.go
+++ b/v2/tools/generate-docs.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/datadog/stratus-red-team/v2/pkg/stratus"
+	_ "github.com/datadog/stratus-red-team/v2/pkg/stratus/loader"
+)
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "specify the docs output directory")
+		os.Exit(1)
+	}
+	docsDirectory := os.Args[1]
+
+	registry := stratus.GetRegistry()
+	techniques := registry.ListAttackTechniques()
+
+	// Platform => [MITRE ATT&CK tactic => list of stratus techniques]
+	index := NewIndex(techniques).Values()
+
+	if err := GenerateTechDocs(docsDirectory, techniques, index); err != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", err)
+		os.Exit(1)
+	}
+
+	// Write a single index file with all techniques. File is enconded in YAML.
+	yamlIndex := filepath.Join(docsDirectory, "index.yaml")
+	if err := GenerateYAML(yamlIndex, index); err != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", err)
+		os.Exit(1)
+	}
+}

--- a/v2/tools/generate-techniques-documentation.go
+++ b/v2/tools/generate-techniques-documentation.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"bytes"
-	"fmt"
 	"log"
 	"os"
 	"path/filepath"
@@ -12,19 +11,19 @@ import (
 	"github.com/datadog/stratus-red-team/v2/pkg/stratus"
 	_ "github.com/datadog/stratus-red-team/v2/pkg/stratus/loader"
 	"github.com/datadog/stratus-red-team/v2/pkg/stratus/mitreattack"
-	"gopkg.in/yaml.v3"
 )
 
-func main() {
-	if len(os.Args) != 2 {
-		fmt.Fprintln(os.Stderr, "specify the docs output directory")
-		os.Exit(1)
+func GenerateTechDocs(docsDirectory string, techniques []*stratus.AttackTechnique, index map[stratus.Platform]map[string][]*stratus.AttackTechnique) error {
+	techniqueTemplate, err := os.ReadFile("tools/doc.tpl")
+	if err != nil {
+		return err
 	}
-	docsDirectory := os.Args[1]
-	techniqueTemplate, _ := os.ReadFile("tools/doc.tpl")
-	indexTemplate, _ := os.ReadFile("tools/index-by-platform.tpl")
-	registry := stratus.GetRegistry()
-	techniques := registry.ListAttackTechniques()
+
+	indexTemplate, err := os.ReadFile("tools/index-by-platform.tpl")
+	if err != nil {
+		return err
+	}
+
 	funcMap := template.FuncMap{
 		"ToUpper": strings.ToUpper,
 		"JoinTactics": func(tactics []mitreattack.Tactic, prefix string, sep string) string {
@@ -38,22 +37,9 @@ func main() {
 		"FormatPlatformName": FormatPlatformName,
 	}
 
-	// Platform => [MITRE ATT&CK tactic => list of stratus techniques]
-	index := map[stratus.Platform]map[string][]*stratus.AttackTechnique{}
-
 	// Pass 1: write techniques docs
 	for i := range techniques {
 		technique := techniques[i]
-		for j := range technique.MitreAttackTactics {
-			tactic := mitreattack.AttackTacticToString(technique.MitreAttackTactics[j])
-			if index[technique.Platform] == nil {
-				index[technique.Platform] = make(map[string][]*stratus.AttackTechnique)
-			}
-			if index[technique.Platform][tactic] == nil {
-				index[technique.Platform][tactic] = make([]*stratus.AttackTechnique, 0)
-			}
-			index[technique.Platform][tactic] = append(index[technique.Platform][tactic], technique)
-		}
 
 		tpl, _ := template.New("technique").Funcs(funcMap).Parse(string(techniqueTemplate))
 		result := ""
@@ -61,7 +47,7 @@ func main() {
 		formatTechniqueDescription(technique)
 		err := tpl.Execute(buf, technique)
 		if err != nil {
-			panic(err)
+			return err
 		}
 		dir := filepath.Join(docsDirectory, "attack-techniques", string(technique.Platform))
 		if !FileExists(dir) {
@@ -69,7 +55,7 @@ func main() {
 		}
 		err = os.WriteFile(filepath.Join(dir, technique.ID+".md"), buf.Bytes(), 0744)
 		if err != nil {
-			panic(err)
+			return err
 		}
 	}
 
@@ -87,11 +73,11 @@ func main() {
 		}
 		err := tpl.Execute(buf, vars)
 		if err != nil {
-			panic(err)
+			return err
 		}
 		err = os.WriteFile(platformIndexFile, buf.Bytes(), 0744)
 		if err != nil {
-			panic(err)
+			return err
 		}
 	}
 
@@ -101,36 +87,15 @@ func main() {
 	tpl, _ := template.New("index-by-platform").Funcs(funcMap).Parse(string(listTemplate))
 	result := ""
 	buf := bytes.NewBufferString(result)
-	err := tpl.Execute(buf, techniques)
+	err = tpl.Execute(buf, techniques)
 	if err != nil {
-		panic(err)
+		return err
 	}
 	err = os.WriteFile(listFile, buf.Bytes(), 0744)
 	if err != nil {
-		panic(err)
-	}
-
-	// Write a single index file with all techniques. File is enconded in YAML.
-	yamlIndex := filepath.Join(docsDirectory, "index.yaml")
-	if err := writeYaml(yamlIndex, index); err != nil {
-		log.Fatal(err)
-	}
-}
-
-func writeYaml(path string, index interface{}) error {
-	// if file doesn't exist, it creates. Truncates file and open it in write only mode.
-	yamlFile, err := os.OpenFile(path, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0644)
-	if err != nil {
 		return err
 	}
-	defer yamlFile.Close()
 
-	enconder := yaml.NewEncoder(yamlFile)
-	defer enconder.Close()
-
-	if err := enconder.Encode(&index); err != nil {
-		return err
-	}
 	return nil
 }
 

--- a/v2/tools/generate-yaml.go
+++ b/v2/tools/generate-yaml.go
@@ -1,0 +1,24 @@
+package main
+
+import (
+	"os"
+
+	"gopkg.in/yaml.v3"
+)
+
+func GenerateYAML(path string, index interface{}) error {
+	// if file doesn't exist, it creates. Truncates file and open it in write only mode.
+	yamlFile, err := os.OpenFile(path, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0644)
+	if err != nil {
+		return err
+	}
+	defer yamlFile.Close()
+
+	enconder := yaml.NewEncoder(yamlFile)
+	defer enconder.Close()
+
+	if err := enconder.Encode(&index); err != nil {
+		return err
+	}
+	return nil
+}

--- a/v2/tools/index.go
+++ b/v2/tools/index.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	"github.com/datadog/stratus-red-team/v2/pkg/stratus"
+	"github.com/datadog/stratus-red-team/v2/pkg/stratus/mitreattack"
+)
+
+type index struct {
+	techniques []*stratus.AttackTechnique
+	values     map[stratus.Platform]map[string][]*stratus.AttackTechnique
+}
+
+func NewIndex(techniques []*stratus.AttackTechnique) index {
+	return index{techniques: techniques, values: make(map[stratus.Platform]map[string][]*stratus.AttackTechnique)}
+}
+
+func (i index) Values() map[stratus.Platform]map[string][]*stratus.AttackTechnique {
+	i.values = map[stratus.Platform]map[string][]*stratus.AttackTechnique{}
+
+	for j := range i.techniques {
+		technique := i.techniques[j]
+		for j := range technique.MitreAttackTactics {
+			tactic := mitreattack.AttackTacticToString(technique.MitreAttackTactics[j])
+			if i.values[technique.Platform] == nil {
+				i.values[technique.Platform] = make(map[string][]*stratus.AttackTechnique)
+			}
+			if i.values[technique.Platform][tactic] == nil {
+				i.values[technique.Platform][tactic] = make([]*stratus.AttackTechnique, 0)
+			}
+			i.values[technique.Platform][tactic] = append(i.values[technique.Platform][tactic], technique)
+		}
+	}
+
+	return i.values
+}


### PR DESCRIPTION
### What does this PR do?
Enhancement: `make docs` now generates a `docs/index.yaml` file with all techniques serialised into it.


### Motivation
Motivation is described on #172 


### Checklist
N/A

### Details

`index.yaml` file contains all techniques grouped by MITRE tactic and platform. Some techniques are classified with in 2 or more tactics, when that happens, the technique is duplicated in the document.