### PR TITLE
Update new issue label link in contributing.md

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -4,7 +4,7 @@ We welcome pull requests, contributions and feedback! For any bug report or feed
 
 ## Contributing to a new attack technique
 
-Stratus Red Team is opinionated in the attack techniques it packages - see [Philosophy](./attack-techniques/philosophy.md). Feel free to open an issue to discuss ideas about new attack techniques. You can see the current backlog using the GitHub issue label [`new-technique`](https://github.com/DataDog/stratus-red-team/issues?q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fnew-technique%20).
+Stratus Red Team is opinionated in the attack techniques it packages - see [Philosophy](./attack-techniques/philosophy.md). Feel free to open an issue to discuss ideas about new attack techniques. You can see the current backlog using the GitHub issue label [`kind/new-technique`](https://github.com/DataDog/stratus-red-team/issues?q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fnew-technique%20).
 
 To create a new attack technique:
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -4,7 +4,7 @@ We welcome pull requests, contributions and feedback! For any bug report or feed
 
 ## Contributing to a new attack technique
 
-Stratus Red Team is opinionated in the attack techniques it packages - see [Philosophy](./attack-techniques/philosophy.md). Feel free to open an issue to discuss ideas about new attack techniques. You can see the current backlog using the GitHub issue label [`new-technique`](https://github.com/DataDog/stratus-red-team/issues?q=is%3Aissue+is%3Aopen+label%3Anew-technique).
+Stratus Red Team is opinionated in the attack techniques it packages - see [Philosophy](./attack-techniques/philosophy.md). Feel free to open an issue to discuss ideas about new attack techniques. You can see the current backlog using the GitHub issue label [`new-technique`](https://github.com/DataDog/stratus-red-team/issues?q=is%3Aissue%20is%3Aopen%20label%3Akind%2Fnew-technique%20).
 
 To create a new attack technique:
 


### PR DESCRIPTION
### What does this PR do?
Update link in `contributing.md` to point to the correct label for new issues, `kind/new-technique`. Currently, this link points to `new-technique`, which leads to an empty page:
<img width="574" alt="image" src="https://github.com/user-attachments/assets/3d3cc176-3bc6-4801-93fc-d0453baff9ba" />

### Motivation
Fixing this after a user noticed this & pointed it out to me.

### Checklist
N/A, change in link filter.