### PR TITLE
Feature/autogenerate attack tactics visualization 95

### DIFF
--- a/docs/attack-techniques/mitre-attack-coverage-matrices.md
+++ b/docs/attack-techniques/mitre-attack-coverage-matrices.md
@@ -1,0 +1,88 @@
+
+# MITRE ATT&CK Coverage by Platform
+
+This provides coverage matrices of MITRE ATT&CK tactics and techniques currently covered by Stratus Red Team for different cloud platforms.
+
+<!DOCTYPE html>
+<html>
+<head>
+	<title>MITRE ATT&CK Coverage</title>
+	<style>
+		body { font-family: SFMono-Regular, Consolas, Menlo, monospace; sans-serif; margin: 20px; }
+		table { width: 100%; border-collapse: collapse; margin: 20px 0; font-size: 16px; }
+		th, td { border: 1px solid #ddd; padding: 8px; text-align: center; }
+		th { background-color: #f4f4f4; font-weight: bold; font-size: 18px; color: #000; }
+		td { font-weight: normal; color: #7e56c2; }
+		tr:hover { background-color: #f1f1f1; }
+		td:hover { background-color: #e9e9ff; color: #5a3ea8; cursor: pointer; }
+		h1 { font-weight: 300; color: #333; }
+		h2 { color: #0000008a; text-transform: capitalize; }
+	</style>
+</head>
+<body>
+<h2>GCP</h2>
+<table>
+<thead><tr><th>Persistence</th><th>Privilege Escalation</th><th>Credential Access</th><th>Exfiltration</th></tr></thead>
+<tbody>
+<tr><td>Backdoor a GCP Service Account through its IAM Policy</td><td>Create an Admin GCP Service Account</td><td>Retrieve a High Number of Secret Manager secrets</td><td>Exfiltrate Compute Disk by sharing it</td></tr>
+<tr><td>Create an Admin GCP Service Account</td><td>Create a GCP Service Account Key</td><td></td><td>Exfiltrate Compute Image by sharing it</td></tr>
+<tr><td>Create a GCP Service Account Key</td><td>Impersonate GCP Service Accounts</td><td></td><td>Exfiltrate Compute Disk by sharing a snapshot</td></tr>
+<tr><td>Invite an External User to a GCP Project</td><td></td><td></td><td></td></tr>
+</tbody>
+</table>
+<h2>kubernetes</h2>
+<table>
+<thead><tr><th>Persistence</th><th>Privilege Escalation</th><th>Credential Access</th></tr></thead>
+<tbody>
+<tr><td>Create Admin ClusterRole</td><td>Create Admin ClusterRole</td><td>Dump All Secrets</td></tr>
+<tr><td>Create Client Certificate Credential</td><td>Container breakout via hostPath volume mount</td><td>Steal Pod Service Account Token</td></tr>
+<tr><td>Create Long-Lived Token</td><td>Privilege escalation through node/proxy permissions</td><td></td></tr>
+<tr><td></td><td>Run a Privileged Pod</td><td></td></tr>
+</tbody>
+</table>
+<h2>AWS</h2>
+<table>
+<thead><tr><th>Initial Access</th><th>Execution</th><th>Persistence</th><th>Privilege Escalation</th><th>Defense Evasion</th><th>Credential Access</th><th>Discovery</th><th>Lateral Movement</th><th>Exfiltration</th><th>Impact</th></tr></thead>
+<tbody>
+<tr><td>Console Login without MFA</td><td>Launch Unusual EC2 instances</td><td>Backdoor an IAM Role</td><td>Execute Commands on EC2 Instance via User Data</td><td>Delete CloudTrail Trail</td><td>Retrieve EC2 Password Data</td><td>Execute Discovery Commands on an EC2 Instance</td><td>Usage of EC2 Serial Console to push SSH public key</td><td>Open Ingress Port 22 on a Security Group</td><td>Invoke Bedrock Model</td></tr>
+<tr><td></td><td>Execute Commands on EC2 Instance via User Data</td><td>Create an Access Key on an IAM User</td><td>Create an Access Key on an IAM User</td><td>Disable CloudTrail Logging Through Event Selectors</td><td>Steal EC2 Instance Credentials</td><td>Download EC2 Instance User Data</td><td>Usage of EC2 Instance Connect on multiple instances</td><td>Exfiltrate an AMI by Sharing It</td><td>S3 Ransomware through batch file deletion</td></tr>
+<tr><td></td><td>Usage of ssm:SendCommand on multiple instances</td><td>Create an administrative IAM User</td><td>Create an administrative IAM User</td><td>CloudTrail Logs Impairment Through S3 Lifecycle Rule</td><td>Retrieve a High Number of Secrets Manager secrets (Batch)</td><td>Enumerate SES</td><td></td><td>Exfiltrate EBS Snapshot by Sharing It</td><td>S3 Ransomware through client-side encryption</td></tr>
+<tr><td></td><td>Usage of ssm:StartSession on multiple instances</td><td>Create a backdoored IAM Role</td><td>Create a Login Profile on an IAM User</td><td>Stop CloudTrail Trail</td><td>Retrieve a High Number of Secrets Manager secrets</td><td></td><td></td><td>Exfiltrate RDS Snapshot by Sharing</td><td>S3 Ransomware through individual file deletion</td></tr>
+<tr><td></td><td></td><td>Create a Login Profile on an IAM User</td><td>Add a Malicious Lambda Extension</td><td>Delete DNS query logs</td><td>Retrieve And Decrypt SSM Parameters</td><td></td><td></td><td>Backdoor an S3 Bucket via its Bucket Policy</td><td></td></tr>
+<tr><td></td><td></td><td>Backdoor Lambda Function Through Resource-Based Policy</td><td>Create an IAM Roles Anywhere trust anchor</td><td>Attempt to Leave the AWS Organization</td><td></td><td></td><td></td><td></td><td></td></tr>
+<tr><td></td><td></td><td>Add a Malicious Lambda Extension</td><td>Change IAM user password</td><td>Remove VPC Flow Logs</td><td></td><td></td><td></td><td></td><td></td></tr>
+<tr><td></td><td></td><td>Overwrite Lambda Function Code</td><td></td><td></td><td></td><td></td><td></td><td></td><td></td></tr>
+<tr><td></td><td></td><td>Create an IAM Roles Anywhere trust anchor</td><td></td><td></td><td></td><td></td><td></td><td></td><td></td></tr>
+<tr><td></td><td></td><td>Generate temporary AWS credentials using GetFederationToken</td><td></td><td></td><td></td><td></td><td></td><td></td><td></td></tr>
+</tbody>
+</table>
+<h2>azure</h2>
+<table>
+<thead><tr><th>Execution</th><th>Persistence</th><th>Exfiltration</th></tr></thead>
+<tbody>
+<tr><td>Execute Command on Virtual Machine using Custom Script Extension</td><td>Create Azure VM Bastion shareable link</td><td>Export Disk Through SAS URL</td></tr>
+<tr><td>Execute Commands on Virtual Machine using Run Command</td><td></td><td></td></tr>
+</tbody>
+</table>
+<h2>EKS</h2>
+<table>
+<thead><tr><th>Persistence</th><th>Privilege Escalation</th><th>Lateral Movement</th></tr></thead>
+<tbody>
+<tr><td>Backdoor aws-auth EKS ConfigMap</td><td>Backdoor aws-auth EKS ConfigMap</td><td>Create Admin EKS Access Entry</td></tr>
+</tbody>
+</table>
+<h2>entra-id</h2>
+<table>
+<thead><tr><th>Persistence</th><th>Privilege Escalation</th></tr></thead>
+<tbody>
+<tr><td>Backdoor Entra ID application through service principal</td><td>Backdoor Entra ID application through service principal</td></tr>
+<tr><td>Backdoor Entra ID application</td><td>Backdoor Entra ID application</td></tr>
+<tr><td>Create Guest User</td><td>Create Application</td></tr>
+<tr><td>Create Hidden Scoped Role Assignment Through HiddenMembership AU</td><td></td></tr>
+<tr><td>Create Application</td><td></td></tr>
+<tr><td>Create Sticky Backdoor User Through Restricted Management AU</td><td></td></tr>
+</tbody>
+</table>
+
+</body>
+</html>

--- a/docs/attack-techniques/mitre-attack-coverage-matrices.md
+++ b/docs/attack-techniques/mitre-attack-coverage-matrices.md
@@ -1,85 +1,75 @@
 
+<style>
+	table { width: 100%; border-collapse: collapse; margin: 20px 0; font-size: 16px; }
+	th, td { border: 1px solid #ddd; padding: 8px; text-align: center; }
+	.md-sidebar.md-sidebar--secondary { display: none; }
+	.md-content { min-width: 100%; }
+</style>
+
 # MITRE ATT&CK Coverage by Platform
 
 This provides coverage matrices of MITRE ATT&CK tactics and techniques currently covered by Stratus Red Team for different cloud platforms.
-
-<!DOCTYPE html>
-<html>
-<head>
-	<title>MITRE ATT&CK Coverage</title>
-	<style>
-		table { width: 100%; border-collapse: collapse; margin: 20px 0; font-size: 16px; }
-		th, td { border: 1px solid #ddd; padding: 8px; text-align: center; }
-		th { background-color: #f4f4f4; font-weight: bold; font-size: 18px; color: #000; }
-		td { font-weight: normal; color: #7e56c2; }
-		tr:hover { background-color: #f1f1f1; }
-		td:hover { background-color: #e9e9ff; color: #5a3ea8; cursor: pointer; }
-		h1 { font-weight: 300; color: #333; }
-		h2 { color: #0000008a; text-transform: capitalize; }
-	</style>
-</head>
-<body>
-<h2>kubernetes</h2>
-<table>
-<thead><tr><th>Persistence</th><th>Privilege Escalation</th><th>Credential Access</th></tr></thead>
-<tbody>
-<tr><td>Create Admin ClusterRole</td><td>Create Admin ClusterRole</td><td>Dump All Secrets</td></tr>
-<tr><td>Create Client Certificate Credential</td><td>Container breakout via hostPath volume mount</td><td>Steal Pod Service Account Token</td></tr>
-<tr><td>Create Long-Lived Token</td><td>Privilege escalation through node/proxy permissions</td><td></td></tr>
-<tr><td></td><td>Run a Privileged Pod</td><td></td></tr>
-</tbody>
-</table>
-<h2>AWS</h2>
-<table>
-<thead><tr><th>Initial Access</th><th>Execution</th><th>Persistence</th><th>Privilege Escalation</th><th>Defense Evasion</th><th>Credential Access</th><th>Discovery</th><th>Lateral Movement</th><th>Exfiltration</th><th>Impact</th></tr></thead>
-<tbody>
-<tr><td>Console Login without MFA</td><td>Launch Unusual EC2 instances</td><td>Backdoor an IAM Role</td><td>Execute Commands on EC2 Instance via User Data</td><td>Delete CloudTrail Trail</td><td>Retrieve EC2 Password Data</td><td>Execute Discovery Commands on an EC2 Instance</td><td>Usage of EC2 Serial Console to push SSH public key</td><td>Open Ingress Port 22 on a Security Group</td><td>Invoke Bedrock Model</td></tr>
-<tr><td></td><td>Execute Commands on EC2 Instance via User Data</td><td>Create an Access Key on an IAM User</td><td>Create an Access Key on an IAM User</td><td>Disable CloudTrail Logging Through Event Selectors</td><td>Steal EC2 Instance Credentials</td><td>Download EC2 Instance User Data</td><td>Usage of EC2 Instance Connect on multiple instances</td><td>Exfiltrate an AMI by Sharing It</td><td>S3 Ransomware through batch file deletion</td></tr>
-<tr><td></td><td>Usage of ssm:SendCommand on multiple instances</td><td>Create an administrative IAM User</td><td>Create an administrative IAM User</td><td>CloudTrail Logs Impairment Through S3 Lifecycle Rule</td><td>Retrieve a High Number of Secrets Manager secrets (Batch)</td><td>Enumerate SES</td><td></td><td>Exfiltrate EBS Snapshot by Sharing It</td><td>S3 Ransomware through client-side encryption</td></tr>
-<tr><td></td><td>Usage of ssm:StartSession on multiple instances</td><td>Create a backdoored IAM Role</td><td>Create a Login Profile on an IAM User</td><td>Stop CloudTrail Trail</td><td>Retrieve a High Number of Secrets Manager secrets</td><td></td><td></td><td>Exfiltrate RDS Snapshot by Sharing</td><td>S3 Ransomware through individual file deletion</td></tr>
-<tr><td></td><td></td><td>Create a Login Profile on an IAM User</td><td>Add a Malicious Lambda Extension</td><td>Delete DNS query logs</td><td>Retrieve And Decrypt SSM Parameters</td><td></td><td></td><td>Backdoor an S3 Bucket via its Bucket Policy</td><td></td></tr>
-<tr><td></td><td></td><td>Backdoor Lambda Function Through Resource-Based Policy</td><td>Create an IAM Roles Anywhere trust anchor</td><td>Attempt to Leave the AWS Organization</td><td></td><td></td><td></td><td></td><td></td></tr>
-<tr><td></td><td></td><td>Add a Malicious Lambda Extension</td><td>Change IAM user password</td><td>Remove VPC Flow Logs</td><td></td><td></td><td></td><td></td><td></td></tr>
-<tr><td></td><td></td><td>Overwrite Lambda Function Code</td><td></td><td></td><td></td><td></td><td></td><td></td><td></td></tr>
-<tr><td></td><td></td><td>Create an IAM Roles Anywhere trust anchor</td><td></td><td></td><td></td><td></td><td></td><td></td><td></td></tr>
-<tr><td></td><td></td><td>Generate temporary AWS credentials using GetFederationToken</td><td></td><td></td><td></td><td></td><td></td><td></td><td></td></tr>
-</tbody>
-</table>
-<h2>azure</h2>
-<table>
-<thead><tr><th>Execution</th><th>Persistence</th><th>Exfiltration</th></tr></thead>
-<tbody>
-<tr><td>Execute Command on Virtual Machine using Custom Script Extension</td><td>Create Azure VM Bastion shareable link</td><td>Export Disk Through SAS URL</td></tr>
-<tr><td>Execute Commands on Virtual Machine using Run Command</td><td></td><td></td></tr>
-</tbody>
-</table>
-<h2>EKS</h2>
-<table>
-<thead><tr><th>Persistence</th><th>Privilege Escalation</th><th>Lateral Movement</th></tr></thead>
-<tbody>
-<tr><td>Backdoor aws-auth EKS ConfigMap</td><td>Backdoor aws-auth EKS ConfigMap</td><td>Create Admin EKS Access Entry</td></tr>
-</tbody>
-</table>
 <h2>entra-id</h2>
 <table>
 <thead><tr><th>Persistence</th><th>Privilege Escalation</th></tr></thead>
 <tbody>
-<tr><td>Backdoor Entra ID application through service principal</td><td>Backdoor Entra ID application through service principal</td></tr>
-<tr><td>Backdoor Entra ID application</td><td>Backdoor Entra ID application</td></tr>
-<tr><td>Create Guest User</td><td>Create Application</td></tr>
-<tr><td>Create Hidden Scoped Role Assignment Through HiddenMembership AU</td><td></td></tr>
-<tr><td>Create Application</td><td></td></tr>
-<tr><td>Create Sticky Backdoor User Through Restricted Management AU</td><td></td></tr>
+<tr><td><a href="../Entra ID/entra-id.persistence.backdoor-application-sp">Backdoor Entra ID application through service principal</a></td><td><a href="../Entra ID/entra-id.persistence.backdoor-application-sp">Backdoor Entra ID application through service principal</a></td></tr>
+<tr><td><a href="../Entra ID/entra-id.persistence.backdoor-application">Backdoor Entra ID application</a></td><td><a href="../Entra ID/entra-id.persistence.backdoor-application">Backdoor Entra ID application</a></td></tr>
+<tr><td><a href="../Entra ID/entra-id.persistence.guest-user">Create Guest User</a></td><td><a href="../Entra ID/entra-id.persistence.new-application">Create Application</a></td></tr>
+<tr><td><a href="../Entra ID/entra-id.persistence.hidden-au">Create Hidden Scoped Role Assignment Through HiddenMembership AU</a></td><td></td></tr>
+<tr><td><a href="../Entra ID/entra-id.persistence.new-application">Create Application</a></td><td></td></tr>
+<tr><td><a href="../Entra ID/entra-id.persistence.restricted-au">Create Sticky Backdoor User Through Restricted Management AU</a></td><td></td></tr>
 </tbody>
 </table>
 <h2>GCP</h2>
 <table>
 <thead><tr><th>Persistence</th><th>Privilege Escalation</th><th>Credential Access</th><th>Exfiltration</th></tr></thead>
 <tbody>
-<tr><td>Backdoor a GCP Service Account through its IAM Policy</td><td>Create an Admin GCP Service Account</td><td>Retrieve a High Number of Secret Manager secrets</td><td>Exfiltrate Compute Disk by sharing it</td></tr>
-<tr><td>Create an Admin GCP Service Account</td><td>Create a GCP Service Account Key</td><td></td><td>Exfiltrate Compute Image by sharing it</td></tr>
-<tr><td>Create a GCP Service Account Key</td><td>Impersonate GCP Service Accounts</td><td></td><td>Exfiltrate Compute Disk by sharing a snapshot</td></tr>
-<tr><td>Invite an External User to a GCP Project</td><td></td><td></td><td></td></tr>
+<tr><td><a href="../GCP/gcp.persistence.backdoor-service-account-policy">Backdoor a GCP Service Account through its IAM Policy</a></td><td><a href="../GCP/gcp.persistence.create-admin-service-account">Create an Admin GCP Service Account</a></td><td><a href="../GCP/gcp.credential-access.secretmanager-retrieve-secrets">Retrieve a High Number of Secret Manager secrets</a></td><td><a href="../GCP/gcp.exfiltration.share-compute-disk">Exfiltrate Compute Disk by sharing it</a></td></tr>
+<tr><td><a href="../GCP/gcp.persistence.create-admin-service-account">Create an Admin GCP Service Account</a></td><td><a href="../GCP/gcp.persistence.create-service-account-key">Create a GCP Service Account Key</a></td><td></td><td><a href="../GCP/gcp.exfiltration.share-compute-image">Exfiltrate Compute Image by sharing it</a></td></tr>
+<tr><td><a href="../GCP/gcp.persistence.create-service-account-key">Create a GCP Service Account Key</a></td><td><a href="../GCP/gcp.privilege-escalation.impersonate-service-accounts">Impersonate GCP Service Accounts</a></td><td></td><td><a href="../GCP/gcp.exfiltration.share-compute-snapshot">Exfiltrate Compute Disk by sharing a snapshot</a></td></tr>
+<tr><td><a href="../GCP/gcp.persistence.invite-external-user">Invite an External User to a GCP Project</a></td><td></td><td></td><td></td></tr>
+</tbody>
+</table>
+<h2>kubernetes</h2>
+<table>
+<thead><tr><th>Persistence</th><th>Privilege Escalation</th><th>Credential Access</th></tr></thead>
+<tbody>
+<tr><td><a href="../Kubernetes/k8s.persistence.create-admin-clusterrole">Create Admin ClusterRole</a></td><td><a href="../Kubernetes/k8s.persistence.create-admin-clusterrole">Create Admin ClusterRole</a></td><td><a href="../Kubernetes/k8s.credential-access.dump-secrets">Dump All Secrets</a></td></tr>
+<tr><td><a href="../Kubernetes/k8s.persistence.create-client-certificate">Create Client Certificate Credential</a></td><td><a href="../Kubernetes/k8s.privilege-escalation.hostpath-volume">Container breakout via hostPath volume mount</a></td><td><a href="../Kubernetes/k8s.credential-access.steal-serviceaccount-token">Steal Pod Service Account Token</a></td></tr>
+<tr><td><a href="../Kubernetes/k8s.persistence.create-token">Create Long-Lived Token</a></td><td><a href="../Kubernetes/k8s.privilege-escalation.nodes-proxy">Privilege escalation through node/proxy permissions</a></td><td></td></tr>
+<tr><td></td><td><a href="../Kubernetes/k8s.privilege-escalation.privileged-pod">Run a Privileged Pod</a></td><td></td></tr>
+</tbody>
+</table>
+<h2>AWS</h2>
+<table>
+<thead><tr><th>Initial Access</th><th>Execution</th><th>Persistence</th><th>Privilege Escalation</th><th>Defense Evasion</th><th>Credential Access</th><th>Discovery</th><th>Lateral Movement</th><th>Exfiltration</th><th>Impact</th></tr></thead>
+<tbody>
+<tr><td><a href="../AWS/aws.initial-access.console-login-without-mfa">Console Login without MFA</a></td><td><a href="../AWS/aws.execution.ec2-launch-unusual-instances">Launch Unusual EC2 instances</a></td><td><a href="../AWS/aws.persistence.iam-backdoor-role">Backdoor an IAM Role</a></td><td><a href="../AWS/aws.execution.ec2-user-data">Execute Commands on EC2 Instance via User Data</a></td><td><a href="../AWS/aws.defense-evasion.cloudtrail-delete">Delete CloudTrail Trail</a></td><td><a href="../AWS/aws.credential-access.ec2-get-password-data">Retrieve EC2 Password Data</a></td><td><a href="../AWS/aws.discovery.ec2-enumerate-from-instance">Execute Discovery Commands on an EC2 Instance</a></td><td><a href="../AWS/aws.lateral-movement.ec2-serial-console-send-ssh-public-key">Usage of EC2 Serial Console to push SSH public key</a></td><td><a href="../AWS/aws.exfiltration.ec2-security-group-open-port-22-ingress">Open Ingress Port 22 on a Security Group</a></td><td><a href="../AWS/aws.impact.bedrock-invoke-model">Invoke Bedrock Model</a></td></tr>
+<tr><td></td><td><a href="../AWS/aws.execution.ec2-user-data">Execute Commands on EC2 Instance via User Data</a></td><td><a href="../AWS/aws.persistence.iam-backdoor-user">Create an Access Key on an IAM User</a></td><td><a href="../AWS/aws.persistence.iam-backdoor-user">Create an Access Key on an IAM User</a></td><td><a href="../AWS/aws.defense-evasion.cloudtrail-event-selectors">Disable CloudTrail Logging Through Event Selectors</a></td><td><a href="../AWS/aws.credential-access.ec2-steal-instance-credentials">Steal EC2 Instance Credentials</a></td><td><a href="../AWS/aws.discovery.ec2-download-user-data">Download EC2 Instance User Data</a></td><td><a href="../AWS/aws.lateral-movement.ec2-instance-connect">Usage of EC2 Instance Connect on multiple instances</a></td><td><a href="../AWS/aws.exfiltration.ec2-share-ami">Exfiltrate an AMI by Sharing It</a></td><td><a href="../AWS/aws.impact.s3-ransomware-batch-deletion">S3 Ransomware through batch file deletion</a></td></tr>
+<tr><td></td><td><a href="../AWS/aws.execution.ssm-send-command">Usage of ssm:SendCommand on multiple instances</a></td><td><a href="../AWS/aws.persistence.iam-create-admin-user">Create an administrative IAM User</a></td><td><a href="../AWS/aws.persistence.iam-create-admin-user">Create an administrative IAM User</a></td><td><a href="../AWS/aws.defense-evasion.cloudtrail-lifecycle-rule">CloudTrail Logs Impairment Through S3 Lifecycle Rule</a></td><td><a href="../AWS/aws.credential-access.secretsmanager-batch-retrieve-secrets">Retrieve a High Number of Secrets Manager secrets (Batch)</a></td><td><a href="../AWS/aws.discovery.ses-enumerate">Enumerate SES</a></td><td></td><td><a href="../AWS/aws.exfiltration.ec2-share-ebs-snapshot">Exfiltrate EBS Snapshot by Sharing It</a></td><td><a href="../AWS/aws.impact.s3-ransomware-client-side-encryption">S3 Ransomware through client-side encryption</a></td></tr>
+<tr><td></td><td><a href="../AWS/aws.execution.ssm-start-session">Usage of ssm:StartSession on multiple instances</a></td><td><a href="../AWS/aws.persistence.iam-create-backdoor-role">Create a backdoored IAM Role</a></td><td><a href="../AWS/aws.persistence.iam-create-user-login-profile">Create a Login Profile on an IAM User</a></td><td><a href="../AWS/aws.defense-evasion.cloudtrail-stop">Stop CloudTrail Trail</a></td><td><a href="../AWS/aws.credential-access.secretsmanager-retrieve-secrets">Retrieve a High Number of Secrets Manager secrets</a></td><td></td><td></td><td><a href="../AWS/aws.exfiltration.rds-share-snapshot">Exfiltrate RDS Snapshot by Sharing</a></td><td><a href="../AWS/aws.impact.s3-ransomware-individual-deletion">S3 Ransomware through individual file deletion</a></td></tr>
+<tr><td></td><td></td><td><a href="../AWS/aws.persistence.iam-create-user-login-profile">Create a Login Profile on an IAM User</a></td><td><a href="../AWS/aws.persistence.lambda-layer-extension">Add a Malicious Lambda Extension</a></td><td><a href="../AWS/aws.defense-evasion.dns-delete-logs">Delete DNS query logs</a></td><td><a href="../AWS/aws.credential-access.ssm-retrieve-securestring-parameters">Retrieve And Decrypt SSM Parameters</a></td><td></td><td></td><td><a href="../AWS/aws.exfiltration.s3-backdoor-bucket-policy">Backdoor an S3 Bucket via its Bucket Policy</a></td><td></td></tr>
+<tr><td></td><td></td><td><a href="../AWS/aws.persistence.lambda-backdoor-function">Backdoor Lambda Function Through Resource-Based Policy</a></td><td><a href="../AWS/aws.persistence.rolesanywhere-create-trust-anchor">Create an IAM Roles Anywhere trust anchor</a></td><td><a href="../AWS/aws.defense-evasion.organizations-leave">Attempt to Leave the AWS Organization</a></td><td></td><td></td><td></td><td></td><td></td></tr>
+<tr><td></td><td></td><td><a href="../AWS/aws.persistence.lambda-layer-extension">Add a Malicious Lambda Extension</a></td><td><a href="../AWS/aws.privilege-escalation.iam-update-user-login-profile">Change IAM user password</a></td><td><a href="../AWS/aws.defense-evasion.vpc-remove-flow-logs">Remove VPC Flow Logs</a></td><td></td><td></td><td></td><td></td><td></td></tr>
+<tr><td></td><td></td><td><a href="../AWS/aws.persistence.lambda-overwrite-code">Overwrite Lambda Function Code</a></td><td></td><td></td><td></td><td></td><td></td><td></td><td></td></tr>
+<tr><td></td><td></td><td><a href="../AWS/aws.persistence.rolesanywhere-create-trust-anchor">Create an IAM Roles Anywhere trust anchor</a></td><td></td><td></td><td></td><td></td><td></td><td></td><td></td></tr>
+<tr><td></td><td></td><td><a href="../AWS/aws.persistence.sts-federation-token">Generate temporary AWS credentials using GetFederationToken</a></td><td></td><td></td><td></td><td></td><td></td><td></td><td></td></tr>
+</tbody>
+</table>
+<h2>azure</h2>
+<table>
+<thead><tr><th>Execution</th><th>Persistence</th><th>Exfiltration</th></tr></thead>
+<tbody>
+<tr><td><a href="../Azure/azure.execution.vm-custom-script-extension">Execute Command on Virtual Machine using Custom Script Extension</a></td><td><a href="../Azure/azure.persistence.create-bastion-shareable-link">Create Azure VM Bastion shareable link</a></td><td><a href="../Azure/azure.exfiltration.disk-export">Export Disk Through SAS URL</a></td></tr>
+<tr><td><a href="../Azure/azure.execution.vm-run-command">Execute Commands on Virtual Machine using Run Command</a></td><td></td><td></td></tr>
+</tbody>
+</table>
+<h2>EKS</h2>
+<table>
+<thead><tr><th>Persistence</th><th>Privilege Escalation</th><th>Lateral Movement</th></tr></thead>
+<tbody>
+<tr><td><a href="../EKS/eks.persistence.backdoor-aws-auth-configmap">Backdoor aws-auth EKS ConfigMap</a></td><td><a href="../EKS/eks.persistence.backdoor-aws-auth-configmap">Backdoor aws-auth EKS ConfigMap</a></td><td><a href="../EKS/eks.lateral-movement.create-access-entry">Create Admin EKS Access Entry</a></td></tr>
 </tbody>
 </table>
 

--- a/docs/attack-techniques/mitre-attack-coverage-matrices.md
+++ b/docs/attack-techniques/mitre-attack-coverage-matrices.md
@@ -8,7 +8,6 @@ This provides coverage matrices of MITRE ATT&CK tactics and techniques currently
 <head>
 	<title>MITRE ATT&CK Coverage</title>
 	<style>
-		body { font-family: SFMono-Regular, Consolas, Menlo, monospace; sans-serif; margin: 20px; }
 		table { width: 100%; border-collapse: collapse; margin: 20px 0; font-size: 16px; }
 		th, td { border: 1px solid #ddd; padding: 8px; text-align: center; }
 		th { background-color: #f4f4f4; font-weight: bold; font-size: 18px; color: #000; }
@@ -20,16 +19,6 @@ This provides coverage matrices of MITRE ATT&CK tactics and techniques currently
 	</style>
 </head>
 <body>
-<h2>GCP</h2>
-<table>
-<thead><tr><th>Persistence</th><th>Privilege Escalation</th><th>Credential Access</th><th>Exfiltration</th></tr></thead>
-<tbody>
-<tr><td>Backdoor a GCP Service Account through its IAM Policy</td><td>Create an Admin GCP Service Account</td><td>Retrieve a High Number of Secret Manager secrets</td><td>Exfiltrate Compute Disk by sharing it</td></tr>
-<tr><td>Create an Admin GCP Service Account</td><td>Create a GCP Service Account Key</td><td></td><td>Exfiltrate Compute Image by sharing it</td></tr>
-<tr><td>Create a GCP Service Account Key</td><td>Impersonate GCP Service Accounts</td><td></td><td>Exfiltrate Compute Disk by sharing a snapshot</td></tr>
-<tr><td>Invite an External User to a GCP Project</td><td></td><td></td><td></td></tr>
-</tbody>
-</table>
 <h2>kubernetes</h2>
 <table>
 <thead><tr><th>Persistence</th><th>Privilege Escalation</th><th>Credential Access</th></tr></thead>
@@ -81,6 +70,16 @@ This provides coverage matrices of MITRE ATT&CK tactics and techniques currently
 <tr><td>Create Hidden Scoped Role Assignment Through HiddenMembership AU</td><td></td></tr>
 <tr><td>Create Application</td><td></td></tr>
 <tr><td>Create Sticky Backdoor User Through Restricted Management AU</td><td></td></tr>
+</tbody>
+</table>
+<h2>GCP</h2>
+<table>
+<thead><tr><th>Persistence</th><th>Privilege Escalation</th><th>Credential Access</th><th>Exfiltration</th></tr></thead>
+<tbody>
+<tr><td>Backdoor a GCP Service Account through its IAM Policy</td><td>Create an Admin GCP Service Account</td><td>Retrieve a High Number of Secret Manager secrets</td><td>Exfiltrate Compute Disk by sharing it</td></tr>
+<tr><td>Create an Admin GCP Service Account</td><td>Create a GCP Service Account Key</td><td></td><td>Exfiltrate Compute Image by sharing it</td></tr>
+<tr><td>Create a GCP Service Account Key</td><td>Impersonate GCP Service Accounts</td><td></td><td>Exfiltrate Compute Disk by sharing a snapshot</td></tr>
+<tr><td>Invite an External User to a GCP Project</td><td></td><td></td><td></td></tr>
 </tbody>
 </table>
 

--- a/docs/attack-techniques/mitre-attack-coverage-matrices.md
+++ b/docs/attack-techniques/mitre-attack-coverage-matrices.md
@@ -1,16 +1,50 @@
 
 <style>
-	table { width: 100%; border-collapse: collapse; margin: 20px 0; font-size: 16px; }
-	th, td { border: 1px solid #ddd; padding: 8px; text-align: center; }
-	.md-sidebar.md-sidebar--secondary { display: none; }
-	.md-content { min-width: 100%; }
+    .table-container {
+        overflow-x: auto; /* Enables horizontal scrolling */
+        max-width: 80%; /* Ensures it doesn't go beyond the page */
+        border: 1px solid #ddd;
+        padding: 10px;
+        margin-bottom: 20px;
+    }
+    table {
+        width: 100%;
+        border-collapse: collapse;
+        margin: 20px 0;
+        font-size: 16px;
+        white-space: nowrap; /* Prevents text wrapping in cells */
+    }
+    th, td {
+        border: 1px solid #ddd;
+        padding: 8px;
+        text-align: center;
+    }
+    .md-sidebar.md-sidebar--secondary { display: none; }
+    .md-content { min-width: 100%; }
 </style>
 
 # MITRE ATT&CK Coverage by Platform
 
 This provides coverage matrices of MITRE ATT&CK tactics and techniques currently covered by Stratus Red Team for different cloud platforms.
-<h2>entra-id</h2>
-<table>
+<h2 style="text-transform: uppercase;">azure</h2>
+<div class="table-container"><table>
+<thead><tr><th>Execution</th><th>Persistence</th><th>Exfiltration</th></tr></thead>
+<tbody>
+<tr><td><a href="../Azure/azure.execution.vm-custom-script-extension">Execute Command on Virtual Machine using Custom Script Extension</a></td><td><a href="../Azure/azure.persistence.create-bastion-shareable-link">Create Azure VM Bastion shareable link</a></td><td><a href="../Azure/azure.exfiltration.disk-export">Export Disk Through SAS URL</a></td></tr>
+<tr><td><a href="../Azure/azure.execution.vm-run-command">Execute Commands on Virtual Machine using Run Command</a></td><td></td><td></td></tr>
+</tbody>
+</table>
+</div>
+<h2 style="text-transform: uppercase;">EKS</h2>
+<div class="table-container"><table>
+<thead><tr><th>Persistence</th><th>Privilege Escalation</th><th>Lateral Movement</th></tr></thead>
+<tbody>
+<tr><td><a href="../EKS/eks.persistence.backdoor-aws-auth-configmap">Backdoor aws-auth EKS ConfigMap</a></td><td><a href="../EKS/eks.persistence.backdoor-aws-auth-configmap">Backdoor aws-auth EKS ConfigMap</a></td><td><a href="../EKS/eks.lateral-movement.create-access-entry">Create Admin EKS Access Entry</a></td></tr>
+</tbody>
+</table>
+</div>
+<h2 style="text-transform: uppercase;">entra-id</h2>
+<div class="table-container"><table>
 <thead><tr><th>Persistence</th><th>Privilege Escalation</th></tr></thead>
 <tbody>
 <tr><td><a href="../Entra ID/entra-id.persistence.backdoor-application-sp">Backdoor Entra ID application through service principal</a></td><td><a href="../Entra ID/entra-id.persistence.backdoor-application-sp">Backdoor Entra ID application through service principal</a></td></tr>
@@ -21,8 +55,9 @@ This provides coverage matrices of MITRE ATT&CK tactics and techniques currently
 <tr><td><a href="../Entra ID/entra-id.persistence.restricted-au">Create Sticky Backdoor User Through Restricted Management AU</a></td><td></td></tr>
 </tbody>
 </table>
-<h2>GCP</h2>
-<table>
+</div>
+<h2 style="text-transform: uppercase;">GCP</h2>
+<div class="table-container"><table>
 <thead><tr><th>Persistence</th><th>Privilege Escalation</th><th>Credential Access</th><th>Exfiltration</th></tr></thead>
 <tbody>
 <tr><td><a href="../GCP/gcp.persistence.backdoor-service-account-policy">Backdoor a GCP Service Account through its IAM Policy</a></td><td><a href="../GCP/gcp.persistence.create-admin-service-account">Create an Admin GCP Service Account</a></td><td><a href="../GCP/gcp.credential-access.secretmanager-retrieve-secrets">Retrieve a High Number of Secret Manager secrets</a></td><td><a href="../GCP/gcp.exfiltration.share-compute-disk">Exfiltrate Compute Disk by sharing it</a></td></tr>
@@ -31,8 +66,9 @@ This provides coverage matrices of MITRE ATT&CK tactics and techniques currently
 <tr><td><a href="../GCP/gcp.persistence.invite-external-user">Invite an External User to a GCP Project</a></td><td></td><td></td><td></td></tr>
 </tbody>
 </table>
-<h2>kubernetes</h2>
-<table>
+</div>
+<h2 style="text-transform: uppercase;">kubernetes</h2>
+<div class="table-container"><table>
 <thead><tr><th>Persistence</th><th>Privilege Escalation</th><th>Credential Access</th></tr></thead>
 <tbody>
 <tr><td><a href="../Kubernetes/k8s.persistence.create-admin-clusterrole">Create Admin ClusterRole</a></td><td><a href="../Kubernetes/k8s.persistence.create-admin-clusterrole">Create Admin ClusterRole</a></td><td><a href="../Kubernetes/k8s.credential-access.dump-secrets">Dump All Secrets</a></td></tr>
@@ -41,8 +77,9 @@ This provides coverage matrices of MITRE ATT&CK tactics and techniques currently
 <tr><td></td><td><a href="../Kubernetes/k8s.privilege-escalation.privileged-pod">Run a Privileged Pod</a></td><td></td></tr>
 </tbody>
 </table>
-<h2>AWS</h2>
-<table>
+</div>
+<h2 style="text-transform: uppercase;">AWS</h2>
+<div class="table-container"><table>
 <thead><tr><th>Initial Access</th><th>Execution</th><th>Persistence</th><th>Privilege Escalation</th><th>Defense Evasion</th><th>Credential Access</th><th>Discovery</th><th>Lateral Movement</th><th>Exfiltration</th><th>Impact</th></tr></thead>
 <tbody>
 <tr><td><a href="../AWS/aws.initial-access.console-login-without-mfa">Console Login without MFA</a></td><td><a href="../AWS/aws.execution.ec2-launch-unusual-instances">Launch Unusual EC2 instances</a></td><td><a href="../AWS/aws.persistence.iam-backdoor-role">Backdoor an IAM Role</a></td><td><a href="../AWS/aws.execution.ec2-user-data">Execute Commands on EC2 Instance via User Data</a></td><td><a href="../AWS/aws.defense-evasion.cloudtrail-delete">Delete CloudTrail Trail</a></td><td><a href="../AWS/aws.credential-access.ec2-get-password-data">Retrieve EC2 Password Data</a></td><td><a href="../AWS/aws.discovery.ec2-enumerate-from-instance">Execute Discovery Commands on an EC2 Instance</a></td><td><a href="../AWS/aws.lateral-movement.ec2-serial-console-send-ssh-public-key">Usage of EC2 Serial Console to push SSH public key</a></td><td><a href="../AWS/aws.exfiltration.ec2-security-group-open-port-22-ingress">Open Ingress Port 22 on a Security Group</a></td><td><a href="../AWS/aws.impact.bedrock-invoke-model">Invoke Bedrock Model</a></td></tr>
@@ -57,21 +94,4 @@ This provides coverage matrices of MITRE ATT&CK tactics and techniques currently
 <tr><td></td><td></td><td><a href="../AWS/aws.persistence.sts-federation-token">Generate temporary AWS credentials using GetFederationToken</a></td><td></td><td></td><td></td><td></td><td></td><td></td><td></td></tr>
 </tbody>
 </table>
-<h2>azure</h2>
-<table>
-<thead><tr><th>Execution</th><th>Persistence</th><th>Exfiltration</th></tr></thead>
-<tbody>
-<tr><td><a href="../Azure/azure.execution.vm-custom-script-extension">Execute Command on Virtual Machine using Custom Script Extension</a></td><td><a href="../Azure/azure.persistence.create-bastion-shareable-link">Create Azure VM Bastion shareable link</a></td><td><a href="../Azure/azure.exfiltration.disk-export">Export Disk Through SAS URL</a></td></tr>
-<tr><td><a href="../Azure/azure.execution.vm-run-command">Execute Commands on Virtual Machine using Run Command</a></td><td></td><td></td></tr>
-</tbody>
-</table>
-<h2>EKS</h2>
-<table>
-<thead><tr><th>Persistence</th><th>Privilege Escalation</th><th>Lateral Movement</th></tr></thead>
-<tbody>
-<tr><td><a href="../EKS/eks.persistence.backdoor-aws-auth-configmap">Backdoor aws-auth EKS ConfigMap</a></td><td><a href="../EKS/eks.persistence.backdoor-aws-auth-configmap">Backdoor aws-auth EKS ConfigMap</a></td><td><a href="../EKS/eks.lateral-movement.create-access-entry">Create Admin EKS Access Entry</a></td></tr>
-</tbody>
-</table>
-
-</body>
-</html>
+</div>

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -103,4 +103,5 @@ nav:
       - All Attack Techniques: attack-techniques/list.md
       - Philosophy: attack-techniques/philosophy.md
       - Supported Platforms: attack-techniques/supported-platforms.md
+      - MITRE ATT&CK Coverage Matrices: attack-techniques/mitre-attack-coverage-matrices.md
       - ... | attack-techniques/*/*.md

--- a/v2/tools/generate-coverage-matrices.go
+++ b/v2/tools/generate-coverage-matrices.go
@@ -56,7 +56,6 @@ This provides coverage matrices of MITRE ATT&CK tactics and techniques currently
 <head>
 	<title>MITRE ATT&CK Coverage</title>
 	<style>
-		body { font-family: SFMono-Regular, Consolas, Menlo, monospace; sans-serif; margin: 20px; }
 		table { width: 100%; border-collapse: collapse; margin: 20px 0; font-size: 16px; }
 		th, td { border: 1px solid #ddd; padding: 8px; text-align: center; }
 		th { background-color: #f4f4f4; font-weight: bold; font-size: 18px; color: #000; }

--- a/v2/tools/generate-coverage-matrices.go
+++ b/v2/tools/generate-coverage-matrices.go
@@ -61,7 +61,7 @@ This provides coverage matrices of MITRE ATT&CK tactics and techniques currently
 
 	// Loop through each platform and generate tables
 	for platform, tacticsMap := range index {
-		htmlContent += fmt.Sprintf("<h2>%s</h2>\n<table>\n", platform)
+		htmlContent += fmt.Sprintf("<h2 style=\"text-transform: uppercase;\">%s</h2>\n<table>\n", platform)
 
 		// Sort tactics based on MITRE ATT&CK order
 		sortedTactics := []string{}

--- a/v2/tools/generate-coverage-matrices.go
+++ b/v2/tools/generate-coverage-matrices.go
@@ -12,18 +12,18 @@ import (
 var mitreTacticOrder = []string{
 	"Reconnaissance",
 	"Resource Development",
-    "Initial Access",
-    "Execution",
-    "Persistence",
-    "Privilege Escalation",
-    "Defense Evasion",
-    "Credential Access",
-    "Discovery",
-    "Lateral Movement",
-    "Collection",
+	"Initial Access",
+	"Execution",
+	"Persistence",
+	"Privilege Escalation",
+	"Defense Evasion",
+	"Credential Access",
+	"Discovery",
+	"Lateral Movement",
+	"Collection",
 	"Command and Control",
-    "Exfiltration",
-    "Impact",
+	"Exfiltration",
+	"Impact",
 }
 
 // GenerateCoverageMatrics generates a single static .md file containing MITRE ATT&CK coverage tables split by platform
@@ -47,26 +47,16 @@ func GenerateCoverageMatrices(index map[stratus.Platform]map[string][]*stratus.A
 	defer file.Close()
 
 	htmlContent := `
+<style>
+	table { width: 100%; border-collapse: collapse; margin: 20px 0; font-size: 16px; }
+	th, td { border: 1px solid #ddd; padding: 8px; text-align: center; }
+	.md-sidebar.md-sidebar--secondary { display: none; }
+	.md-content { min-width: 100%; }
+</style>
+
 # MITRE ATT&CK Coverage by Platform
 
 This provides coverage matrices of MITRE ATT&CK tactics and techniques currently covered by Stratus Red Team for different cloud platforms.
-
-<!DOCTYPE html>
-<html>
-<head>
-	<title>MITRE ATT&CK Coverage</title>
-	<style>
-		table { width: 100%; border-collapse: collapse; margin: 20px 0; font-size: 16px; }
-		th, td { border: 1px solid #ddd; padding: 8px; text-align: center; }
-		th { background-color: #f4f4f4; font-weight: bold; font-size: 18px; color: #000; }
-		td { font-weight: normal; color: #7e56c2; }
-		tr:hover { background-color: #f1f1f1; }
-		td:hover { background-color: #e9e9ff; color: #5a3ea8; cursor: pointer; }
-		h1 { font-weight: 300; color: #333; }
-		h2 { color: #0000008a; text-transform: capitalize; }
-	</style>
-</head>
-<body>
 `
 
 	// Loop through each platform and generate tables
@@ -105,7 +95,9 @@ This provides coverage matrices of MITRE ATT&CK tactics and techniques currently
 		for _, tactic := range sortedTactics {
 			techniques := tacticsMap[tactic]
 			for _, technique := range techniques {
-				tacticToTechniques[tactic] = append(tacticToTechniques[tactic], technique.FriendlyName)
+				platform, _ := technique.Platform.FormatName()
+				cellText := fmt.Sprintf("<a href=\"%s\">%s</a>", fmt.Sprintf("../%s/%s", platform, technique.ID), technique.FriendlyName)
+				tacticToTechniques[tactic] = append(tacticToTechniques[tactic], cellText)
 			}
 			if len(tacticToTechniques[tactic]) > maxRows {
 				maxRows = len(tacticToTechniques[tactic])
@@ -148,6 +140,6 @@ This provides coverage matrices of MITRE ATT&CK tactics and techniques currently
 	if _, err := file.WriteString(htmlContent); err != nil {
 		return fmt.Errorf("failed to write to file: %w", err)
 	}
-	
+
 	return nil
 }

--- a/v2/tools/generate-coverage-matrices.go
+++ b/v2/tools/generate-coverage-matrices.go
@@ -26,7 +26,7 @@ var mitreTacticOrder = []string{
 	"Impact",
 }
 
-// GenerateCoverageMatrics generates a single static .md file containing MITRE ATT&CK coverage tables split by platform
+// GenerateCoverageMatrices generates a single static .md file containing MITRE ATT&CK coverage tables split by platform
 func GenerateCoverageMatrices(index map[stratus.Platform]map[string][]*stratus.AttackTechnique, docsDirectory string) error {
 	outputFilePath := filepath.Join(docsDirectory, "attack-techniques", "mitre-attack-coverage-matrices.md")
 
@@ -48,10 +48,27 @@ func GenerateCoverageMatrices(index map[stratus.Platform]map[string][]*stratus.A
 
 	htmlContent := `
 <style>
-	table { width: 100%; border-collapse: collapse; margin: 20px 0; font-size: 16px; }
-	th, td { border: 1px solid #ddd; padding: 8px; text-align: center; }
-	.md-sidebar.md-sidebar--secondary { display: none; }
-	.md-content { min-width: 100%; }
+    .table-container {
+        overflow-x: auto; /* Enables horizontal scrolling */
+        max-width: 80%; /* Ensures it doesn't go beyond the page */
+        border: 1px solid #ddd;
+        padding: 10px;
+        margin-bottom: 20px;
+    }
+    table {
+        width: 100%;
+        border-collapse: collapse;
+        margin: 20px 0;
+        font-size: 16px;
+        white-space: nowrap; /* Prevents text wrapping in cells */
+    }
+    th, td {
+        border: 1px solid #ddd;
+        padding: 8px;
+        text-align: center;
+    }
+    .md-sidebar.md-sidebar--secondary { display: none; }
+    .md-content { min-width: 100%; }
 </style>
 
 # MITRE ATT&CK Coverage by Platform
@@ -61,7 +78,11 @@ This provides coverage matrices of MITRE ATT&CK tactics and techniques currently
 
 	// Loop through each platform and generate tables
 	for platform, tacticsMap := range index {
-		htmlContent += fmt.Sprintf("<h2 style=\"text-transform: uppercase;\">%s</h2>\n<table>\n", platform)
+		htmlContent += fmt.Sprintf("<h2 style=\"text-transform: uppercase;\">%s</h2>\n", platform)
+		htmlContent += `<div class="table-container">` // Add scrollable div
+
+		// Start the table
+		htmlContent += "<table>\n"
 
 		// Sort tactics based on MITRE ATT&CK order
 		sortedTactics := []string{}
@@ -130,16 +151,14 @@ This provides coverage matrices of MITRE ATT&CK tactics and techniques currently
 			htmlContent += "</tr>\n"
 		}
 
-		htmlContent += "</tbody>\n</table>\n"
+		htmlContent += "</tbody>\n</table>\n</div>\n" // Close scrollable div
 	}
 
-	htmlContent += `
-</body>
-</html>`
-
+	// Write to Markdown file
 	if _, err := file.WriteString(htmlContent); err != nil {
 		return fmt.Errorf("failed to write to file: %w", err)
 	}
 
+	fmt.Printf("Generated MITRE ATT&CK coverage markdown file: %s\n", outputFilePath)
 	return nil
 }

--- a/v2/tools/generate-coverage-matrices.go
+++ b/v2/tools/generate-coverage-matrices.go
@@ -1,0 +1,112 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+
+	"github.com/datadog/stratus-red-team/v2/pkg/stratus"
+)
+
+func GenerateCoverageMatrices(index map[stratus.Platform]map[string][]*stratus.AttackTechnique, docsDirectory string) error {
+	// Process each platform in the index
+	for platform, tacticsMap := range index {
+		// Initialize the HTML content
+		htmlContent := fmt.Sprintf(`
+<!DOCTYPE html>
+<html>
+<head>
+	<title>%s Coverage Matrix</title>
+	<link rel="icon" type="image/png" href="logo.png">
+	<style>
+		body { font-family: Arial, sans-serif; margin: 20px;}
+		table { width: 100%%; border-collapse: collapse; margin: 20px 0; font-size: 12px}
+		th, td { border: 1px solid #ddd; padding: 8px; text-align: left; color: #7e56c2}
+		th { background-color: #f4f4f4; font-weight: bold; font-size: 14px; color: #333; }
+		tr:nth-child(even) { background-color: #f9f9f9; }
+		tr:hover { background-color: #f1f1f1; }
+		td:hover { background-color: #e9e9ff; color: #5a3ea8; cursor: pointer;}
+		caption { font-size: 1.5em; margin-bottom: 10px; font-weight: bold; }
+	</style>
+</head>
+<body>
+	<h1>Stratus Red Team</h1>
+	<table>
+		<caption>Coverage Matrix for %s</caption>
+`, platform, platform)
+
+		// Extract unique tactics
+		tacticsSet := make(map[string]struct{})
+		for tactic := range tacticsMap {
+			tacticsSet[tactic] = struct{}{}
+		}
+		tactics := make([]string, 0, len(tacticsSet))
+		for tactic := range tacticsSet {
+			tactics = append(tactics, tactic)
+		}
+		sort.Strings(tactics)
+
+		// Add header row
+		htmlContent += "<thead><tr>"
+		for _, tactic := range tactics {
+			htmlContent += fmt.Sprintf("<th>%s</th>", tactic)
+		}
+		htmlContent += "</tr></thead>\n<tbody>\n"
+
+		rows := make([][]string, 0)
+		maxRows := 0
+
+		// Map tactic to techniques
+		tacticToTechniques := make(map[string][]string)
+		for _, tactic := range tactics {
+			techniques := tacticsMap[tactic]
+			for _, technique := range techniques {
+				tacticToTechniques[tactic] = append(tacticToTechniques[tactic], technique.FriendlyName)
+			}
+			if len(tacticToTechniques[tactic]) > maxRows {
+				maxRows = len(tacticToTechniques[tactic])
+			}
+		}
+
+		// Fill rows with Stratus techniques for each ATT&CK tactic
+		for i := 0; i < maxRows; i++ {
+			row := make([]string, len(tactics))
+			for j, tactic := range tactics {
+				if i < len(tacticToTechniques[tactic]) {
+					row[j] = tacticToTechniques[tactic][i]
+				} else {
+					row[j] = ""
+				}
+			}
+			rows = append(rows, row)
+		}
+
+		// Add rows to the HTML table
+		for _, row := range rows {
+			htmlContent += "<tr>"
+			for _, cell := range row {
+				if cell != "" {
+					htmlContent += fmt.Sprintf("<td>%s</td>", cell)
+				} else {
+					htmlContent += "<td></td>"
+				}
+			}
+			htmlContent += "</tr>\n"
+		}
+
+		// Close table and HTML document
+		htmlContent += `
+		</tbody>
+	</table>
+</body>
+</html>`
+		filePath := filepath.Join(docsDirectory, fmt.Sprintf("%s.html", platform))
+		if err := os.WriteFile(filePath, []byte(htmlContent), 0644); err != nil {
+			return fmt.Errorf("failed to write HTML file for platform %s: %w", platform, err)
+		}
+		fmt.Printf("Generated coverage matrix for platform: %s\n", platform)
+	}
+
+	return nil
+}

--- a/v2/tools/generate-docs.go
+++ b/v2/tools/generate-docs.go
@@ -28,9 +28,8 @@ func main() {
 		os.Exit(1)
 	}
 
-	// Generate HTML files for each platform
 	if err := GenerateCoverageMatrices(index, docsDirectory); err != nil {
-		fmt.Fprintln(os.Stderr, "Could not generate coverage matrices")
+		fmt.Fprintln(os.Stderr, "Could not generate MITRE ATT&CK coverage file")
 		fmt.Fprintf(os.Stderr, "%v\n", err)
 		os.Exit(1)
 	}

--- a/v2/tools/generate-docs.go
+++ b/v2/tools/generate-docs.go
@@ -28,6 +28,13 @@ func main() {
 		os.Exit(1)
 	}
 
+	// Generate HTML files for each platform
+	if err := GenerateCoverageMatrices(index, docsDirectory); err != nil {
+		fmt.Fprintln(os.Stderr, "Could not generate coverage matrices")
+		fmt.Fprintf(os.Stderr, "%v\n", err)
+		os.Exit(1)
+	}
+
 	// Write a single index file with all techniques. File is enconded in YAML.
 	yamlIndex := filepath.Join(docsDirectory, "index.yaml")
 	if err := GenerateYAML(yamlIndex, index); err != nil {


### PR DESCRIPTION
### What does this PR do?

Adds the functionality to generate stylized HTML coverage matrices for each platform with Columns: ATT&CK Tactics and Rows: Stratus Red Team techniques.
Integrates the GenerateCoverageMatrices function into the generate-docs.go workflow so that platform-specific matrices are generated by running `make docs`

- Tested the output for correctness and styling (e.g., AWS.html, GCP.html).
- Added hover effects and color coding to improve readability and likeness to Stratus Red Team color scheme.
- Ensured no breaking changes to the existing codebase.
- Verified that the generated HTML includes the favicon for branding.

### Motivation

Resolves #95
This PR addresses the need for automatically generating stylized coverage matrices for all platforms currently covered by Stratus Red team, improving documentation usability and visibility for maintainers and users.

### Checklist
N/A

### Sample Screenshot of HTML Table
<img width="1501" alt="Screenshot 2025-01-01 at 23 58 35" src="https://github.com/user-attachments/assets/00145e55-0a25-4ce1-999e-2940edfb4a57" />

