### PR TITLE
Update aws.defense-evasion.dns-delete-logs.md with current CloudTrail event name

### DIFF
--- a/docs/attack-techniques/AWS/aws.defense-evasion.dns-delete-logs.md
+++ b/docs/attack-techniques/AWS/aws.defense-evasion.dns-delete-logs.md
@@ -35,6 +35,6 @@ stratus detonate aws.defense-evasion.dns-delete-logs
 ## Detection
 
 
-Identify when a DNS logging configuration is deleted, through CloudTrail's <code>DeleteQueryLoggingConfig</code> event.
+Identify when a DNS logging configuration is deleted, through CloudTrail's <code>DeleteResolverQueryLogConfig</code> event.
 
 

--- a/docs/attack-techniques/AWS/aws.defense-evasion.dns-delete-logs.md
+++ b/docs/attack-techniques/AWS/aws.defense-evasion.dns-delete-logs.md
@@ -25,7 +25,7 @@ Deletes a Route53 DNS Resolver query logging configuration. Simulates an attacke
 
 <span style="font-variant: small-caps;">Detonation</span>:
 
-- Delete the DNS logging configuration using <code>route53:DeleteQueryLoggingConfig</code>.
+- Delete the DNS logging configuration using <code>route53:DeleteResolverQueryLogConfig</code>.
 
 ## Instructions
 

--- a/v2/internal/attacktechniques/aws/defense-evasion/dns-delete-logs/main.go
+++ b/v2/internal/attacktechniques/aws/defense-evasion/dns-delete-logs/main.go
@@ -29,9 +29,9 @@ Warm-up:
 
 Detonation:
 
-- Delete the DNS logging configuration using <code>route53:DeleteQueryLoggingConfig</code>.`,
+- Delete the DNS logging configuration using <code>route53:DeleteResolverQueryLogConfig</code>.`,
 		Detection: `
-Identify when a DNS logging configuration is deleted, through CloudTrail's <code>DeleteQueryLoggingConfig</code> event.
+Identify when a DNS logging configuration is deleted, through CloudTrail's <code>DeleteResolverQueryLogConfig</code> event.
 `,
 		IsIdempotent:               false, // can't delete a DNS logging configuration twice
 		PrerequisitesTerraformCode: tf,


### PR DESCRIPTION
Corrected the AWS CloudTrail Event name for detection

### What does this PR do?

- Correct the KB for aws.defense-evasion.dns-delete-logs to show the current CloudTrail event name

### Motivation

- When detonating this attack, `DeleteQueryLoggingConfig` does not show up in CloudTrail logs. Instead, the event `DeleteResolverQueryLogConfig` shows.

<img width="559" alt="image" src="https://github.com/DataDog/stratus-red-team/assets/123410020/751b7132-7c9b-4f20-a13c-900e49f14b6a">

