### PR TITLE
New technique: Launch unusual GCE instances

### DIFF
--- a/docs/attack-techniques/GCP/gcp.execution.gce-launch-unusual-instances.md
+++ b/docs/attack-techniques/GCP/gcp.execution.gce-launch-unusual-instances.md
@@ -1,0 +1,61 @@
+---
+title: Launch unusual GCE instances
+---
+
+# Launch unusual GCE instances
+
+
+ <span class="smallcaps w3-badge w3-blue w3-round w3-text-white" title="This attack technique can be detonated multiple times">idempotent</span>
+
+Platform: GCP
+
+## MITRE ATT&CK Tactics
+
+
+- Execution
+
+## Description
+
+
+Attempts to launch several unusual Compute Engine instances (default: `f1-micro`).
+
+<span style="font-variant: small-caps;">Warm-up</span>: 
+
+- Create an IAM role that doesn't have permissions to launch Compute instance (roles/compute.viewer). This ensures the attempts is not successful, and the attack technique is fast to detonate.
+- Assign caller with role 'roles/iam.serviceAccountTokenCreator' so it can impersonate service account.
+
+<span style="font-variant: small-caps;">Detonation</span>: 
+
+- Attempts to launch several unusual Compute instances. The calls will fail as the IAM role doesn't have sufficient permissions.
+
+
+## Instructions
+
+```bash title="Detonate with Stratus Red Team"
+stratus detonate gcp.execution.gce-launch-unusual-instances
+```
+
+
+## Detection 
+
+Attempt to launch compute instance is detected as `compute.instances.insert` in Cloud Logging.
+
+Sample event (shortened for readability):
+
+```json
+{
+  "logName": "projects/my-project-id/logs/cloudaudit.googleapis.com%2Factivity",
+  "protoPayload": {
+    "authenticationInfo": {
+      "principalEmail": "username@service.com",
+    },
+    "serviceName": "compute.googleapis.com",
+    "methodName": "v1.compute.instances.insert",
+    "resourceName": "projects/my-project-id/zones/my-zone-id/instances/my-instance-id",
+  },
+  "resource": {
+    "type": "gce_instance",
+  },
+  "severity": "ERROR",
+}
+```

--- a/docs/attack-techniques/GCP/index.md
+++ b/docs/attack-techniques/GCP/index.md
@@ -9,6 +9,11 @@ Note that some Stratus attack techniques may correspond to more than a single AT
 - [Retrieve a High Number of Secret Manager secrets](./gcp.credential-access.secretmanager-retrieve-secrets.md)
 
 
+## Execution
+
+- [Launch unusual GCE instances](./gcp.execution.gce-launch-unusual-instances.md)
+
+
 ## Exfiltration
 
 - [Exfiltrate Compute Disk by sharing it](./gcp.exfiltration.share-compute-disk.md)

--- a/docs/attack-techniques/list.md
+++ b/docs/attack-techniques/list.md
@@ -64,6 +64,7 @@ This page contains the list of all Stratus Attack Techniques.
 | [Create Application](./entra-id/entra-id.persistence.new-application.md) | [Entra ID](./entra-id/index.md) | Persistence, Privilege Escalation |
 | [Create Sticky Backdoor User Through Restricted Management AU](./entra-id/entra-id.persistence.restricted-au.md) | [Entra ID](./entra-id/index.md) | Persistence |
 | [Retrieve a High Number of Secret Manager secrets](./GCP/gcp.credential-access.secretmanager-retrieve-secrets.md) | [GCP](./GCP/index.md) | Credential Access |
+| [Launch unusual GCE instances](./GCP/gcp.execution.gce-launch-unusual-instances.md) | [GCP](./GCP/index.md) | Execution |
 | [Exfiltrate Compute Disk by sharing it](./GCP/gcp.exfiltration.share-compute-disk.md) | [GCP](./GCP/index.md) | Exfiltration |
 | [Exfiltrate Compute Image by sharing it](./GCP/gcp.exfiltration.share-compute-image.md) | [GCP](./GCP/index.md) | Exfiltration |
 | [Exfiltrate Compute Disk by sharing a snapshot](./GCP/gcp.exfiltration.share-compute-snapshot.md) | [GCP](./GCP/index.md) | Exfiltration |

--- a/docs/index.yaml
+++ b/docs/index.yaml
@@ -393,6 +393,14 @@ GCP:
             - Credential Access
           platform: GCP
           isIdempotent: true
+    Execution:
+        - id: gcp.execution.gce-launch-unusual-instances
+          name: Launch unusual GCE instances
+          isSlow: false
+          mitreAttackTactics:
+            - Execution
+          platform: GCP
+          isIdempotent: true
     Exfiltration:
         - id: gcp.exfiltration.share-compute-disk
           name: Exfiltrate Compute Disk by sharing it

