### PR TITLE
Add sts:TagSession permission to Stratus role

### DIFF
--- a/v2/internal/attacktechniques/aws/defense-evasion/organizations-leave/main.tf
+++ b/v2/internal/attacktechniques/aws/defense-evasion/organizations-leave/main.tf
@@ -29,7 +29,7 @@ resource "aws_iam_role" "role" {
     Version = "2012-10-17"
     Statement = [
       {
-        Action = ["sts:AssumeRole", "sts:SetSourceIdentity"]
+        Action = ["sts:AssumeRole", "sts:SetSourceIdentity", "sts:TagSession"]
         Effect = "Allow"
         Sid    = ""
         Principal = {


### PR DESCRIPTION
### What does this PR do?

* Bug fix: Adds the `sts:TagSession` permission to the Trust Relationship config for the role used to detonate `aws.defense-evasion.organizations-leave`. Without this permission, Stratus returns 403 Forbidden errors from AWS due to insufficient permissions. See issue below for more details

### Motivation

Issue raised here: https://github.com/DataDog/stratus-red-team/issues/462