### PR TITLE
v2/pkg/stratus/runner: Allow concurrent NewRunner()

### DIFF
--- a/v2/internal/state/state.go
+++ b/v2/internal/state/state.go
@@ -2,11 +2,14 @@ package state
 
 import (
 	"encoding/json"
-	"github.com/datadog/stratus-red-team/v2/internal/utils"
-	"github.com/datadog/stratus-red-team/v2/pkg/stratus"
+	"errors"
+	"io/fs"
 	"log"
 	"os"
 	"path/filepath"
+
+	"github.com/datadog/stratus-red-team/v2/internal/utils"
+	"github.com/datadog/stratus-red-team/v2/pkg/stratus"
 )
 
 const StratusStateDirectoryName = ".stratus-red-team"
@@ -76,14 +79,16 @@ func (m *FileSystemStateManager) Initialize() {
 	if !m.FileSystem.FileExists(m.RootDirectory) {
 		log.Println("Creating " + m.RootDirectory + " as it doesn't exist yet")
 		err := m.FileSystem.CreateDirectory(m.RootDirectory, 0744)
-		if err != nil {
+		// ignore "already exists" errors caused by concurrent instances
+		if err != nil && !errors.Is(err, fs.ErrExist) {
 			panic("Unable to create persistent directory: " + err.Error())
 		}
 	}
 
 	if !m.FileSystem.FileExists(m.getTechniqueStateDirectory()) {
 		err := m.FileSystem.CreateDirectory(m.getTechniqueStateDirectory(), 0744)
-		if err != nil {
+		// ignore "already exists" errors caused by concurrent instances
+		if err != nil && !errors.Is(err, fs.ErrExist) {
 			panic("Unable to create persistent directory: " + err.Error())
 		}
 	}


### PR DESCRIPTION
### What does this PR do?

The tests in github.com/datadog/threatest failed when I ran them on my machine, because they call NewRunner() from multiple goroutines at the same time. If you have never run them before, they will attempt to create the directories at the same time, causing all but one to panic(). This adds a test to reproduce this, and fixes it by ignoring the "already exists" errors.


### Motivation

I am attempting to do some internal upgrades to code that transitively depends on this and discovered the failing tests.