--- a/v2/internal/attacktechniques/gcp/execution/gce-launch-unusual-instances/main.go
+++ b/v2/internal/attacktechniques/gcp/execution/gce-launch-unusual-instances/main.go
@@ -1,0 +1,145 @@
+package gcp
+
+import (
+    "context"
+    _ "embed"
+    "errors"
+    "strings"
+    "fmt"
+    "log"
+    "google.golang.org/api/compute/v1"
+    "google.golang.org/api/impersonate"
+    "google.golang.org/api/option"
+    "github.com/datadog/stratus-red-team/v2/pkg/stratus"
+    "github.com/datadog/stratus-red-team/v2/pkg/stratus/mitreattack"
+)
+
+//go:embed main.tf
+var tf []byte
+
+const instanceType = "f1-micro"
+const imageSource  = "projects/debian-cloud/global/images/family/debian-12"
+const numInstances = 10
+
+
+func init() {
+    const CodeBlock = "```"
+    const AttackTechniqueId = "gcp.execution.gce-launch-unusual-instances"
+
+    stratus.GetRegistry().RegisterAttackTechnique(&stratus.AttackTechnique{
+        ID:           AttackTechniqueId,
+        FriendlyName: "Launch unusual GCE instances",
+        Description: `
+Attempts to launch several unusual Compute Engine instances (` + string(instanceType) + `).
+
+Warm-up: 
+
+- Create an IAM role that doesn't have permissions to launch Compute instance (roles/compute.viewer). This ensures the attempts is not successful, and the attack technique is fast to detonate.
+- Assign caller with role 'roles/iam.serviceAccountTokenCreator' so it can impersonate service account.
+
+Detonation:
+
+- Attempts to launch several unusual Compute instances. The calls will fail as the IAM role doesn't have sufficient permissions.
+`,
+        Detection: `
+Attempt to launch compute instance is detected as 'compute.instances.insert' in Cloud Logging.
+
+` + CodeBlock + `json
+{
+  logName: "projects/my-project-id/logs/cloudaudit.googleapis.com%2Factivity",
+  protoPayload: {
+    authenticationInfo: {
+      principalEmail: "username@service.com"
+    }
+    methodName: "v1.compute.instances.insert"
+    resourceName: "projects/my-project-id/zones/my-zone-id/instances/my-instance-id"
+  }
+  resource: {
+    type: "gce_instance"
+  }
+  severity: "ERROR"
+}
+` + CodeBlock + `
+`,
+        Platform:                   stratus.GCP,
+        IsIdempotent:               true,
+        MitreAttackTactics:         []mitreattack.Tactic{ mitreattack.Execution },
+        PrerequisitesTerraformCode: tf,
+        Detonate:                   detonate,
+    })
+}
+
+func detonate(params map[string]string, providers stratus.CloudProviders) error {
+    gcp := providers.GCP()
+    ctx := context.Background()
+
+    log.Printf("Attempting to run up to %d instances of type ", numInstances)
+
+    hostName    := "stratusvm"
+    diskName    := "stratusvm-disk"
+
+    saEmail     := params["sa_email"]
+    zone        := params["zone"]
+    network     := params["network"]
+    subnet      := params["subnet"]
+
+    diskType    := fmt.Sprintf("projects/%s/zones/%s/diskTypes/pd-ssd", gcp.GetProjectId(), zone)
+    machineType := fmt.Sprintf("projects/%s/zones/%s/machineTypes/%s", gcp.GetProjectId(), zone, instanceType)
+    
+    log.Printf("Impersonating '%s' service account", saEmail)
+
+    // create the token for service account
+    token, err := impersonate.CredentialsTokenSource(ctx, impersonate.CredentialsConfig {
+        TargetPrincipal: saEmail,
+        Scopes: []string{
+            compute.CloudPlatformScope,
+            compute.ComputeScope,
+        },
+    })
+
+    service, err := compute.NewService(ctx, option.WithTokenSource(token))
+    if err != nil {
+        return fmt.Errorf("Failed to create compute service: %v", err)
+    }
+
+    log.Printf("Launching instance: zone='%s'", zone)
+
+    for idx := 0; idx < numInstances; idx++ {
+        // request for instance creation
+        req := &compute.Instance {
+            Name:           hostName,
+            Description:    "gcp.execution.gce-launch-unusual-instances SCENARIO",
+            MachineType:    machineType,
+            Disks:          []*compute.AttachedDisk {
+                {
+                    AutoDelete: true,
+                    Boot:       true,
+                    Type:       "PERSISTENT",
+                    InitializeParams: &compute.AttachedDiskInitializeParams {
+                        DiskName:    diskName,
+                        DiskType:    diskType,
+                        SourceImage: imageSource,
+                    },
+                },
+            },
+            NetworkInterfaces: []*compute.NetworkInterface {
+                {
+                    Network:    network,
+                    Subnetwork: subnet,
+                },
+            },
+        }
+
+        // attempt to create instance (should be failed) and err has value
+        if _, err := service.Instances.Insert(gcp.GetProjectId(), zone, req).Do(); err == nil {
+            return errors.New("expected to return an error")
+        // it should be forbidden because we don't have permission to create instance
+        } else if !strings.Contains(err.Error(), "forbidden") {
+            return errors.New("expected to return forbidden due to lack of permissions")
+        }
+
+        log.Printf("Launch-%d: Got a permission denied as expected\n", idx)
+    }
+
+    return nil
+}

