### PR TITLE
Remove `skip_metadata_api_check = true` from TF AWS Provider

### DIFF
--- a/examples/custom/prerequisites.tf
+++ b/examples/custom/prerequisites.tf
@@ -10,8 +10,7 @@ provider "aws" {
   skip_region_validation      = true
   skip_credentials_validation = true
   skip_get_ec2_platforms      = true
-  skip_metadata_api_check     = true
-  default_tags {
+    default_tags {
     tags = {
       StratusRedTeam = true
     }

--- a/examples/custom/prerequisites.tf
+++ b/examples/custom/prerequisites.tf
@@ -10,7 +10,7 @@ provider "aws" {
   skip_region_validation      = true
   skip_credentials_validation = true
   skip_get_ec2_platforms      = true
-    default_tags {
+  default_tags {
     tags = {
       StratusRedTeam = true
     }

--- a/v2/internal/attacktechniques/aws/credential-access/ec2-get-password-data/main.tf
+++ b/v2/internal/attacktechniques/aws/credential-access/ec2-get-password-data/main.tf
@@ -10,8 +10,7 @@ provider "aws" {
   skip_region_validation      = true
   skip_credentials_validation = true
   skip_get_ec2_platforms      = true
-  skip_metadata_api_check     = true
-  default_tags {
+    default_tags {
     tags = {
       StratusRedTeam = true
     }

--- a/v2/internal/attacktechniques/aws/credential-access/ec2-get-password-data/main.tf
+++ b/v2/internal/attacktechniques/aws/credential-access/ec2-get-password-data/main.tf
@@ -10,7 +10,7 @@ provider "aws" {
   skip_region_validation      = true
   skip_credentials_validation = true
   skip_get_ec2_platforms      = true
-    default_tags {
+  default_tags {
     tags = {
       StratusRedTeam = true
     }

--- a/v2/internal/attacktechniques/aws/credential-access/ec2-steal-instance-credentials/main.tf
+++ b/v2/internal/attacktechniques/aws/credential-access/ec2-steal-instance-credentials/main.tf
@@ -11,7 +11,7 @@ provider "aws" {
   skip_region_validation      = true
   skip_credentials_validation = true
   skip_get_ec2_platforms      = true
-    default_tags {
+  default_tags {
     tags = {
       StratusRedTeam = true
     }

--- a/v2/internal/attacktechniques/aws/credential-access/ec2-steal-instance-credentials/main.tf
+++ b/v2/internal/attacktechniques/aws/credential-access/ec2-steal-instance-credentials/main.tf
@@ -11,8 +11,7 @@ provider "aws" {
   skip_region_validation      = true
   skip_credentials_validation = true
   skip_get_ec2_platforms      = true
-  skip_metadata_api_check     = true
-  default_tags {
+    default_tags {
     tags = {
       StratusRedTeam = true
     }

--- a/v2/internal/attacktechniques/aws/credential-access/secretsmanager-retrieve-secrets/main.tf
+++ b/v2/internal/attacktechniques/aws/credential-access/secretsmanager-retrieve-secrets/main.tf
@@ -10,8 +10,7 @@ provider "aws" {
   skip_region_validation      = true
   skip_credentials_validation = true
   skip_get_ec2_platforms      = true
-  skip_metadata_api_check     = true
-  default_tags {
+    default_tags {
     tags = {
       StratusRedTeam = true
     }

--- a/v2/internal/attacktechniques/aws/credential-access/secretsmanager-retrieve-secrets/main.tf
+++ b/v2/internal/attacktechniques/aws/credential-access/secretsmanager-retrieve-secrets/main.tf
@@ -10,7 +10,7 @@ provider "aws" {
   skip_region_validation      = true
   skip_credentials_validation = true
   skip_get_ec2_platforms      = true
-    default_tags {
+  default_tags {
     tags = {
       StratusRedTeam = true
     }

--- a/v2/internal/attacktechniques/aws/credential-access/ssm-retrieve-securestring-parameters/main.tf
+++ b/v2/internal/attacktechniques/aws/credential-access/ssm-retrieve-securestring-parameters/main.tf
@@ -10,8 +10,7 @@ provider "aws" {
   skip_region_validation      = true
   skip_credentials_validation = true
   skip_get_ec2_platforms      = true
-  skip_metadata_api_check     = true
-  default_tags {
+    default_tags {
     tags = {
       StratusRedTeam = true
     }

--- a/v2/internal/attacktechniques/aws/credential-access/ssm-retrieve-securestring-parameters/main.tf
+++ b/v2/internal/attacktechniques/aws/credential-access/ssm-retrieve-securestring-parameters/main.tf
@@ -10,7 +10,7 @@ provider "aws" {
   skip_region_validation      = true
   skip_credentials_validation = true
   skip_get_ec2_platforms      = true
-    default_tags {
+  default_tags {
     tags = {
       StratusRedTeam = true
     }

--- a/v2/internal/attacktechniques/aws/defense-evasion/cloudtrail-delete/main.tf
+++ b/v2/internal/attacktechniques/aws/defense-evasion/cloudtrail-delete/main.tf
@@ -10,8 +10,7 @@ provider "aws" {
   skip_region_validation      = true
   skip_credentials_validation = true
   skip_get_ec2_platforms      = true
-  skip_metadata_api_check     = true
-  default_tags {
+    default_tags {
     tags = {
       StratusRedTeam = true
     }

--- a/v2/internal/attacktechniques/aws/defense-evasion/cloudtrail-delete/main.tf
+++ b/v2/internal/attacktechniques/aws/defense-evasion/cloudtrail-delete/main.tf
@@ -10,7 +10,7 @@ provider "aws" {
   skip_region_validation      = true
   skip_credentials_validation = true
   skip_get_ec2_platforms      = true
-    default_tags {
+  default_tags {
     tags = {
       StratusRedTeam = true
     }

--- a/v2/internal/attacktechniques/aws/defense-evasion/cloudtrail-event-selectors/main.tf
+++ b/v2/internal/attacktechniques/aws/defense-evasion/cloudtrail-event-selectors/main.tf
@@ -10,8 +10,7 @@ provider "aws" {
   skip_region_validation      = true
   skip_credentials_validation = true
   skip_get_ec2_platforms      = true
-  skip_metadata_api_check     = true
-  default_tags {
+    default_tags {
     tags = {
       StratusRedTeam = true
     }

--- a/v2/internal/attacktechniques/aws/defense-evasion/cloudtrail-event-selectors/main.tf
+++ b/v2/internal/attacktechniques/aws/defense-evasion/cloudtrail-event-selectors/main.tf
@@ -10,7 +10,7 @@ provider "aws" {
   skip_region_validation      = true
   skip_credentials_validation = true
   skip_get_ec2_platforms      = true
-    default_tags {
+  default_tags {
     tags = {
       StratusRedTeam = true
     }

--- a/v2/internal/attacktechniques/aws/defense-evasion/cloudtrail-lifecycle-rule/main.tf
+++ b/v2/internal/attacktechniques/aws/defense-evasion/cloudtrail-lifecycle-rule/main.tf
@@ -10,8 +10,7 @@ provider "aws" {
   skip_region_validation      = true
   skip_credentials_validation = true
   skip_get_ec2_platforms      = true
-  skip_metadata_api_check     = true
-  default_tags {
+    default_tags {
     tags = {
       StratusRedTeam = true
     }

--- a/v2/internal/attacktechniques/aws/defense-evasion/cloudtrail-lifecycle-rule/main.tf
+++ b/v2/internal/attacktechniques/aws/defense-evasion/cloudtrail-lifecycle-rule/main.tf
@@ -10,7 +10,7 @@ provider "aws" {
   skip_region_validation      = true
   skip_credentials_validation = true
   skip_get_ec2_platforms      = true
-    default_tags {
+  default_tags {
     tags = {
       StratusRedTeam = true
     }

--- a/v2/internal/attacktechniques/aws/defense-evasion/cloudtrail-stop/main.tf
+++ b/v2/internal/attacktechniques/aws/defense-evasion/cloudtrail-stop/main.tf
@@ -10,8 +10,7 @@ provider "aws" {
   skip_region_validation      = true
   skip_credentials_validation = true
   skip_get_ec2_platforms      = true
-  skip_metadata_api_check     = true
-  default_tags {
+    default_tags {
     tags = {
       StratusRedTeam = true
     }

--- a/v2/internal/attacktechniques/aws/defense-evasion/cloudtrail-stop/main.tf
+++ b/v2/internal/attacktechniques/aws/defense-evasion/cloudtrail-stop/main.tf
@@ -10,7 +10,7 @@ provider "aws" {
   skip_region_validation      = true
   skip_credentials_validation = true
   skip_get_ec2_platforms      = true
-    default_tags {
+  default_tags {
     tags = {
       StratusRedTeam = true
     }

--- a/v2/internal/attacktechniques/aws/defense-evasion/organizations-leave/main.tf
+++ b/v2/internal/attacktechniques/aws/defense-evasion/organizations-leave/main.tf
@@ -10,8 +10,7 @@ provider "aws" {
   skip_region_validation      = true
   skip_credentials_validation = true
   skip_get_ec2_platforms      = true
-  skip_metadata_api_check     = true
-  default_tags {
+    default_tags {
     tags = {
       StratusRedTeam = true
     }

--- a/v2/internal/attacktechniques/aws/defense-evasion/organizations-leave/main.tf
+++ b/v2/internal/attacktechniques/aws/defense-evasion/organizations-leave/main.tf
@@ -10,7 +10,7 @@ provider "aws" {
   skip_region_validation      = true
   skip_credentials_validation = true
   skip_get_ec2_platforms      = true
-    default_tags {
+  default_tags {
     tags = {
       StratusRedTeam = true
     }

--- a/v2/internal/attacktechniques/aws/defense-evasion/vpc-remove-flow-logs/main.tf
+++ b/v2/internal/attacktechniques/aws/defense-evasion/vpc-remove-flow-logs/main.tf
@@ -10,8 +10,7 @@ provider "aws" {
   skip_region_validation      = true
   skip_credentials_validation = true
   skip_get_ec2_platforms      = true
-  skip_metadata_api_check     = true
-  default_tags {
+    default_tags {
     tags = {
       StratusRedTeam = true
     }

--- a/v2/internal/attacktechniques/aws/defense-evasion/vpc-remove-flow-logs/main.tf
+++ b/v2/internal/attacktechniques/aws/defense-evasion/vpc-remove-flow-logs/main.tf
@@ -10,7 +10,7 @@ provider "aws" {
   skip_region_validation      = true
   skip_credentials_validation = true
   skip_get_ec2_platforms      = true
-    default_tags {
+  default_tags {
     tags = {
       StratusRedTeam = true
     }

--- a/v2/internal/attacktechniques/aws/discovery/ec2-enumerate-from-instance/main.tf
+++ b/v2/internal/attacktechniques/aws/discovery/ec2-enumerate-from-instance/main.tf
@@ -11,7 +11,7 @@ provider "aws" {
   skip_region_validation      = true
   skip_credentials_validation = true
   skip_get_ec2_platforms      = true
-    default_tags {
+  default_tags {
     tags = {
       StratusRedTeam = true
     }

--- a/v2/internal/attacktechniques/aws/discovery/ec2-enumerate-from-instance/main.tf
+++ b/v2/internal/attacktechniques/aws/discovery/ec2-enumerate-from-instance/main.tf
@@ -11,8 +11,7 @@ provider "aws" {
   skip_region_validation      = true
   skip_credentials_validation = true
   skip_get_ec2_platforms      = true
-  skip_metadata_api_check     = true
-  default_tags {
+    default_tags {
     tags = {
       StratusRedTeam = true
     }

--- a/v2/internal/attacktechniques/aws/discovery/ec2-get-user-data/main.tf
+++ b/v2/internal/attacktechniques/aws/discovery/ec2-get-user-data/main.tf
@@ -10,8 +10,7 @@ provider "aws" {
   skip_region_validation      = true
   skip_credentials_validation = true
   skip_get_ec2_platforms      = true
-  skip_metadata_api_check     = true
-  default_tags {
+    default_tags {
     tags = {
       StratusRedTeam = true
     }

--- a/v2/internal/attacktechniques/aws/discovery/ec2-get-user-data/main.tf
+++ b/v2/internal/attacktechniques/aws/discovery/ec2-get-user-data/main.tf
@@ -10,7 +10,7 @@ provider "aws" {
   skip_region_validation      = true
   skip_credentials_validation = true
   skip_get_ec2_platforms      = true
-    default_tags {
+  default_tags {
     tags = {
       StratusRedTeam = true
     }

--- a/v2/internal/attacktechniques/aws/execution/ec2-launch-unusual-instances/main.tf
+++ b/v2/internal/attacktechniques/aws/execution/ec2-launch-unusual-instances/main.tf
@@ -10,8 +10,7 @@ provider "aws" {
   skip_region_validation      = true
   skip_credentials_validation = true
   skip_get_ec2_platforms      = true
-  skip_metadata_api_check     = true
-  default_tags {
+    default_tags {
     tags = {
       StratusRedTeam = true
     }

--- a/v2/internal/attacktechniques/aws/execution/ec2-launch-unusual-instances/main.tf
+++ b/v2/internal/attacktechniques/aws/execution/ec2-launch-unusual-instances/main.tf
@@ -10,7 +10,7 @@ provider "aws" {
   skip_region_validation      = true
   skip_credentials_validation = true
   skip_get_ec2_platforms      = true
-    default_tags {
+  default_tags {
     tags = {
       StratusRedTeam = true
     }

--- a/v2/internal/attacktechniques/aws/execution/ec2-user-data/main.tf
+++ b/v2/internal/attacktechniques/aws/execution/ec2-user-data/main.tf
@@ -11,7 +11,7 @@ provider "aws" {
   skip_region_validation      = true
   skip_credentials_validation = true
   skip_get_ec2_platforms      = true
-    default_tags {
+  default_tags {
     tags = {
       StratusRedTeam = true
     }

--- a/v2/internal/attacktechniques/aws/execution/ec2-user-data/main.tf
+++ b/v2/internal/attacktechniques/aws/execution/ec2-user-data/main.tf
@@ -11,8 +11,7 @@ provider "aws" {
   skip_region_validation      = true
   skip_credentials_validation = true
   skip_get_ec2_platforms      = true
-  skip_metadata_api_check     = true
-  default_tags {
+    default_tags {
     tags = {
       StratusRedTeam = true
     }

--- a/v2/internal/attacktechniques/aws/exfiltration/ec2-security-group-open-port-22-ingress/main.tf
+++ b/v2/internal/attacktechniques/aws/exfiltration/ec2-security-group-open-port-22-ingress/main.tf
@@ -10,8 +10,7 @@ provider "aws" {
   skip_region_validation      = true
   skip_credentials_validation = true
   skip_get_ec2_platforms      = true
-  skip_metadata_api_check     = true
-  default_tags {
+    default_tags {
     tags = {
       StratusRedTeam = true
     }

--- a/v2/internal/attacktechniques/aws/exfiltration/ec2-security-group-open-port-22-ingress/main.tf
+++ b/v2/internal/attacktechniques/aws/exfiltration/ec2-security-group-open-port-22-ingress/main.tf
@@ -10,7 +10,7 @@ provider "aws" {
   skip_region_validation      = true
   skip_credentials_validation = true
   skip_get_ec2_platforms      = true
-    default_tags {
+  default_tags {
     tags = {
       StratusRedTeam = true
     }

--- a/v2/internal/attacktechniques/aws/exfiltration/ec2-share-ami/main.tf
+++ b/v2/internal/attacktechniques/aws/exfiltration/ec2-share-ami/main.tf
@@ -10,8 +10,7 @@ provider "aws" {
   skip_region_validation      = true
   skip_credentials_validation = true
   skip_get_ec2_platforms      = true
-  skip_metadata_api_check     = true
-  default_tags {
+    default_tags {
     tags = {
       StratusRedTeam = true
     }

--- a/v2/internal/attacktechniques/aws/exfiltration/ec2-share-ami/main.tf
+++ b/v2/internal/attacktechniques/aws/exfiltration/ec2-share-ami/main.tf
@@ -10,7 +10,7 @@ provider "aws" {
   skip_region_validation      = true
   skip_credentials_validation = true
   skip_get_ec2_platforms      = true
-    default_tags {
+  default_tags {
     tags = {
       StratusRedTeam = true
     }

--- a/v2/internal/attacktechniques/aws/exfiltration/ec2-share-ebs-snapshot/main.tf
+++ b/v2/internal/attacktechniques/aws/exfiltration/ec2-share-ebs-snapshot/main.tf
@@ -10,8 +10,7 @@ provider "aws" {
   skip_region_validation      = true
   skip_credentials_validation = true
   skip_get_ec2_platforms      = true
-  skip_metadata_api_check     = true
-  default_tags {
+    default_tags {
     tags = {
       StratusRedTeam = true
     }

--- a/v2/internal/attacktechniques/aws/exfiltration/ec2-share-ebs-snapshot/main.tf
+++ b/v2/internal/attacktechniques/aws/exfiltration/ec2-share-ebs-snapshot/main.tf
@@ -10,7 +10,7 @@ provider "aws" {
   skip_region_validation      = true
   skip_credentials_validation = true
   skip_get_ec2_platforms      = true
-    default_tags {
+  default_tags {
     tags = {
       StratusRedTeam = true
     }

--- a/v2/internal/attacktechniques/aws/exfiltration/rds-share-snapshot/main.tf
+++ b/v2/internal/attacktechniques/aws/exfiltration/rds-share-snapshot/main.tf
@@ -10,8 +10,7 @@ provider "aws" {
   skip_region_validation      = true
   skip_credentials_validation = true
   skip_get_ec2_platforms      = true
-  skip_metadata_api_check     = true
-  default_tags {
+    default_tags {
     tags = {
       StratusRedTeam = true
     }

--- a/v2/internal/attacktechniques/aws/exfiltration/rds-share-snapshot/main.tf
+++ b/v2/internal/attacktechniques/aws/exfiltration/rds-share-snapshot/main.tf
@@ -10,7 +10,7 @@ provider "aws" {
   skip_region_validation      = true
   skip_credentials_validation = true
   skip_get_ec2_platforms      = true
-    default_tags {
+  default_tags {
     tags = {
       StratusRedTeam = true
     }

--- a/v2/internal/attacktechniques/aws/exfiltration/s3-backdoor-bucket-policy/main.tf
+++ b/v2/internal/attacktechniques/aws/exfiltration/s3-backdoor-bucket-policy/main.tf
@@ -10,8 +10,7 @@ provider "aws" {
   skip_region_validation      = true
   skip_credentials_validation = true
   skip_get_ec2_platforms      = true
-  skip_metadata_api_check     = true
-  default_tags {
+    default_tags {
     tags = {
       StratusRedTeam = true
     }

--- a/v2/internal/attacktechniques/aws/exfiltration/s3-backdoor-bucket-policy/main.tf
+++ b/v2/internal/attacktechniques/aws/exfiltration/s3-backdoor-bucket-policy/main.tf
@@ -10,7 +10,7 @@ provider "aws" {
   skip_region_validation      = true
   skip_credentials_validation = true
   skip_get_ec2_platforms      = true
-    default_tags {
+  default_tags {
     tags = {
       StratusRedTeam = true
     }

--- a/v2/internal/attacktechniques/aws/initial-access/console-login-without-mfa/main.tf
+++ b/v2/internal/attacktechniques/aws/initial-access/console-login-without-mfa/main.tf
@@ -10,7 +10,7 @@ provider "aws" {
   skip_region_validation      = true
   skip_credentials_validation = true
   skip_get_ec2_platforms      = true
-  }
+}
 
 data "aws_caller_identity" "current" {}
 

--- a/v2/internal/attacktechniques/aws/initial-access/console-login-without-mfa/main.tf
+++ b/v2/internal/attacktechniques/aws/initial-access/console-login-without-mfa/main.tf
@@ -10,8 +10,7 @@ provider "aws" {
   skip_region_validation      = true
   skip_credentials_validation = true
   skip_get_ec2_platforms      = true
-  skip_metadata_api_check     = true
-}
+  }
 
 data "aws_caller_identity" "current" {}
 

--- a/v2/internal/attacktechniques/aws/persistence/iam-backdoor-role/main.tf
+++ b/v2/internal/attacktechniques/aws/persistence/iam-backdoor-role/main.tf
@@ -10,7 +10,7 @@ provider "aws" {
   skip_region_validation      = true
   skip_credentials_validation = true
   skip_get_ec2_platforms      = true
-  }
+}
 
 locals {
   resource_prefix = "stratus-red-team-backdoor-r"

--- a/v2/internal/attacktechniques/aws/persistence/iam-backdoor-role/main.tf
+++ b/v2/internal/attacktechniques/aws/persistence/iam-backdoor-role/main.tf
@@ -10,8 +10,7 @@ provider "aws" {
   skip_region_validation      = true
   skip_credentials_validation = true
   skip_get_ec2_platforms      = true
-  skip_metadata_api_check     = true
-}
+  }
 
 locals {
   resource_prefix = "stratus-red-team-backdoor-r"

--- a/v2/internal/attacktechniques/aws/persistence/iam-backdoor-user/main.tf
+++ b/v2/internal/attacktechniques/aws/persistence/iam-backdoor-user/main.tf
@@ -10,8 +10,7 @@ provider "aws" {
   skip_region_validation      = true
   skip_credentials_validation = true
   skip_get_ec2_platforms      = true
-  skip_metadata_api_check     = true
-  default_tags {
+    default_tags {
     tags = {
       StratusRedTeam = true
     }

--- a/v2/internal/attacktechniques/aws/persistence/iam-backdoor-user/main.tf
+++ b/v2/internal/attacktechniques/aws/persistence/iam-backdoor-user/main.tf
@@ -10,7 +10,7 @@ provider "aws" {
   skip_region_validation      = true
   skip_credentials_validation = true
   skip_get_ec2_platforms      = true
-    default_tags {
+  default_tags {
     tags = {
       StratusRedTeam = true
     }

--- a/v2/internal/attacktechniques/aws/persistence/iam-create-user-login-profile/main.tf
+++ b/v2/internal/attacktechniques/aws/persistence/iam-create-user-login-profile/main.tf
@@ -10,8 +10,7 @@ provider "aws" {
   skip_region_validation      = true
   skip_credentials_validation = true
   skip_get_ec2_platforms      = true
-  skip_metadata_api_check     = true
-  default_tags {
+    default_tags {
     tags = {
       StratusRedTeam = true
     }

--- a/v2/internal/attacktechniques/aws/persistence/iam-create-user-login-profile/main.tf
+++ b/v2/internal/attacktechniques/aws/persistence/iam-create-user-login-profile/main.tf
@@ -10,7 +10,7 @@ provider "aws" {
   skip_region_validation      = true
   skip_credentials_validation = true
   skip_get_ec2_platforms      = true
-    default_tags {
+  default_tags {
     tags = {
       StratusRedTeam = true
     }

--- a/v2/internal/attacktechniques/aws/persistence/lambda-backdoor-function/main.tf
+++ b/v2/internal/attacktechniques/aws/persistence/lambda-backdoor-function/main.tf
@@ -10,8 +10,7 @@ provider "aws" {
   skip_region_validation      = true
   skip_credentials_validation = true
   skip_get_ec2_platforms      = true
-  skip_metadata_api_check     = true
-  default_tags {
+    default_tags {
     tags = {
       StratusRedTeam = true
     }

--- a/v2/internal/attacktechniques/aws/persistence/lambda-backdoor-function/main.tf
+++ b/v2/internal/attacktechniques/aws/persistence/lambda-backdoor-function/main.tf
@@ -10,7 +10,7 @@ provider "aws" {
   skip_region_validation      = true
   skip_credentials_validation = true
   skip_get_ec2_platforms      = true
-    default_tags {
+  default_tags {
     tags = {
       StratusRedTeam = true
     }

--- a/v2/internal/attacktechniques/aws/persistence/lambda-overwrite-code/main.tf
+++ b/v2/internal/attacktechniques/aws/persistence/lambda-overwrite-code/main.tf
@@ -10,8 +10,7 @@ provider "aws" {
   skip_region_validation      = true
   skip_credentials_validation = true
   skip_get_ec2_platforms      = true
-  skip_metadata_api_check     = true
-  default_tags {
+    default_tags {
     tags = {
       StratusRedTeam = true
     }

--- a/v2/internal/attacktechniques/aws/persistence/lambda-overwrite-code/main.tf
+++ b/v2/internal/attacktechniques/aws/persistence/lambda-overwrite-code/main.tf
@@ -10,7 +10,7 @@ provider "aws" {
   skip_region_validation      = true
   skip_credentials_validation = true
   skip_get_ec2_platforms      = true
-    default_tags {
+  default_tags {
     tags = {
       StratusRedTeam = true
     }

--- a/v2/internal/attacktechniques/aws/persistence/rolesanywhere-create-trust-anchor/main.tf
+++ b/v2/internal/attacktechniques/aws/persistence/rolesanywhere-create-trust-anchor/main.tf
@@ -10,8 +10,7 @@ provider "aws" {
   skip_region_validation      = true
   skip_credentials_validation = true
   skip_get_ec2_platforms      = true
-  skip_metadata_api_check     = true
-  default_tags {
+    default_tags {
     tags = {
       StratusRedTeam = true
     }

--- a/v2/internal/attacktechniques/aws/persistence/rolesanywhere-create-trust-anchor/main.tf
+++ b/v2/internal/attacktechniques/aws/persistence/rolesanywhere-create-trust-anchor/main.tf
@@ -10,7 +10,7 @@ provider "aws" {
   skip_region_validation      = true
   skip_credentials_validation = true
   skip_get_ec2_platforms      = true
-    default_tags {
+  default_tags {
     tags = {
       StratusRedTeam = true
     }


### PR DESCRIPTION
closes https://github.com/DataDog/stratus-red-team/issues/367.

TL;DR: AWS Providers initialised with `skip_metadata_api_check = true` prevent Stratus techniques executing within AWS contexts from discovering instance profile credentials. This change will allow the terraform provider to use the instance-profile assigned to the EC2 within which Stratus is running as it won't skip checking the Instance Metadata for those credentials. 