### PR TITLE
Fix incorrect AWS VPC module version (#626)

### DIFF
--- a/v2/internal/attacktechniques/aws/credential-access/ec2-steal-instance-credentials/main.tf
+++ b/v2/internal/attacktechniques/aws/credential-access/ec2-steal-instance-credentials/main.tf
@@ -28,7 +28,7 @@ data "aws_availability_zones" "available" {
 
 module "vpc" {
   source  = "terraform-aws-modules/vpc/aws"
-  version = ">= 4.54.0, < 5.0.0" # 4.54.0 at least is required for proper AWS SSO support, see #626
+  version = "~> 3.0"
 
   name = "${local.resource_prefix}-vpc"
   cidr = "10.0.0.0/16"

--- a/v2/internal/attacktechniques/aws/discovery/ec2-enumerate-from-instance/main.tf
+++ b/v2/internal/attacktechniques/aws/discovery/ec2-enumerate-from-instance/main.tf
@@ -28,7 +28,7 @@ data "aws_availability_zones" "available" {
 
 module "vpc" {
   source  = "terraform-aws-modules/vpc/aws"
-  version = ">= 4.54.0, < 5.0.0" # 4.54.0 at least is required for proper AWS SSO support, see #626
+  version = "~> 3.0"
 
   name = "${local.resource_prefix}-vpc"
   cidr = "10.0.0.0/16"

--- a/v2/internal/attacktechniques/aws/execution/ec2-launch-unusual-instances/main.tf
+++ b/v2/internal/attacktechniques/aws/execution/ec2-launch-unusual-instances/main.tf
@@ -72,7 +72,7 @@ data "aws_availability_zones" "available" {
 
 module "vpc" {
   source  = "terraform-aws-modules/vpc/aws"
-  version = ">= 4.54.0, < 5.0.0" # 4.54.0 at least is required for proper AWS SSO support, see #626
+  version = "~> 3.0"
 
   name = "${local.resource_prefix}-vpc"
   cidr = "10.0.0.0/16"

--- a/v2/internal/attacktechniques/aws/execution/ec2-user-data/main.tf
+++ b/v2/internal/attacktechniques/aws/execution/ec2-user-data/main.tf
@@ -28,7 +28,7 @@ data "aws_availability_zones" "available" {
 
 module "vpc" {
   source  = "terraform-aws-modules/vpc/aws"
-  version = ">= 4.54.0, < 5.0.0" # 4.54.0 at least is required for proper AWS SSO support, see #626
+  version = "~> 3.0"
 
   name = "${local.resource_prefix}-vpc"
   cidr = "10.0.0.0/16"

--- a/v2/internal/attacktechniques/aws/execution/ssm-send-command/main.tf
+++ b/v2/internal/attacktechniques/aws/execution/ssm-send-command/main.tf
@@ -32,7 +32,7 @@ data "aws_availability_zones" "available" {
 
 module "vpc" {
   source  = "terraform-aws-modules/vpc/aws"
-  version = ">= 4.54.0, < 5.0.0" # 4.54.0 at least is required for proper AWS SSO support, see #626
+  version = "~> 3.0"
 
   name = "${local.resource_prefix}-vpc"
   cidr = "10.0.0.0/16"

--- a/v2/internal/attacktechniques/aws/execution/ssm-start-session/main.tf
+++ b/v2/internal/attacktechniques/aws/execution/ssm-start-session/main.tf
@@ -32,7 +32,7 @@ data "aws_availability_zones" "available" {
 
 module "vpc" {
   source  = "terraform-aws-modules/vpc/aws"
-  version = ">= 4.54.0, < 5.0.0" # 4.54.0 at least is required for proper AWS SSO support, see #626
+  version = "~> 3.0"
 
   name = "${local.resource_prefix}-vpc"
   cidr = "10.0.0.0/16"

--- a/v2/internal/attacktechniques/aws/exfiltration/rds-share-snapshot/main.tf
+++ b/v2/internal/attacktechniques/aws/exfiltration/rds-share-snapshot/main.tf
@@ -33,7 +33,7 @@ data "aws_availability_zones" "available" {
 
 module "vpc" {
   source  = "terraform-aws-modules/vpc/aws"
-  version = ">= 4.54.0, < 5.0.0" # 4.54.0 at least is required for proper AWS SSO support, see #626
+  version = "~> 3.0"
 
   name = "${local.resource_prefix}-vpc"
   cidr = "10.0.0.0/16"

--- a/v2/internal/attacktechniques/aws/lateral-movement/ec2-send-serial-console-send-ssh-public-key/main.tf
+++ b/v2/internal/attacktechniques/aws/lateral-movement/ec2-send-serial-console-send-ssh-public-key/main.tf
@@ -34,7 +34,7 @@ data "aws_ec2_serial_console_access" "current" {}
 
 module "vpc" {
   source  = "terraform-aws-modules/vpc/aws"
-  version = ">= 4.54.0, < 5.0.0" # 4.54.0 at least is required for proper AWS SSO support, see #626
+  version = "~> 3.0"
 
   name = "${local.resource_prefix}-vpc"
   cidr = "10.0.0.0/16"

--- a/v2/internal/attacktechniques/aws/lateral-movement/ec2-send-ssh-public-key/main.tf
+++ b/v2/internal/attacktechniques/aws/lateral-movement/ec2-send-ssh-public-key/main.tf
@@ -32,7 +32,7 @@ data "aws_availability_zones" "available" {
 
 module "vpc" {
   source  = "terraform-aws-modules/vpc/aws"
-  version = ">= 4.54.0, < 5.0.0" # 4.54.0 at least is required for proper AWS SSO support, see #626
+  version = "~> 3.0"
 
   name = "${local.resource_prefix}-vpc"
   cidr = "10.0.0.0/16"


### PR DESCRIPTION
The fix in #629 incorrectly changed version constraints for the Terraform AWS VPC module, while it was meant to be changed only for the Terraform AWS provider

As reported in https://github.com/DataDog/stratus-red-team/issues/626#issuecomment-2681693462