### PR TITLE
Add STRATUS_RED_TEAM_ATTACKER_EMAIL env to gcp.exfiltration.share-compute-disk

### DIFF
--- a/v2/internal/attacktechniques/gcp/persistence/backdoor-service-account-policy/main.go
+++ b/v2/internal/attacktechniques/gcp/persistence/backdoor-service-account-policy/main.go
@@ -6,9 +6,8 @@ import (
 	"errors"
 	"fmt"
 	"log"
-	"os"
-	"strings"
 
+	gcp_utils "github.com/datadog/stratus-red-team/v2/internal/utils/gcp"
 	"github.com/datadog/stratus-red-team/v2/pkg/stratus"
 	"github.com/datadog/stratus-red-team/v2/pkg/stratus/mitreattack"
 	iam "google.golang.org/api/iam/v1"
@@ -40,12 +39,12 @@ it's a resource-based policy that grants permissions to other identities to impe
 
 !!! info
 
-	Since the target e-mail must exist for this attack simulation to work, Stratus Red Team grants the role to ` + DefaultFictitiousAttackerEmail + ` by default.
+	Since the target e-mail must exist for this attack simulation to work, Stratus Red Team grants the role to ` + gcp_utils.DefaultFictitiousAttackerEmail + ` by default.
 	This is a real Google account, owned by Stratus Red Team maintainers and that is not used for any other purpose than this attack simulation. However, you can override
-	this behavior by setting the environment variable <code>` + AttackerEmailEnvVarKey + `</code>, for instance:
+	this behavior by setting the environment variable <code>` + gcp_utils.AttackerEmailEnvVarKey + `</code>, for instance:
 
 	` + codeBlock + `bash
-	export ` + AttackerEmailEnvVarKey + `="your-own-gmail-account@gmail.com"
+	export ` + gcp_utils.AttackerEmailEnvVarKey + `="your-own-gmail-account@gmail.com"
 	stratus detonate ` + AttackTechniqueId + `
 	` + codeBlock + `
 `,
@@ -98,7 +97,7 @@ const AttackerEmailEnvVarKey = "STRATUS_RED_TEAM_ATTACKER_EMAIL"
 const RoleToGrant = "iam.serviceAccountTokenCreator"
 
 func detonate(params map[string]string, providers stratus.CloudProviders) error {
-	attackerPrincipal := getAttackerPrincipal()
+	attackerPrincipal := gcp_utils.GetAttackerPrincipal()
 	policy := &iam.Policy{
 		Bindings: []*iam.Binding{
 			{
@@ -142,11 +141,3 @@ func setServiceAccountPolicy(providers stratus.CloudProviders, saEmail string, s
 	return nil
 }
 
-func getAttackerPrincipal() string {
-	const UserPrefix = "user:"
-	if attackerEmail := os.Getenv(AttackerEmailEnvVarKey); attackerEmail != "" {
-		return UserPrefix + strings.ToLower(attackerEmail)
-	} else {
-		return UserPrefix + DefaultFictitiousAttackerEmail
-	}
-}

--- a/v2/internal/utils/gcp/gcp_utils.go
+++ b/v2/internal/utils/gcp/gcp_utils.go
@@ -1,6 +1,8 @@
 package gcp_utils
 
 import (
+	"os"
+	"strings"
 	"context"
 	"errors"
 	"fmt"
@@ -90,4 +92,16 @@ func GCPUnassignProjectRole(gcp *providers.GCPProvider, principal string, roleTo
 
 	// no reference to the principal in the project's IAM policy, we're good to go - nothing to do
 	return nil
+}
+
+const DefaultFictitiousAttackerEmail = "stratusredteam@gmail.com"
+const AttackerEmailEnvVarKey = "STRATUS_RED_TEAM_ATTACKER_EMAIL"
+
+func GetAttackerPrincipal() string {
+	const UserPrefix = "user:"
+	if attackerEmail := os.Getenv(AttackerEmailEnvVarKey); attackerEmail != "" {
+		return UserPrefix + strings.ToLower(attackerEmail)
+	} else {
+		return UserPrefix + DefaultFictitiousAttackerEmail
+	}
 }


### PR DESCRIPTION
### What does this PR do?

This adds the `STRATUS_RED_TEAM_ATTACKER_EMAIL` env variable to change the attacker email that is used in the IAM policy for `gcp.exfiltration.share-compute-disk` 

### Motivation

This addresses #385 and allows user of the technique to use their own external user.
