### PR TITLE
[Enhancement] Add blank space before instance-id in log.Println

### DIFF
--- a/v2/internal/utils/aws_utils.go
+++ b/v2/internal/utils/aws_utils.go
@@ -174,7 +174,7 @@ func UploadFile(s3Client *s3.Client, bucketName string, filename string, content
 // may be slow (60+ seconds)
 func WaitForInstancesToRegisterInSSM(ssmClient *ssm.Client, instanceIds []string) error {
 	if len(instanceIds) == 1 {
-		log.Println("Waiting for instance" + instanceIds[0] + " to show up in AWS SSM")
+		log.Println("Waiting for instance " + instanceIds[0] + " to show up in AWS SSM")
 	} else {
 		log.Println("Waiting for " + strconv.Itoa(len(instanceIds)) + " instances to show up in AWS SSM. This can take a few minutes.")
 	}


### PR DESCRIPTION
```
stratus detonate aws.credential-access.ec2-steal-instance-credentials 
```

before:
```
2024/11/19 16:59:06 Waiting for instancei-0<snipped> to show up in AWS SSM
```

after:
```
2024/11/19 16:59:06 Waiting for instance i-0<snipped> to show up in AWS SSM
```

### What does this PR do?
Just adding a blank space to make the log more readable.