### PR TITLE
Fix broken GCP technique

### DIFF
--- a/v2/internal/attacktechniques/gcp/privilege-escalation/impersonate-service-accounts/main.go
+++ b/v2/internal/attacktechniques/gcp/privilege-escalation/impersonate-service-accounts/main.go
@@ -47,7 +47,21 @@ References:
 - https://cloud.google.com/iam/docs/impersonating-service-accounts
 `,
 		Detection: `
-Using GCP Admin Activity audit logs event <code>GenerateAccessToken</code>.
+Using GCP Admin Activity audit logs event <code>GenerateAccessToken</code>. 
+To get this event, you need to [enable IAM audit logs for data access activity](https://cloud.google.com/iam/docs/audit-logging#enabling_audit_logging).
+More specifically, you need to enable <code>DATA_READ</code> for your GCP project, e.g. using Terraform:
+
+` + codeBlock + `hcl
+data "google_client_config" "current" {}
+
+resource "google_project_iam_audit_config" "audit" {
+  project = data.google_client_config.current.project
+  service = "allServices"
+  audit_log_config {
+    log_type = "DATA_READ"
+  }
+}
+` + codeBlock + `
 
 Sample successful event (shortened for clarity):
 
@@ -93,9 +107,9 @@ Sample successful event (shortened for clarity):
 When impersonation fails, the generated event **does not contain** the identity of the caller, as explained in the
 [GCP documentation](https://cloud.google.com/logging/docs/audit#user-id):
 
-> For privacy reasons, the caller's principal email address is redacted from an audit log if the operation is 
-> read-only and fails with a "permission denied" error. The only exception is when the caller is a service 
-> account in the Google Cloud organization associated with the resource; in this case, the email address isn't redacted.
+> Audit logging doesn't redact the caller's principal email address for any access that succeeds or for any write operation.
+> For read-only operations that fail with a "permission denied" error, Audit Logging might redact the caller's principal 
+> email address unless the caller is a service account.
 
 Sample **unsuccessful** event (shortened for clarity):
 

--- a/v2/internal/attacktechniques/gcp/privilege-escalation/impersonate-service-accounts/main.go
+++ b/v2/internal/attacktechniques/gcp/privilege-escalation/impersonate-service-accounts/main.go
@@ -207,7 +207,8 @@ func impersonateServiceAccount(iamCredentialsClient *iamcredentials.Service, ser
 
 // Checks if an error returned by `GenerateAccessToken` corresponds to an (expected) access denied error
 func isPermissionDeniedError(err error) bool {
-	return strings.Contains(err.Error(), "403: The caller does not have permission")
+	errorMessage := strings.ToLower(err.Error())
+	return strings.Contains(errorMessage, "403") && strings.Contains(errorMessage, "denied")
 }
 
 // For some reason, the access tokens are padded with dots, which isn't pretty to display

--- a/v2/internal/attacktechniques/gcp/privilege-escalation/impersonate-service-accounts/main.go
+++ b/v2/internal/attacktechniques/gcp/privilege-escalation/impersonate-service-accounts/main.go
@@ -184,7 +184,7 @@ func detonate(params map[string]string, providers stratus.CloudProviders) error 
 
 	if !success {
 		log.Println("Note: None of the impersonation attempts succeeded. " +
-			"It might take a few seconds for GCP to take the permissions into account; try again in a few seconds!")
+			"It might take a few minutes for GCP to take the permissions into account; try again shortly!")
 	}
 	return nil
 }


### PR DESCRIPTION
- Fix GCP attack technique failing to impersonate service accounts (closes #299)
- Adapt GCP attack technique error message
- Update GCP docs quote

### What does this PR do?

<!--
* New attack technique
* Bug fix
* Enhancement
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Checklist

<!--
For new attack techniques
-->
- [ ] The attack technique emulates a single attack step, not a full attack chain
- [ ] We have factual evidence & references that the attack technique was used by real malware, pentesters, or attackers
- [ ] The attack technique makes no assumption about the state of the environment prior to warming it up