### PR TITLE
refactor: remove global variables for all commands

### DIFF
--- a/v2/cmd/stratus/list_cmd.go
+++ b/v2/cmd/stratus/list_cmd.go
@@ -2,19 +2,20 @@ package main
 
 import (
 	"fmt"
+	"log"
+	"strings"
+
 	"github.com/datadog/stratus-red-team/v2/pkg/stratus"
 	"github.com/datadog/stratus-red-team/v2/pkg/stratus/mitreattack"
 	"github.com/fatih/color"
 	"github.com/jedib0t/go-pretty/v6/table"
 	"github.com/spf13/cobra"
-	"log"
-	"strings"
 )
 
-var listPlatform string
-var listMitreAttackTactic string
-
 func buildListCmd() *cobra.Command {
+	var listPlatform string
+	var listMitreAttackTactic string
+
 	listCmd := &cobra.Command{
 		Use:   "list",
 		Short: "List attack techniques",
@@ -26,13 +27,16 @@ func buildListCmd() *cobra.Command {
 			doListCmd(listMitreAttackTactic, listPlatform)
 		},
 	}
+
 	listCmd.Flags().StringVarP(&listPlatform, "platform", "", "", "Filter on specific platform")
 	listCmd.Flags().StringVarP(&listMitreAttackTactic, "mitre-attack-tactic", "", "", "Filter on a specific MITRE ATT&CK tactic.")
+	
 	return listCmd
 }
 
 func doListCmd(mitreAttackTactic string, platform string) {
 	filter := stratus.AttackTechniqueFilter{}
+
 	if platform != "" {
 		platform, err := stratus.PlatformFromString(platform)
 		if err != nil {
@@ -40,6 +44,7 @@ func doListCmd(mitreAttackTactic string, platform string) {
 		}
 		filter.Platform = platform
 	}
+
 	if mitreAttackTactic != "" {
 		tactic, err := mitreattack.AttackTacticFromString(mitreAttackTactic)
 		if err != nil {
@@ -47,7 +52,9 @@ func doListCmd(mitreAttackTactic string, platform string) {
 		}
 		filter.Tactic = tactic
 	}
+
 	techniques := stratus.GetRegistry().GetAttackTechniques(&filter)
+
 	t := GetDisplayTable()
 	t.AppendHeader(table.Row{"Technique ID", "Technique name", "Platform", "MITRE ATT&CK Tactic"})
 


### PR DESCRIPTION
### What does this PR do?

This PR refactors the detonate_cmd.go file by removing the use of global variables, which improves code maintainability and readability.

### Motivation
This is my first contribution to a Datadog repository, and I'm eager to get started on security in the cloud and security in general.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Checklist

<!--
For new attack techniques
-->
- [ ] The attack technique emulates a single attack step, not a full attack chain
- [ ] We have factual evidence & references that the attack technique was used by real malware, pentesters, or attackers
- [ ] The attack technique makes no assumption about the state of the environment prior to warming it up