### PR TITLE
Cleanup leftover files on warmup failure

### DIFF
--- a/v2/pkg/stratus/runner/runner.go
+++ b/v2/pkg/stratus/runner/runner.go
@@ -211,6 +211,13 @@ func (m *runnerImpl) WarmUp() (map[string]string, error) {
 	if err != nil {
 		log.Println("Error during warm up. Cleaning up technique prerequisites with terraform destroy")
 		_ = m.TerraformManager.TerraformDestroy(m.TerraformDir, overrideVars)
+		// Drop the technique directory and any managed artifacts so a failed
+		// warm-up does not leak a terraform.tfstate: on warmup failure TF sets
+		// the `resource` key of the tfstate file to an empty array but doesn't
+		// delete it.
+		if cleanupErr := m.StateManager.CleanupTechnique(); cleanupErr != nil {
+			log.Println("Warning: failed to remove technique state after failed warm up: " + cleanupErr.Error())
+		}
 		if errors.Is(err, context.Canceled) {
 			return nil, err
 		}

--- a/v2/pkg/stratus/runner/runner_test.go
+++ b/v2/pkg/stratus/runner/runner_test.go
@@ -54,6 +54,7 @@ func TestRunnerWarmUp(t *testing.T) {
 				terraform.AssertCalled(t, "TerraformInitAndApply", "/root/foo", map[string]string{})
 				state.AssertCalled(t, "WriteTerraformOutputs", map[string]string{"myoutput": "new"})
 				state.AssertCalled(t, "SetTechniqueState", stratus.AttackTechniqueState(stratus.AttackTechniqueStatusWarm))
+				state.AssertNotCalled(t, "CleanupTechnique")
 
 				assert.Nil(t, err)
 				assert.Len(t, outputs, 1)
@@ -105,6 +106,7 @@ func TestRunnerWarmUp(t *testing.T) {
 			CheckExpectations: func(t *testing.T, terraform *mocks.TerraformManager, state *statemocks.StateManager, outputs map[string]string, err error) {
 				terraform.AssertCalled(t, "TerraformInitAndApply", "/root/foo", map[string]string{})
 				terraform.AssertCalled(t, "TerraformDestroy", "/root/foo", map[string]string{})
+				state.AssertCalled(t, "CleanupTechnique")
 				assert.NotNil(t, err)
 				assert.Len(t, outputs, 0)
 			},
@@ -125,6 +127,7 @@ func TestRunnerWarmUp(t *testing.T) {
 		terraform.On("TerraformDestroy", mock.Anything, mock.Anything).Return(nil)
 		state.On("WriteTerraformOutputs", mock.Anything).Return(nil)
 		state.On("SetTechniqueState", mock.Anything).Return(nil)
+		state.On("CleanupTechnique").Return(nil)
 
 		runner := runnerImpl{
 			Technique:        scenario[i].Technique,


### PR DESCRIPTION
### What does this PR do?

<!--
* New attack technique
* Bug fix
* Enhancement
-->

Bug Fix:

If the terraform apply step of the warmup fails in the middle (because the scheduling of a pod is blocked for instance), terraform will 'empty' the tfstate but will not delete the file. When using the remote state feature with an S3 bucket, it can clutter the view with attacks.

This change calls the state cleanup action on warmup failure to make sure all the files are deleted.
