### PR TITLE
Bump Terraform Kubernetes provider to support recent K8s versiont that don't create service account token secrets by default

### DIFF
--- a/v2/internal/attacktechniques/k8s/credential-access/steal-serviceaccount-token/main.tf
+++ b/v2/internal/attacktechniques/k8s/credential-access/steal-serviceaccount-token/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     kubernetes = {
       source  = "hashicorp/kubernetes"
-      version = "2.7.1"
+      version = "2.13.0"
     }
   }
 }

--- a/v2/internal/attacktechniques/k8s/privilege-escalation/nodes-proxy/main.tf
+++ b/v2/internal/attacktechniques/k8s/privilege-escalation/nodes-proxy/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     kubernetes = {
       source  = "hashicorp/kubernetes"
-      version = "2.7.1"
+      version = "2.13.0"
     }
   }
 }


### PR DESCRIPTION
fixes #428
