### PR TITLE
Fix aws.persistence.lambda-backdoor-function failing due to unsupported NodeJS Lambda version (closes #359)

### DIFF
--- a/v2/internal/attacktechniques/aws/persistence/lambda-backdoor-function/main.tf
+++ b/v2/internal/attacktechniques/aws/persistence/lambda-backdoor-function/main.tf
@@ -64,7 +64,7 @@ resource "aws_lambda_function" "lambda" {
   s3_key        = aws_s3_bucket_object.code.key
   role          = aws_iam_role.lambda.arn
   handler       = "index.test"
-  runtime       = "nodejs12.x"
+  runtime       = "nodejs18.x"
 }
 
 output "lambda_function_name" {


### PR DESCRIPTION
closes #359 

Thanks @dayspringjohnson for the report

![image](https://github.com/DataDog/stratus-red-team/assets/136675/4783aa10-77f5-44d8-b36c-05737ad38727)
