### PR TITLE
Implement retry mechanism when creating and assuming an IAM role ^

### DIFF
--- a/v2/go.mod
+++ b/v2/go.mod
@@ -22,6 +22,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/ssm v1.31.0
 	github.com/aws/aws-sdk-go-v2/service/sts v1.16.19
 	github.com/aws/smithy-go v1.13.3
+	github.com/cenkalti/backoff/v4 v4.2.1
 	github.com/fatih/color v1.13.0
 	github.com/golang-jwt/jwt v3.2.2+incompatible
 	github.com/google/uuid v1.3.0

--- a/v2/go.sum
+++ b/v2/go.sum
@@ -90,6 +90,8 @@ github.com/aws/aws-sdk-go-v2/service/sts v1.16.19 h1:9pPi0PsFNAGILFfPCk8Y0iyEBGc
 github.com/aws/aws-sdk-go-v2/service/sts v1.16.19/go.mod h1:h4J3oPZQbxLhzGnk+j9dfYHi5qIOVJ5kczZd658/ydM=
 github.com/aws/smithy-go v1.13.3 h1:l7LYxGuzK6/K+NzJ2mC+VvLUbae0sL3bXU//04MkmnA=
 github.com/aws/smithy-go v1.13.3/go.mod h1:Tg+OJXh4MB2R/uN61Ko2f6hTZwB/ZYGOtib8J3gBHzA=
+github.com/cenkalti/backoff/v4 v4.2.1 h1:y4OZtCnogmCPw98Zjyt5a6+QwPLGkiQsYW5oUqylYbM=
+github.com/cenkalti/backoff/v4 v4.2.1/go.mod h1:Y3VNntkOUPxTVeUxJ/G5vcM//AlwfmyYozVcomhLiZE=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=

--- a/v2/internal/utils/aws_utils.go
+++ b/v2/internal/utils/aws_utils.go
@@ -46,6 +46,11 @@ func WaitForAndAssumeAWSRole(awsConnection *aws.Config, roleArn string) error {
 	backoffStrategy.MaxElapsedTime = 1 * time.Minute  // stop trying after 1 minute
 	err := backoff.Retry(func() error {
 		_, err := assumeRoleProvider.Retrieve(context.Background())
+		if err == nil {
+			log.Println("[DEBUG] Successfully assumed role!")
+		} else {
+			log.Println("[DEBUG] Unable to assume role, error: ", err.Error())
+		}
 		return err
 	}, backoffStrategy)
 	if err != nil {


### PR DESCRIPTION
Several attack techniques start by creating an IAM role and assuming it. Unfortunately, AWS IAM is _eventually consistent_, meaning that a role may not be assumable right away. It can take anywhere from a few seconds (usually) to a minute (rare) for changes to propagate.

This was causing #353.

This PR implements a retry mechanism with exponential backoff. It will try to assume the role right away, then wait up to 10 seconds until it succeeds (1 minute most)