### PR TITLE
Add pod annotations to config

### DIFF
--- a/v2/internal/attacktechniques/k8s/credential-access/steal-serviceaccount-token/main.tf
+++ b/v2/internal/attacktechniques/k8s/credential-access/steal-serviceaccount-token/main.tf
@@ -55,9 +55,10 @@ resource "kubernetes_service_account" "serviceaccount" {
 
 resource "kubernetes_pod" "pod" {
   metadata {
-    name      = format("%s-pod", local.resource_prefix)
-    labels    = local.labels
-    namespace = local.namespace
+    name        = format("%s-pod", local.resource_prefix)
+    labels      = local.labels
+    annotations = var.config.kubernetes.pod.annotations
+    namespace   = local.namespace
   }
   spec {
     service_account_name = kubernetes_service_account.serviceaccount.metadata[0].name

--- a/v2/pkg/stratus/config/config.go
+++ b/v2/pkg/stratus/config/config.go
@@ -15,7 +15,17 @@ const (
 	StratusBaseDirectoryName = ".stratus-red-team"
 	ConfigFileName           = "config.yaml"
 	ConfigEnvVar             = "STRATUS_CONFIG_PATH"
+
+	// keyDelimiter is the Viper path separator. The default "." would split keys
+	// like "app.kubernetes.io/name" inside annotations/labels into nested maps.
+	keyDelimiter = "::"
 )
+
+// newViper returns a Viper instance configured with a non-dot key delimiter so
+// that keys containing dots (common in k8s annotations and labels) are not split.
+func newViper() *viper.Viper {
+	return viper.NewWithOptions(viper.KeyDelimiter(keyDelimiter))
+}
 
 // Config is the root configuration structure.
 //
@@ -35,7 +45,7 @@ var _ Config = &ConfigImpl{}
 
 // LoadConfig loads configuration from file.
 func LoadConfig() (Config, error) {
-	v := viper.New()
+	v := newViper()
 	configPath := getConfigPath()
 	if configPath != "" {
 		rawYAML, err := os.ReadFile(configPath)
@@ -92,7 +102,7 @@ func (c *ConfigImpl) GetKubernetesConfig() KubernetesConfig {
 // buildMergedViper produces a Viper containing the merged technique config.
 // Each provider populates its own subtree via populateViperOverride.
 func (c *ConfigImpl) buildMergedViper(techniqueID string) *viper.Viper {
-	v := viper.New()
+	v := newViper()
 	if c == nil || c.kubernetes == nil {
 		return v
 	}

--- a/v2/pkg/stratus/config/config.schema.json
+++ b/v2/pkg/stratus/config/config.schema.json
@@ -36,6 +36,10 @@
                     "type": "object",
                     "additionalProperties": { "type": "string" }
                 },
+                "annotations": {
+                    "type": "object",
+                    "additionalProperties": { "type": "string" }
+                },
                 "tolerations": {
                     "type": "array",
                     "items": { "type": "object" }

--- a/v2/pkg/stratus/config/config.tf
+++ b/v2/pkg/stratus/config/config.tf
@@ -3,26 +3,30 @@ variable "config" {
     kubernetes = object({
       namespace = optional(string, "")
       pod = optional(object({
-        image         = optional(string, "")
-        labels        = optional(map(string), {})
-        node_selector = optional(map(string), {})
+        image            = optional(string, "")
+        labels           = optional(map(string), {})
+        annotations      = optional(map(string), {})
+        node_selector    = optional(map(string), {})
+        security_context = optional(any, {})
         tolerations = optional(list(object({
           key      = string
           operator = string
           value    = string
           effect   = string
         })), [])
-      }), { image = "", labels = {}, node_selector = {}, tolerations = [] })
+      }), { image = "", labels = {}, annotations = {}, node_selector = {}, security_context = {}, tolerations = [] })
     })
   })
   default = {
     kubernetes = {
       namespace = ""
       pod = {
-        image         = ""
-        labels        = {}
-        node_selector = {}
-        tolerations   = []
+        image            = ""
+        labels           = {}
+        annotations      = {}
+        node_selector    = {}
+        security_context = {}
+        tolerations      = []
       }
     }
   }

--- a/v2/pkg/stratus/config/config_test.go
+++ b/v2/pkg/stratus/config/config_test.go
@@ -5,15 +5,50 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
+// TestKeyDelimiter documents the "::" Viper key delimiter used package-wide.
+// Paths are joined with keyDelimiter ("::"). Dotted technique IDs (e.g.
+// "k8s.privilege-escalation.privileged-pod") and dotted annotation/label keys
+// (e.g. "app.kubernetes.io/name") are each a single literal segment, not nested
+// map levels.
+func TestKeyDelimiter(t *testing.T) {
+	v := newViper()
+	v.SetConfigType("yaml")
+	require.NoError(t, v.ReadConfig(strings.NewReader(`
+kubernetes:
+  techniques:
+    "k8s.privilege-escalation.privileged-pod":
+      pod:
+        annotations:
+          app.kubernetes.io/name: hello
+`)))
+
+	// Build a deep path through Viper whose 3rd and 6th segments contain dots.
+	// With keyDelimiter == "::", neither dot is treated as a separator.
+	path := strings.Join([]string{
+		"kubernetes",
+		"techniques",
+		"k8s.privilege-escalation.privileged-pod",
+		"pod",
+		"annotations",
+		"app.kubernetes.io/name",
+	}, keyDelimiter)
+
+	assert.Equal(t,
+		"kubernetes::techniques::k8s.privilege-escalation.privileged-pod::pod::annotations::app.kubernetes.io/name",
+		path,
+		"sanity check: keyDelimiter joins literal segments without altering them")
+
+	assert.Equal(t, "hello", v.GetString(path))
+}
+
 // newTestConfig builds a ConfigImpl from a YAML string, mirroring how LoadConfig
 // works when reading from a file.
 func newTestConfig(yamlStr string) *ConfigImpl {
-	v := viper.New()
+	v := newViper()
 	v.SetConfigType("yaml")
 	_ = v.ReadConfig(strings.NewReader(yamlStr))
 	return &ConfigImpl{kubernetes: &KubernetesConfigImpl{v: v}, v: v}

--- a/v2/pkg/stratus/config/kubernetes.go
+++ b/v2/pkg/stratus/config/kubernetes.go
@@ -23,13 +23,13 @@ var _ KubernetesConfig = &KubernetesConfigImpl{}
 // It deep-merges the default settings with technique-specific overrides. Technique values
 // take precedence, but unset keys fall through to the default.
 func (k *KubernetesConfigImpl) populateViperOverride(src *viper.Viper, dst *viper.Viper, techniqueID string) {
-	defaultRaw := src.Get("kubernetes.default")
+	defaultRaw := src.Get("kubernetes" + keyDelimiter + "default")
 	if defaultRaw == nil {
 		return
 	}
 
 	merged := toStringMap(defaultRaw)
-	if techniqueRaw := src.Get("kubernetes.techniques." + techniqueID); techniqueRaw != nil {
+	if techniqueRaw := src.Get("kubernetes" + keyDelimiter + "techniques" + keyDelimiter + techniqueID); techniqueRaw != nil {
 		deepMerge(merged, toStringMap(techniqueRaw))
 	}
 
@@ -70,11 +70,11 @@ func (k *KubernetesConfigImpl) GetTechniquePodConfig(techniqueID string) K8sPodC
 	if k == nil || k.v == nil {
 		return K8sPodConfig{}
 	}
-	merged := viper.New()
+	merged := newViper()
 	k.populateViperOverride(k.v, merged, techniqueID)
 
 	var podConfig K8sPodConfig
-	if sub := merged.Sub("kubernetes.pod"); sub != nil {
+	if sub := merged.Sub("kubernetes" + keyDelimiter + "pod"); sub != nil {
 		if err := sub.Unmarshal(&podConfig); err != nil {
 			log.Println("unable to unmarshal pod config: " + err.Error())
 		}
@@ -86,6 +86,7 @@ func (k *KubernetesConfigImpl) GetTechniquePodConfig(techniqueID string) K8sPodC
 type K8sPodConfig struct {
 	Image       string            `yaml:"image"`
 	Labels      map[string]string `yaml:"labels"`
+	Annotations map[string]string `yaml:"annotations"`
 	Tolerations []v1.Toleration   `yaml:"tolerations"`
 	NodeSelector    map[string]string   `yaml:"node_selector"`
 	SecurityContext *v1.SecurityContext `yaml:"security_context"`
@@ -106,6 +107,13 @@ func (c *K8sPodConfig) ApplyToPod(pod *v1.Pod) {
 			pod.ObjectMeta.Labels = make(map[string]string)
 		}
 		maps.Copy(pod.ObjectMeta.Labels, c.Labels)
+	}
+
+	if len(c.Annotations) > 0 {
+		if pod.ObjectMeta.Annotations == nil {
+			pod.ObjectMeta.Annotations = make(map[string]string)
+		}
+		maps.Copy(pod.ObjectMeta.Annotations, c.Annotations)
 	}
 
 	if len(c.Tolerations) > 0 {

--- a/v2/pkg/stratus/config/kubernetes_test.go
+++ b/v2/pkg/stratus/config/kubernetes_test.go
@@ -53,6 +53,29 @@ kubernetes:
 			},
 		},
 		{
+			name: "annotations-merge-with-technique-override",
+			yaml: `
+kubernetes:
+  default:
+    pod:
+      annotations:
+        app.kubernetes.io/name: stratus
+        app.kubernetes.io/managed-by: default
+  techniques:
+    "k8s.test.technique":
+      pod:
+        annotations:
+          app.kubernetes.io/managed-by: technique
+`,
+			techniqueID: "k8s.test.technique",
+			expected: K8sPodConfig{
+				Annotations: map[string]string{
+					"app.kubernetes.io/name":       "stratus",
+					"app.kubernetes.io/managed-by": "technique",
+				},
+			},
+		},
+		{
 			name: "technique-override-merges-with-default",
 			yaml: `
 kubernetes:
@@ -85,8 +108,8 @@ kubernetes:
 			},
 		},
 		{
-			name: "no-config",
-			yaml: ``,
+			name:        "no-config",
+			yaml:        ``,
 			techniqueID: "k8s.test.technique",
 			expected:    K8sPodConfig{},
 		},

--- a/v2/pkg/stratus/config/validate_test.go
+++ b/v2/pkg/stratus/config/validate_test.go
@@ -36,6 +36,8 @@ kubernetes:
       image: busybox:latest
       labels:
         app: stratus
+      annotations:
+        app.kubernetes.io/managed-by: stratus
       tolerations:
         - key: dedicated
           operator: Equal
@@ -54,6 +56,16 @@ kubernetes:
         image: custom.registry.io/custom-2:latest
 `,
 			wantError: false,
+		},
+		{
+			name: "wrong-type-for-annotations",
+			yaml: `
+kubernetes:
+  default:
+    pod:
+      annotations: "not-a-map"
+`,
+			wantError: true,
 		},
 		{
 			name: "unknown-top-level-key",


### PR DESCRIPTION
### What does this PR do?

<!--
* New attack technique
* Bug fix
* Enhancement
-->

Enhancement: Add a way to control pod _annotations_ from the config files

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

Add annotations, that are sometimes used by monitoring system for alert tagging (for instance, Datadog's [tag autodiscovery](https://docs.datadoghq.com/containers/kubernetes/tag/?tab=datadogoperator#tag-autodiscovery)) 

### Checklist

 Launched a pod with the config
 ```yaml
kubernetes:
  default:
    pod:
      annotations:
        ad.datadoghq.com/tags: '{"datadoghq.com/stratus-red-team" : true }'
```
and the pod did have the annotation