--- a/v2/internal/attacktechniques/gcp/execution/gce-launch-unusual-instances/main.tf
+++ b/v2/internal/attacktechniques/gcp/execution/gce-launch-unusual-instances/main.tf
@@ -1,0 +1,87 @@
+terraform {
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 6.18.1"
+    }
+  }
+}
+
+provider "google" {
+  default_labels = {
+    stratus-red-team = "true"
+  }
+}
+
+locals {
+  resource_prefix = "stratus-red-team-lui"
+  region          = "us-east1"
+}
+
+resource "random_string" "suffix" {
+  special = false
+  length  = 16
+  min_lower = 16
+}
+
+data "google_project" "current" { }
+
+data "google_client_openid_userinfo" "whoami" { }
+
+data "google_compute_zones" "available" {
+  region  = local.region
+}
+
+resource "google_service_account" "launcher" {
+  account_id   = "stratus-sa-${random_string.suffix.result}"
+  display_name = "Instance Launcher (Stratus Red Team)"
+}
+
+resource "google_project_iam_binding" "binding" {
+  project = data.google_project.current.project_id
+  role    = "roles/compute.viewer"
+  members = [ "serviceAccount:${google_service_account.launcher.email}" ]
+}
+
+resource "google_project_iam_binding" "impersonator" {
+  project = data.google_project.current.project_id
+  role    = "roles/iam.serviceAccountTokenCreator"
+  members = [ "user:${data.google_client_openid_userinfo.whoami.email}" ]
+}
+
+resource "google_compute_network" "network" {
+  name  = "${local.resource_prefix}-vpc-${random_string.suffix.result}"
+  routing_mode  = "REGIONAL"
+  auto_create_subnetworks = false
+}
+
+resource "google_compute_subnetwork" "subnet" {
+  name          = "${local.resource_prefix}-subnet-${random_string.suffix.result}"
+  ip_cidr_range = "10.10.1.0/24"
+  network       = google_compute_network.network.id
+  region        = local.region
+}
+
+output "sa_email" {
+  value = google_service_account.launcher.email
+}
+
+output "sa_id" {
+  value = google_service_account.launcher.id
+}
+
+output "zone" {
+  value = data.google_compute_zones.available.names[0]
+}
+
+output "network" {
+  value = google_compute_network.network.id
+}
+
+output "subnet" {
+  value = google_compute_subnetwork.subnet.id
+}
+
+output "display" {
+  value = format("Service account '%s' ready for use", google_service_account.launcher.email)
+}

--- a/v2/internal/attacktechniques/main.go
+++ b/v2/internal/attacktechniques/main.go
@@ -55,6 +55,7 @@ import (
 	_ "github.com/datadog/stratus-red-team/v2/internal/attacktechniques/entra-id/persistence/hidden-au"
 	_ "github.com/datadog/stratus-red-team/v2/internal/attacktechniques/entra-id/persistence/new-application"
 	_ "github.com/datadog/stratus-red-team/v2/internal/attacktechniques/entra-id/persistence/restricted-au"
+	_ "github.com/datadog/stratus-red-team/v2/internal/attacktechniques/gcp/execution/gce-launch-unusual-instances"
 	_ "github.com/datadog/stratus-red-team/v2/internal/attacktechniques/gcp/exfiltration/share-compute-disk"
 	_ "github.com/datadog/stratus-red-team/v2/internal/attacktechniques/gcp/exfiltration/share-compute-image"
 	_ "github.com/datadog/stratus-red-team/v2/internal/attacktechniques/gcp/exfiltration/share-compute-snapshot"


### PR DESCRIPTION
### What does this PR do?

* add new technique: Launch unusual GCE instances

Similar to launch unusual EC2 instances technique. This technique will attempt to launch Compute instance on GCP.

### Motivation

This technique is developed as part of Grab's purple teaming activity and we want to share it so more people can get the benefit.

------

Co-authored-by: Satria Ady Pradana <xathrya@reversing.id>