### PR TITLE
Remove requirement for default VPC and default subnets from aws.exfiltration.rds-share-snapshot. Add output indicating if an attack technique is slow.

### DIFF
--- a/v2/pkg/stratus/runner/runner.go
+++ b/v2/pkg/stratus/runner/runner.go
@@ -2,13 +2,12 @@ package runner
 
 import (
 	"errors"
-	"log"
-	"path/filepath"
-	"strings"
-
 	"github.com/datadog/stratus-red-team/v2/internal/providers"
 	"github.com/datadog/stratus-red-team/v2/internal/state"
 	"github.com/datadog/stratus-red-team/v2/pkg/stratus"
+	"log"
+	"path/filepath"
+	"strings"
 )
 
 const StratusRunnerForce = true

--- a/v2/pkg/stratus/runner/runner.go
+++ b/v2/pkg/stratus/runner/runner.go
@@ -105,7 +105,7 @@ func (m *Runner) Detonate() error {
 	}
 
 	if m.Technique.IsSlow {
-		log.Println("Note: This is a slow attack technique, it might take a long time to detonate")
+		log.Println("Note: This is a slow attack technique, it might take a long time to warm up or detonate")
 	}
 
 	if willWarmUp {

--- a/v2/pkg/stratus/runner/runner.go
+++ b/v2/pkg/stratus/runner/runner.go
@@ -2,12 +2,13 @@ package runner
 
 import (
 	"errors"
-	"github.com/datadog/stratus-red-team/v2/internal/providers"
-	"github.com/datadog/stratus-red-team/v2/internal/state"
-	"github.com/datadog/stratus-red-team/v2/pkg/stratus"
 	"log"
 	"path/filepath"
 	"strings"
+
+	"github.com/datadog/stratus-red-team/v2/internal/providers"
+	"github.com/datadog/stratus-red-team/v2/internal/state"
+	"github.com/datadog/stratus-red-team/v2/pkg/stratus"
 )
 
 const StratusRunnerForce = true
@@ -102,6 +103,10 @@ func (m *Runner) Detonate() error {
 				"Revert it with 'stratus revert' before detonating it again, or use --force")
 		}
 		willWarmUp = false
+	}
+
+	if m.Technique.IsSlow {
+		log.Println("Note: This is a slow attack technique, it might take a long time to detonate")
 	}
 
 	if willWarmUp {


### PR DESCRIPTION
### What does this PR do?

* Bug fix
* Enhancement

### Motivation

* https://github.com/DataDog/stratus-red-team/issues/140
* https://github.com/DataDog/stratus-red-team/issues/141

### Checklist

Behavior when detonating `aws.exfiltration.rds-share-snapshot` prior to this change (with no default VPC or default subnets configured):

```
2022/12/06 12:46:58 Checking your authentication against AWS
2022/12/06 12:46:59 Warming up aws.exfiltration.rds-share-snapshot
2022/12/06 12:46:59 Applying Terraform to spin up technique prerequisites
2022/12/06 12:47:03 unable to run terraform apply on prerequisite: unable to apply Terraform: exit status 1

Error: Error creating DB Instance: InvalidSubnet: No default subnet detected in VPC. Please contact AWS Support to recreate default Subnets.
        status code: 400, request id: ______

  with aws_db_instance.default,
  on main.tf line 31, in resource "aws_db_instance" "default":
  31: resource "aws_db_instance" "default" {
```

Behavior after (including note about slow attack technique):

```
2022/12/06 13:33:57 Checking your authentication against AWS
2022/12/06 13:33:58 Note: This is a slow attack technique, it might take a long time to detonate
2022/12/06 13:33:58 Warming up aws.exfiltration.rds-share-snapshot
2022/12/06 13:33:58 Applying Terraform to spin up technique prerequisites
2022/12/06 13:41:44 RDS Snapshot exfiltration of RDS Instance terraform-______ is ready
2022/12/06 13:41:44 Sharing RDS Snapshot exfiltration with an external AWS account