### PR TITLE
Forward correlation ID in warmup to tag resources

### DIFF
--- a/v2/internal/attacktechniques/k8s/credential-access/steal-serviceaccount-token/main.tf
+++ b/v2/internal/attacktechniques/k8s/credential-access/steal-serviceaccount-token/main.tf
@@ -12,6 +12,7 @@ locals {
 
   base_labels = {
     "datadoghq.com/stratus-red-team" : true
+    "datadoghq.com/stratus-red-team-correlation-id" : var.correlation.id
   }
   custom_labels = var.config.kubernetes.pod.labels
   labels        = merge(local.base_labels, local.custom_labels)
@@ -55,7 +56,7 @@ resource "kubernetes_service_account" "serviceaccount" {
 
 resource "kubernetes_pod" "pod" {
   metadata {
-    name        = format("%s-pod", local.resource_prefix)
+    name        = format("%s-pod-%s", local.resource_prefix, var.correlation.id)
     labels      = local.labels
     annotations = var.config.kubernetes.pod.annotations
     namespace   = local.namespace

--- a/v2/internal/attacktechniques/k8s/credential-access/steal-serviceaccount-token/main.tf
+++ b/v2/internal/attacktechniques/k8s/credential-access/steal-serviceaccount-token/main.tf
@@ -56,7 +56,7 @@ resource "kubernetes_service_account" "serviceaccount" {
 
 resource "kubernetes_pod" "pod" {
   metadata {
-    name        = format("%s-pod-%s", local.resource_prefix, var.correlation.id)
+    name        = format("%s-pod", local.resource_prefix)
     labels      = local.labels
     annotations = var.config.kubernetes.pod.annotations
     namespace   = local.namespace

--- a/v2/internal/attacktechniques/k8s/credential-access/steal-serviceaccount-token/main.tf
+++ b/v2/internal/attacktechniques/k8s/credential-access/steal-serviceaccount-token/main.tf
@@ -13,6 +13,7 @@ locals {
   base_labels = {
     "datadoghq.com/stratus-red-team" : true
     "datadoghq.com/stratus-red-team-correlation-id" : var.correlation.id
+    "datadoghq.com/stratus-red-team-stage" : "warmup"
   }
   custom_labels = var.config.kubernetes.pod.labels
   labels        = merge(local.base_labels, local.custom_labels)

--- a/v2/internal/attacktechniques/k8s/privilege-escalation/hostpath-volume/main.go
+++ b/v2/internal/attacktechniques/k8s/privilege-escalation/hostpath-volume/main.go
@@ -89,6 +89,10 @@ func basePodSpec(namespace string, correlationID string) *v1.Pod {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      fmt.Sprintf("%s-%s", techniqueID, correlationID),
 			Namespace: namespace,
+			Labels: map[string]string{
+				"datadoghq.com/stratus-red-team":                "true",
+				"datadoghq.com/stratus-red-team-correlation-id": correlationID,
+			},
 		},
 		Spec: v1.PodSpec{
 			Containers: []v1.Container{

--- a/v2/internal/attacktechniques/k8s/privilege-escalation/hostpath-volume/main.go
+++ b/v2/internal/attacktechniques/k8s/privilege-escalation/hostpath-volume/main.go
@@ -91,6 +91,7 @@ func basePodSpec(namespace string, correlationID string) *v1.Pod {
 			Labels: map[string]string{
 				"datadoghq.com/stratus-red-team":                "true",
 				"datadoghq.com/stratus-red-team-correlation-id": correlationID,
+				"datadoghq.com/stratus-red-team-stage":          "detonation",
 			},
 		},
 		Spec: v1.PodSpec{

--- a/v2/internal/attacktechniques/k8s/privilege-escalation/hostpath-volume/main.go
+++ b/v2/internal/attacktechniques/k8s/privilege-escalation/hostpath-volume/main.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	_ "embed"
 	"errors"
-	"fmt"
 	"log"
 
 	"github.com/aws/smithy-go/ptr"
@@ -87,7 +86,7 @@ func revert(params map[string]string, providers stratus.CloudProviders) error {
 func basePodSpec(namespace string, correlationID string) *v1.Pod {
 	return &v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      fmt.Sprintf("%s-%s", techniqueID, correlationID),
+			Name:      techniqueID,
 			Namespace: namespace,
 			Labels: map[string]string{
 				"datadoghq.com/stratus-red-team":                "true",

--- a/v2/internal/attacktechniques/k8s/privilege-escalation/hostpath-volume/main.go
+++ b/v2/internal/attacktechniques/k8s/privilege-escalation/hostpath-volume/main.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	_ "embed"
 	"errors"
+	"fmt"
 	"log"
 
 	"github.com/aws/smithy-go/ptr"
@@ -51,7 +52,8 @@ Detonation:
 func detonate(params map[string]string, providers stratus.CloudProviders) error {
 	client := providers.K8s().GetClient()
 	namespace := params["namespace"]
-	podSpec := basePodSpec(namespace)
+	correlationID := providers.K8s().UniqueCorrelationId.String()
+	podSpec := basePodSpec(namespace, correlationID)
 
 	// Apply configuration overrides (image, tolerations, nodeSelector, securityContext)
 	providers.K8s().ApplyPodConfig(techniqueID, podSpec)
@@ -69,7 +71,8 @@ func detonate(params map[string]string, providers stratus.CloudProviders) error 
 func revert(params map[string]string, providers stratus.CloudProviders) error {
 	client := providers.K8s().GetClient()
 	namespace := params["namespace"]
-	podSpec := basePodSpec(namespace)
+	correlationID := providers.K8s().UniqueCorrelationId.String()
+	podSpec := basePodSpec(namespace, correlationID)
 
 	log.Println("Removing malicious pod " + podSpec.ObjectMeta.Name)
 	deleteOptions := metav1.DeleteOptions{GracePeriodSeconds: ptr.Int64(0)}
@@ -81,10 +84,10 @@ func revert(params map[string]string, providers stratus.CloudProviders) error {
 	return nil
 }
 
-func basePodSpec(namespace string) *v1.Pod {
+func basePodSpec(namespace string, correlationID string) *v1.Pod {
 	return &v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      techniqueID,
+			Name:      fmt.Sprintf("%s-%s", techniqueID, correlationID),
 			Namespace: namespace,
 		},
 		Spec: v1.PodSpec{

--- a/v2/internal/attacktechniques/k8s/privilege-escalation/hostpath-volume/main.tf
+++ b/v2/internal/attacktechniques/k8s/privilege-escalation/hostpath-volume/main.tf
@@ -29,8 +29,11 @@ resource "random_string" "suffix" {
 resource "kubernetes_namespace" "namespace" {
   count = local.create_namespace ? 1 : 0
   metadata {
-    name   = local.generated_ns_name
-    labels = { "datadoghq.com/stratus-red-team" : true }
+    name = local.generated_ns_name
+    labels = {
+      "datadoghq.com/stratus-red-team" : true
+      "datadoghq.com/stratus-red-team-correlation-id" : var.correlation.id
+    }
   }
 }
 

--- a/v2/internal/attacktechniques/k8s/privilege-escalation/hostpath-volume/main.tf
+++ b/v2/internal/attacktechniques/k8s/privilege-escalation/hostpath-volume/main.tf
@@ -33,6 +33,7 @@ resource "kubernetes_namespace" "namespace" {
     labels = {
       "datadoghq.com/stratus-red-team" : true
       "datadoghq.com/stratus-red-team-correlation-id" : var.correlation.id
+      "datadoghq.com/stratus-red-team-stage" : "warmup"
     }
   }
 }

--- a/v2/internal/attacktechniques/k8s/privilege-escalation/nodes-proxy/main.tf
+++ b/v2/internal/attacktechniques/k8s/privilege-escalation/nodes-proxy/main.tf
@@ -30,8 +30,11 @@ resource "random_string" "suffix" {
 resource "kubernetes_namespace" "namespace" {
   count = local.create_namespace ? 1 : 0
   metadata {
-    name   = local.generated_ns_name
-    labels = { "datadoghq.com/stratus-red-team" : true }
+    name = local.generated_ns_name
+    labels = {
+      "datadoghq.com/stratus-red-team" : true
+      "datadoghq.com/stratus-red-team-correlation-id" : var.correlation.id
+    }
   }
 }
 

--- a/v2/internal/attacktechniques/k8s/privilege-escalation/nodes-proxy/main.tf
+++ b/v2/internal/attacktechniques/k8s/privilege-escalation/nodes-proxy/main.tf
@@ -34,6 +34,7 @@ resource "kubernetes_namespace" "namespace" {
     labels = {
       "datadoghq.com/stratus-red-team" : true
       "datadoghq.com/stratus-red-team-correlation-id" : var.correlation.id
+      "datadoghq.com/stratus-red-team-stage" : "warmup"
     }
   }
 }

--- a/v2/internal/attacktechniques/k8s/privilege-escalation/privileged-pod/main.go
+++ b/v2/internal/attacktechniques/k8s/privilege-escalation/privileged-pod/main.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	_ "embed"
 	"errors"
+	"fmt"
 	"log"
 
 	"github.com/aws/smithy-go/ptr"
@@ -90,7 +91,8 @@ Sample event (shortened):
 func detonate(params map[string]string, providers stratus.CloudProviders) error {
 	client := providers.K8s().GetClient()
 	namespace := params["namespace"]
-	podSpec := basePodSpec(namespace)
+	correlationID := providers.K8s().UniqueCorrelationId.String()
+	podSpec := basePodSpec(namespace, correlationID)
 
 	// Apply configuration overrides (image, tolerations, nodeSelector, securityContext)
 	providers.K8s().ApplyPodConfig(techniqueID, podSpec)
@@ -110,7 +112,8 @@ func revert(params map[string]string, providers stratus.CloudProviders) error {
 	// Param retrieved from the Terraform output. If a namespace was defined in the config, it will
 	// be passed through terraform, otherwise it's the created namespace.
 	namespace := params["namespace"]
-	podSpec := basePodSpec(namespace)
+	correlationID := providers.K8s().UniqueCorrelationId.String()
+	podSpec := basePodSpec(namespace, correlationID)
 
 	log.Println("Removing privileged pod " + podSpec.ObjectMeta.Name)
 	deleteOptions := metav1.DeleteOptions{GracePeriodSeconds: ptr.Int64(0)}
@@ -122,10 +125,10 @@ func revert(params map[string]string, providers stratus.CloudProviders) error {
 	return nil
 }
 
-func basePodSpec(namespace string) *v1.Pod {
+func basePodSpec(namespace string, correlationID string) *v1.Pod {
 	return &v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      techniqueID,
+			Name:      fmt.Sprintf("%s-%s", techniqueID, correlationID),
 			Namespace: namespace,
 		},
 		Spec: v1.PodSpec{

--- a/v2/internal/attacktechniques/k8s/privilege-escalation/privileged-pod/main.go
+++ b/v2/internal/attacktechniques/k8s/privilege-escalation/privileged-pod/main.go
@@ -132,6 +132,7 @@ func basePodSpec(namespace string, correlationID string) *v1.Pod {
 			Labels: map[string]string{
 				"datadoghq.com/stratus-red-team":                "true",
 				"datadoghq.com/stratus-red-team-correlation-id": correlationID,
+				"datadoghq.com/stratus-red-team-stage":          "detonation",
 			},
 		},
 		Spec: v1.PodSpec{

--- a/v2/internal/attacktechniques/k8s/privilege-escalation/privileged-pod/main.go
+++ b/v2/internal/attacktechniques/k8s/privilege-escalation/privileged-pod/main.go
@@ -130,6 +130,10 @@ func basePodSpec(namespace string, correlationID string) *v1.Pod {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      fmt.Sprintf("%s-%s", techniqueID, correlationID),
 			Namespace: namespace,
+			Labels: map[string]string{
+				"datadoghq.com/stratus-red-team":                "true",
+				"datadoghq.com/stratus-red-team-correlation-id": correlationID,
+			},
 		},
 		Spec: v1.PodSpec{
 			Containers: []v1.Container{{

--- a/v2/internal/attacktechniques/k8s/privilege-escalation/privileged-pod/main.go
+++ b/v2/internal/attacktechniques/k8s/privilege-escalation/privileged-pod/main.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	_ "embed"
 	"errors"
-	"fmt"
 	"log"
 
 	"github.com/aws/smithy-go/ptr"
@@ -128,7 +127,7 @@ func revert(params map[string]string, providers stratus.CloudProviders) error {
 func basePodSpec(namespace string, correlationID string) *v1.Pod {
 	return &v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      fmt.Sprintf("%s-%s", techniqueID, correlationID),
+			Name:      techniqueID,
 			Namespace: namespace,
 			Labels: map[string]string{
 				"datadoghq.com/stratus-red-team":                "true",

--- a/v2/internal/attacktechniques/k8s/privilege-escalation/privileged-pod/main.tf
+++ b/v2/internal/attacktechniques/k8s/privilege-escalation/privileged-pod/main.tf
@@ -29,8 +29,11 @@ resource "random_string" "suffix" {
 resource "kubernetes_namespace" "namespace" {
   count = local.create_namespace ? 1 : 0
   metadata {
-    name   = local.generated_ns_name
-    labels = { "datadoghq.com/stratus-red-team" : true }
+    name = local.generated_ns_name
+    labels = {
+      "datadoghq.com/stratus-red-team" : true
+      "datadoghq.com/stratus-red-team-correlation-id" : var.correlation.id
+    }
   }
 }
 

--- a/v2/internal/attacktechniques/k8s/privilege-escalation/privileged-pod/main.tf
+++ b/v2/internal/attacktechniques/k8s/privilege-escalation/privileged-pod/main.tf
@@ -33,6 +33,7 @@ resource "kubernetes_namespace" "namespace" {
     labels = {
       "datadoghq.com/stratus-red-team" : true
       "datadoghq.com/stratus-red-team-correlation-id" : var.correlation.id
+      "datadoghq.com/stratus-red-team-stage" : "warmup"
     }
   }
 }

--- a/v2/internal/state/correlation.tf
+++ b/v2/internal/state/correlation.tf
@@ -1,0 +1,9 @@
+variable "correlation" {
+  description = "Correlation metadata for this detonation, used to tag resources for signal matching."
+  type = object({
+    id = optional(string, "")
+  })
+  default = {
+    id = ""
+  }
+}

--- a/v2/internal/state/state.go
+++ b/v2/internal/state/state.go
@@ -1,6 +1,7 @@
 package state
 
 import (
+	_ "embed"
 	"encoding/json"
 	"log"
 	"os"
@@ -10,6 +11,13 @@ import (
 	"github.com/datadog/stratus-red-team/v2/pkg/stratus"
 	"github.com/datadog/stratus-red-team/v2/pkg/stratus/config"
 )
+
+// sharedCorrelationVariable is the shared Terraform variable "correlation",
+// injected alongside technique main.tf files at warmup time. Techniques can
+// use var.correlation.id to embed the correlation ID in resource names.
+//
+//go:embed correlation.tf
+var sharedCorrelationVariable []byte
 
 const StratusStateTerraformOutputsFileName = ".terraform-outputs"
 const StratusStateTerraformVariablesFileName = ".terraform-variables"
@@ -101,9 +109,14 @@ func (m *FileSystemStateManager) ExtractTechnique() error {
 		return err
 	}
 
-	// Inject the shared config variable definition alongside the technique's main.tf
+	// Inject shared variable definitions alongside the technique's main.tf
 	configFile := filepath.Join(terraformDirectory, "config.tf")
 	if err := m.FileSystem.WriteFile(configFile, config.SharedTerraformConfigVariable, 0644); err != nil {
+		return err
+	}
+
+	correlationFile := filepath.Join(terraformDirectory, "correlation.tf")
+	if err := m.FileSystem.WriteFile(correlationFile, sharedCorrelationVariable, 0644); err != nil {
 		return err
 	}
 

--- a/v2/internal/state/state.go
+++ b/v2/internal/state/state.go
@@ -19,6 +19,27 @@ import (
 //go:embed correlation.tf
 var sharedCorrelationVariable []byte
 
+// TerraformCorrelationVarName is the key under which MarshalCorrelation's output
+// is passed to Terraform; matches the variable declared in correlation.tf.
+const TerraformCorrelationVarName = "correlation"
+
+// TerraformCorrelation mirrors the schema of the "correlation" Terraform variable
+// declared in correlation.tf. Keep the JSON tags in sync with that file.
+type TerraformCorrelation struct {
+	ID string `json:"id"`
+}
+
+// MarshalCorrelation returns the JSON-encoded value Terraform expects for var.correlation.
+func MarshalCorrelation(id string) string {
+	encoded, err := json.Marshal(TerraformCorrelation{ID: id})
+	if err != nil {
+		// json.Marshal of a struct with one string field cannot fail.
+		log.Println("unable to marshal correlation: " + err.Error())
+		return "{}"
+	}
+	return string(encoded)
+}
+
 const StratusStateTerraformOutputsFileName = ".terraform-outputs"
 const StratusStateTerraformVariablesFileName = ".terraform-variables"
 const StratusStateTechniqueStateFileName = ".state"

--- a/v2/internal/utils/aws_utils.go
+++ b/v2/internal/utils/aws_utils.go
@@ -35,15 +35,14 @@ func GetCurrentAccountId(cfg aws.Config) (string, error) {
 	return *result.Account, nil
 }
 
-func AwsConfigFromCredentials(accessKeyId string, secretAccessKey string, sessionToken string, detonationUid *uuid.UUID) aws.Config {
+func AwsConfigFromCredentials(accessKeyId string, secretAccessKey string, sessionToken string, correlationID *uuid.UUID) aws.Config {
 	options := []func(*config.LoadOptions) error{
 		config.WithCredentialsProvider(
 			credentials.NewStaticCredentialsProvider(accessKeyId, secretAccessKey, sessionToken),
 		),
 	}
-	if detonationUid != nil {
-		// propagate the detonation UID to the new provider
-		options = append(options, CustomUserAgentApiOptions(*detonationUid))
+	if correlationID != nil {
+		options = append(options, CustomUserAgentApiOptions(*correlationID))
 	}
 	cfg, err := config.LoadDefaultConfig(context.Background(), options...)
 

--- a/v2/pkg/stratus/runner/runner.go
+++ b/v2/pkg/stratus/runner/runner.go
@@ -3,7 +3,6 @@ package runner
 import (
 	"context"
 	"errors"
-	"fmt"
 	"log"
 	"os"
 	"path/filepath"
@@ -158,25 +157,21 @@ func NewRunnerWithContext(ctx context.Context, technique *stratus.AttackTechniqu
 func resolveCorrelationID() uuid.UUID {
 	raw := os.Getenv(EnvVarStratusRedTeamCorrelationId)
 	envName := EnvVarStratusRedTeamCorrelationId
-
 	if raw == "" {
-		raw = os.Getenv(EnvVarStratusRedTeamDetonationId)
-		envName = EnvVarStratusRedTeamDetonationId
-		if raw != "" {
+		if raw = os.Getenv(EnvVarStratusRedTeamDetonationId); raw != "" {
+			envName = EnvVarStratusRedTeamDetonationId
 			log.Printf("WARNING: %s is deprecated, use %s instead", EnvVarStratusRedTeamDetonationId, EnvVarStratusRedTeamCorrelationId)
 		}
 	}
-
-	if raw != "" {
-		log.Printf("%s is set, using it as the correlation ID", envName)
-		parsed, err := uuid.Parse(raw)
-		if err != nil {
-			log.Printf("%s is not a valid UUID, falling back to a randomly-generated one: %s", envName, err.Error())
-			return uuid.New()
-		}
-		return parsed
+	if raw == "" {
+		return uuid.New()
 	}
-	return uuid.New()
+	parsed, err := uuid.Parse(raw)
+	if err != nil {
+		log.Printf("%s is not a valid UUID, using a random one: %s", envName, err.Error())
+		return uuid.New()
+	}
+	return parsed
 }
 
 func (m *runnerImpl) initialize() {
@@ -222,7 +217,7 @@ func (m *runnerImpl) WarmUp() (map[string]string, error) {
 	}
 
 	log.Println("Warming up " + m.Technique.ID)
-	overrideVars := m.getTerraformVariablesFromConfig()
+	overrideVars := m.buildTerraformVariables()
 	outputs, err := m.TerraformManager.TerraformInitAndApply(m.TerraformDir, overrideVars)
 	if err != nil {
 		log.Println("Error during warm up. Cleaning up technique prerequisites with terraform destroy")
@@ -395,14 +390,14 @@ func (m *runnerImpl) GetUniqueExecutionId() string {
 	return m.UniqueCorrelationID.String()
 }
 
-// getTerraformVariablesFromConfig returns the terraform variables to use,
+// buildTerraformVariables returns the terraform variables to use,
 // including the correlation metadata and any config-file overrides.
-func (m *runnerImpl) getTerraformVariablesFromConfig() map[string]string {
+func (m *runnerImpl) buildTerraformVariables() map[string]string {
 	vars := m.Config.GetTerraformVariables(m.Technique.ID)
 	if vars == nil {
 		vars = make(map[string]string)
 	}
-	vars["correlation"] = fmt.Sprintf(`{"id":"%s"}`, m.UniqueCorrelationID.String())
+	vars[state.TerraformCorrelationVarName] = state.MarshalCorrelation(m.UniqueCorrelationID.String())
 	return vars
 }
 

--- a/v2/pkg/stratus/runner/runner.go
+++ b/v2/pkg/stratus/runner/runner.go
@@ -3,6 +3,7 @@ package runner
 import (
 	"context"
 	"errors"
+	"fmt"
 	"log"
 	"os"
 	"path/filepath"
@@ -22,6 +23,9 @@ type S3BackendConfig = state.S3BackendConfig
 const StratusRunnerForce = true
 const StratusRunnerNoForce = false
 
+const EnvVarStratusRedTeamCorrelationId = "STRATUS_RED_TEAM_CORRELATION_ID"
+
+// Deprecated: Use EnvVarStratusRedTeamCorrelationId instead.
 const EnvVarStratusRedTeamDetonationId = "STRATUS_RED_TEAM_DETONATION_ID"
 
 // Use an existing terraform binary path instead of letting the runner download it.
@@ -149,13 +153,25 @@ func NewRunnerWithContext(ctx context.Context, technique *stratus.AttackTechniqu
 }
 
 // resolveCorrelationID returns the correlation ID from the environment variable
-// STRATUS_RED_TEAM_DETONATION_ID if set and valid, otherwise generates a new one.
+// STRATUS_RED_TEAM_CORRELATION_ID (or the deprecated STRATUS_RED_TEAM_DETONATION_ID)
+// if set and valid, otherwise generates a new one.
 func resolveCorrelationID() uuid.UUID {
-	if raw := os.Getenv(EnvVarStratusRedTeamDetonationId); raw != "" {
-		log.Printf("%s is set, using it as the correlation ID", EnvVarStratusRedTeamDetonationId)
+	raw := os.Getenv(EnvVarStratusRedTeamCorrelationId)
+	envName := EnvVarStratusRedTeamCorrelationId
+
+	if raw == "" {
+		raw = os.Getenv(EnvVarStratusRedTeamDetonationId)
+		envName = EnvVarStratusRedTeamDetonationId
+		if raw != "" {
+			log.Printf("WARNING: %s is deprecated, use %s instead", EnvVarStratusRedTeamDetonationId, EnvVarStratusRedTeamCorrelationId)
+		}
+	}
+
+	if raw != "" {
+		log.Printf("%s is set, using it as the correlation ID", envName)
 		parsed, err := uuid.Parse(raw)
 		if err != nil {
-			log.Printf("%s is not a valid UUID, falling back to a randomly-generated one: %s", EnvVarStratusRedTeamDetonationId, err.Error())
+			log.Printf("%s is not a valid UUID, falling back to a randomly-generated one: %s", envName, err.Error())
 			return uuid.New()
 		}
 		return parsed
@@ -379,9 +395,15 @@ func (m *runnerImpl) GetUniqueExecutionId() string {
 	return m.UniqueCorrelationID.String()
 }
 
-// getTerraformVariablesFromConfig returns the terraform variables to use from the config file
+// getTerraformVariablesFromConfig returns the terraform variables to use,
+// including the correlation metadata and any config-file overrides.
 func (m *runnerImpl) getTerraformVariablesFromConfig() map[string]string {
-	return m.Config.GetTerraformVariables(m.Technique.ID)
+	vars := m.Config.GetTerraformVariables(m.Technique.ID)
+	if vars == nil {
+		vars = make(map[string]string)
+	}
+	vars["correlation"] = fmt.Sprintf(`{"id":"%s"}`, m.UniqueCorrelationID.String())
+	return vars
 }
 
 // Utility function to display better error messages than the Terraform ones

--- a/v2/pkg/stratus/runner/runner_test.go
+++ b/v2/pkg/stratus/runner/runner_test.go
@@ -51,7 +51,7 @@ func TestRunnerWarmUp(t *testing.T) {
 			TerraformOutputs:      map[string]string{"myoutput": "new"},
 			CheckExpectations: func(t *testing.T, terraform *mocks.TerraformManager, state *statemocks.StateManager, outputs map[string]string, err error) {
 				state.AssertCalled(t, "ExtractTechnique")
-				terraform.AssertCalled(t, "TerraformInitAndApply", "/root/foo", map[string]string{})
+				terraform.AssertCalled(t, "TerraformInitAndApply", "/root/foo", mock.MatchedBy(func(vars map[string]string) bool { return vars["correlation"] == `{"id":"11111111-2222-3333-4444-555555555555"}` }))
 				state.AssertCalled(t, "WriteTerraformOutputs", map[string]string{"myoutput": "new"})
 				state.AssertCalled(t, "SetTechniqueState", stratus.AttackTechniqueState(stratus.AttackTechniqueStatusWarm))
 				state.AssertNotCalled(t, "CleanupTechnique")
@@ -80,7 +80,7 @@ func TestRunnerWarmUp(t *testing.T) {
 			InitialTechniqueState: stratus.AttackTechniqueStatusWarm,
 			TerraformOutputs:      map[string]string{"myoutput": "old"},
 			CheckExpectations: func(t *testing.T, terraform *mocks.TerraformManager, state *statemocks.StateManager, outputs map[string]string, err error) {
-				terraform.AssertCalled(t, "TerraformInitAndApply", "/root/foo", map[string]string{})
+				terraform.AssertCalled(t, "TerraformInitAndApply", "/root/foo", mock.MatchedBy(func(vars map[string]string) bool { return vars["correlation"] == `{"id":"11111111-2222-3333-4444-555555555555"}` }))
 				assert.Nil(t, err)
 				assert.Len(t, outputs, 1)
 				assert.Equal(t, "old", outputs["myoutput"])
@@ -104,8 +104,8 @@ func TestRunnerWarmUp(t *testing.T) {
 			InitialTechniqueState: stratus.AttackTechniqueStatusCold,
 			Error:                 errors.New("error during init and apply"),
 			CheckExpectations: func(t *testing.T, terraform *mocks.TerraformManager, state *statemocks.StateManager, outputs map[string]string, err error) {
-				terraform.AssertCalled(t, "TerraformInitAndApply", "/root/foo", map[string]string{})
-				terraform.AssertCalled(t, "TerraformDestroy", "/root/foo", map[string]string{})
+				terraform.AssertCalled(t, "TerraformInitAndApply", "/root/foo", mock.MatchedBy(func(vars map[string]string) bool { return vars["correlation"] == `{"id":"11111111-2222-3333-4444-555555555555"}` }))
+				terraform.AssertCalled(t, "TerraformDestroy", "/root/foo", mock.MatchedBy(func(vars map[string]string) bool { return vars["correlation"] == `{"id":"11111111-2222-3333-4444-555555555555"}` }))
 				state.AssertCalled(t, "CleanupTechnique")
 				assert.NotNil(t, err)
 				assert.Len(t, outputs, 0)
@@ -126,15 +126,17 @@ func TestRunnerWarmUp(t *testing.T) {
 		terraform.On("TerraformInitAndApply", mock.Anything, mock.Anything).Return(scenario[i].TerraformOutputs, scenario[i].Error)
 		terraform.On("TerraformDestroy", mock.Anything, mock.Anything).Return(nil)
 		state.On("WriteTerraformOutputs", mock.Anything).Return(nil)
+		state.On("WriteTerraformVariables", mock.Anything).Return(nil)
 		state.On("SetTechniqueState", mock.Anything).Return(nil)
 		state.On("CleanupTechnique").Return(nil)
 
 		runner := runnerImpl{
-			Technique:        scenario[i].Technique,
-			ShouldForce:      scenario[i].ShouldForce,
-			Config:           config,
-			TerraformManager: terraform,
-			StateManager:     state,
+			Technique:           scenario[i].Technique,
+			ShouldForce:         scenario[i].ShouldForce,
+			Config:              config,
+			TerraformManager:    terraform,
+			StateManager:        state,
+			UniqueCorrelationID: uuid.MustParse("11111111-2222-3333-4444-555555555555"),
 		}
 		runner.initialize()
 		outputs, err := runner.WarmUp()
@@ -220,11 +222,13 @@ func TestRunnerDetonate(t *testing.T) {
 			state.On("GetTechniqueState", mock.Anything).Return(scenario[i].TechniqueState, nil)
 			terraform.On("TerraformInitAndApply", mock.Anything, mock.Anything).Return(map[string]string{}, nil)
 			state.On("WriteTerraformOutputs", mock.Anything).Return(nil)
+			state.On("WriteTerraformVariables", mock.Anything).Return(nil)
 			state.On("GetTerraformOutputs").Return(map[string]string{}, nil)
 			state.On("SetTechniqueState", mock.Anything).Return(nil)
 
 			var wasDetonated = false
 			runner := runnerImpl{
+				UniqueCorrelationID: uuid.MustParse("11111111-2222-3333-4444-555555555555"),
 				Technique: &stratus.AttackTechnique{
 					ID: "sample-technique",
 					Detonate: func(map[string]string, stratus.CloudProviders) error {
@@ -532,6 +536,7 @@ func TestNewRunnerWithProviderFactory(t *testing.T) {
 	stateMock.On("GetTerraformOutputs").Return(map[string]string{}, nil)
 	stateMock.On("SetTechniqueState", mock.Anything).Return(nil)
 	stateMock.On("WriteTerraformOutputs", mock.Anything).Return(nil)
+	stateMock.On("WriteTerraformVariables", mock.Anything).Return(nil)
 	configMock.On("GetTerraformVariables", mock.Anything).Return(map[string]string{})
 	tfMock.On("TerraformInitAndApply", mock.Anything, mock.Anything).Return(map[string]string{}, nil)
 
@@ -568,6 +573,7 @@ func TestProviderCredentialInjection(t *testing.T) {
 	stateMock.On("GetTerraformOutputs").Return(map[string]string{}, nil)
 	stateMock.On("SetTechniqueState", mock.Anything).Return(nil)
 	stateMock.On("WriteTerraformOutputs", mock.Anything).Return(nil)
+	stateMock.On("WriteTerraformVariables", mock.Anything).Return(nil)
 	configMock.On("GetTerraformVariables", mock.Anything).Return(map[string]string{})
 	tfMock.On("TerraformInitAndApply", mock.Anything, mock.Anything).Return(map[string]string{}, nil)
 

--- a/v2/pkg/stratus/runner/runner_test.go
+++ b/v2/pkg/stratus/runner/runner_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/datadog/stratus-red-team/v2/internal/state"
 	statemocks "github.com/datadog/stratus-red-team/v2/internal/state/mocks"
 	"github.com/datadog/stratus-red-team/v2/pkg/stratus"
 	configmocks "github.com/datadog/stratus-red-team/v2/pkg/stratus/config/mocks"
@@ -14,6 +15,15 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )
+
+const testCorrelationID = "11111111-2222-3333-4444-555555555555"
+
+func varsHaveCorrelation(id string) any {
+	expected := state.MarshalCorrelation(id)
+	return mock.MatchedBy(func(vars map[string]string) bool {
+		return vars[state.TerraformCorrelationVarName] == expected
+	})
+}
 
 func TestRunnerWarmUp(t *testing.T) {
 
@@ -51,7 +61,7 @@ func TestRunnerWarmUp(t *testing.T) {
 			TerraformOutputs:      map[string]string{"myoutput": "new"},
 			CheckExpectations: func(t *testing.T, terraform *mocks.TerraformManager, state *statemocks.StateManager, outputs map[string]string, err error) {
 				state.AssertCalled(t, "ExtractTechnique")
-				terraform.AssertCalled(t, "TerraformInitAndApply", "/root/foo", mock.MatchedBy(func(vars map[string]string) bool { return vars["correlation"] == `{"id":"11111111-2222-3333-4444-555555555555"}` }))
+				terraform.AssertCalled(t, "TerraformInitAndApply", "/root/foo", varsHaveCorrelation(testCorrelationID))
 				state.AssertCalled(t, "WriteTerraformOutputs", map[string]string{"myoutput": "new"})
 				state.AssertCalled(t, "SetTechniqueState", stratus.AttackTechniqueState(stratus.AttackTechniqueStatusWarm))
 				state.AssertNotCalled(t, "CleanupTechnique")
@@ -80,7 +90,7 @@ func TestRunnerWarmUp(t *testing.T) {
 			InitialTechniqueState: stratus.AttackTechniqueStatusWarm,
 			TerraformOutputs:      map[string]string{"myoutput": "old"},
 			CheckExpectations: func(t *testing.T, terraform *mocks.TerraformManager, state *statemocks.StateManager, outputs map[string]string, err error) {
-				terraform.AssertCalled(t, "TerraformInitAndApply", "/root/foo", mock.MatchedBy(func(vars map[string]string) bool { return vars["correlation"] == `{"id":"11111111-2222-3333-4444-555555555555"}` }))
+				terraform.AssertCalled(t, "TerraformInitAndApply", "/root/foo", varsHaveCorrelation(testCorrelationID))
 				assert.Nil(t, err)
 				assert.Len(t, outputs, 1)
 				assert.Equal(t, "old", outputs["myoutput"])
@@ -104,8 +114,8 @@ func TestRunnerWarmUp(t *testing.T) {
 			InitialTechniqueState: stratus.AttackTechniqueStatusCold,
 			Error:                 errors.New("error during init and apply"),
 			CheckExpectations: func(t *testing.T, terraform *mocks.TerraformManager, state *statemocks.StateManager, outputs map[string]string, err error) {
-				terraform.AssertCalled(t, "TerraformInitAndApply", "/root/foo", mock.MatchedBy(func(vars map[string]string) bool { return vars["correlation"] == `{"id":"11111111-2222-3333-4444-555555555555"}` }))
-				terraform.AssertCalled(t, "TerraformDestroy", "/root/foo", mock.MatchedBy(func(vars map[string]string) bool { return vars["correlation"] == `{"id":"11111111-2222-3333-4444-555555555555"}` }))
+				terraform.AssertCalled(t, "TerraformInitAndApply", "/root/foo", varsHaveCorrelation(testCorrelationID))
+				terraform.AssertCalled(t, "TerraformDestroy", "/root/foo", varsHaveCorrelation(testCorrelationID))
 				state.AssertCalled(t, "CleanupTechnique")
 				assert.NotNil(t, err)
 				assert.Len(t, outputs, 0)
@@ -136,7 +146,7 @@ func TestRunnerWarmUp(t *testing.T) {
 			Config:              config,
 			TerraformManager:    terraform,
 			StateManager:        state,
-			UniqueCorrelationID: uuid.MustParse("11111111-2222-3333-4444-555555555555"),
+			UniqueCorrelationID: uuid.MustParse(testCorrelationID),
 		}
 		runner.initialize()
 		outputs, err := runner.WarmUp()
@@ -228,7 +238,7 @@ func TestRunnerDetonate(t *testing.T) {
 
 			var wasDetonated = false
 			runner := runnerImpl{
-				UniqueCorrelationID: uuid.MustParse("11111111-2222-3333-4444-555555555555"),
+				UniqueCorrelationID: uuid.MustParse(testCorrelationID),
 				Technique: &stratus.AttackTechnique{
 					ID: "sample-technique",
 					Detonate: func(map[string]string, stratus.CloudProviders) error {
@@ -519,7 +529,7 @@ func TestNewRunnerWithProviderFactory(t *testing.T) {
 	stateMock.On("GetTechniqueState").Return(stratus.AttackTechniqueState(stratus.AttackTechniqueStatusCold))
 
 	customProviders := stratus.CloudProvidersImpl{
-		UniqueCorrelationID: uuid.MustParse("11111111-2222-3333-4444-555555555555"),
+		UniqueCorrelationID: uuid.MustParse(testCorrelationID),
 	}
 
 	technique := &stratus.AttackTechnique{


### PR DESCRIPTION
### What does this PR do?

<!--
* New attack technique
* Bug fix
* Enhancement
-->

Enhancement:
- Make the correlation ID accessible within the terraform warmup step to tag resources with it
- In K8S attacks that generate resources at detonation time, tag them with the stratus label & detonation id

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

Ease tracking of resources & finding associated signals when using [Threatest](https://github.com/DataDog/threatest)

### QA

Tested with the "steal SA token" attack:
<img width="463" height="33" alt="image" src="https://github.com/user-attachments/assets/e7921391-2c45-4402-97e9-06a336c3a5d3" />

