### PR TITLE
Goreleaser/Homebrew: Install shell completions

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -26,7 +26,7 @@ brews:
     bin.install "stratus"
 
     # Install shell completions
-    generate_completions_from_executable(bin/"stratus", "completions", shells: [:bash, :fish, :zsh])
+    generate_completions_from_executable(bin/"stratus", "completion", shells: [:bash, :fish, :zsh])
 archives:
   - replacements:
       darwin: Darwin

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -26,7 +26,7 @@ brews:
     bin.install "stratus"
 
     # Install shell completions
-    generate_completions_from_executable(bin/"stratus", "completion", shells: [:bash, :fish, :zsh])
+    generate_completions_from_executable(bin/"stratus", "completion", shells: [:bash, :fish, :zsh], base_name: "stratus")
 archives:
   - replacements:
       darwin: Darwin

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -22,6 +22,11 @@ brews:
   url_template: "https://github.com/DataDog/stratus-red-team/releases/download/{{ .Tag }}/{{ .ArtifactName }}"
   license: Apache-2.0
   homepage: "https://stratus-red-team.cloud"
+  install: |
+    bin.install "stratus"
+
+    # Install shell completions
+    generate_completions_from_executable(bin/"stratus", "completions", shells: [:bash, :fish, :zsh])
 archives:
   - replacements:
       darwin: Darwin

--- a/docs/user-guide/commands/autocompletion.md
+++ b/docs/user-guide/commands/autocompletion.md
@@ -6,7 +6,19 @@ title: CLI autocompletion
 
 Stratus Red Team uses [cobra](https://github.com/spf13/cobra)'s built-in support to add autocompletions when working with the CLI.
 
+## Sample usage
+
+```bash
+stratus deton[tab]
+stratus detonate aws[tab][tab]
+```
 ## Setup
+
+### Through Homebrew
+
+When installing Stratus Red Team through Homebrew, shell completions are automatically installed for bash, zsh and fish shells.
+
+### Manually
 
 === "bash"
 
@@ -47,9 +59,4 @@ Stratus Red Team uses [cobra](https://github.com/spf13/cobra)'s built-in support
     stratus completion fish > ~/.config/fish/completions/stratus.fish
     ```
 
-## Sample usage
 
-```bash
-stratus deton[tab]
-stratus detonate aws[tab][tab]
-```


### PR DESCRIPTION
### What does this PR do?

* Enhancement! This will automatically install shell completions, generated by the installed `stratus` binary in their proper locations for users of the Homebrew tap. This method from Homebrew supports bash, fish, and zsh. _Sorry PowerShellers._

### Motivation

I just wanted to have the formula install completions automatically in the most correct manner possible.

### Other

* [Homebrew formula documentation](https://rubydoc.brew.sh/Formula#generate_completions_from_executable-instance_method) for `generate_completions_from_executable` method
* [Goreleaser brew documentation](https://goreleaser.com/customization/homebrew/) for custom install definition

I've never actually used Goreleaser before, but I think I got this right! I tested as much as I could locally, but I have *not* actually tested the creation of the `Formula/stratus-red-team.rb.rb` file as that requires an actual deploy to a Git repo, and I didn't do so during my own testing.