### PR TITLE
Add template variables mechanism in config

### DIFF
--- a/docs/user-guide/getting-started.md
+++ b/docs/user-guide/getting-started.md
@@ -226,8 +226,21 @@ This is currently used for Kubernetes techniques and allows you to:
 - **Add labels** to pods (for attribution, CNP policy selectors, monitoring, etc.)
 - **Add tolerations and node selectors** for pod scheduling
 - **Set a security context** on containers
+- **Reference the current detonation's correlation ID** in any string value via `%%correlation_id%%` (see [Template variables](#template-variables) below)
 
 The `default` section applies to all techniques. The `techniques` section allows per-technique overrides, keyed by technique ID. Overrides are merged on top of defaults, you only need to specify the keys you want to change.
+
+### Template variables
+
+Any string value in the config can reference the current detonation's correlation ID using `%%correlation_id%%`. The substitution is applied whenever Stratus reads the config to build a resource (at warmup for Terraform-built prerequisites, and at detonation for resources created directly by the technique's Go code):
+
+```yaml
+kubernetes:
+  default:
+    pod:
+      labels:
+        detonation_id: "%%correlation_id%%"
+```
 
 !!! note
 
@@ -235,6 +248,6 @@ The `default` section applies to all techniques. The `techniques` section allows
 
 Encountering issues? See our [troubleshooting](./troubleshooting.md) page, or [open an issue](https://github.com/DataDog/stratus-red-team/issues/new/choose).
 
-*[TTP]: Tactics, techniques and procedures
+\*[TTP]: Tactics, techniques and procedures
 
 [^1]: While Stratus Red Team uses Terraform under the hood, it doesn't mess with your current Terraform install nor does it require you to install Terraform as a prerequisite. Stratus Red Team will download its own Terraform binary in `$HOME/.stratus-red-team`.

--- a/docs/user-guide/getting-started.md
+++ b/docs/user-guide/getting-started.md
@@ -226,20 +226,20 @@ This is currently used for Kubernetes techniques and allows you to:
 - **Add labels** to pods (for attribution, CNP policy selectors, monitoring, etc.)
 - **Add tolerations and node selectors** for pod scheduling
 - **Set a security context** on containers
-- **Reference the current detonation's correlation ID** in any string value via `%%correlation_id%%` (see [Template variables](#template-variables) below)
+- **Reference the current detonation's correlation ID** in any string value via `<% .CorrelationID %>` (see [Template variables](#template-variables) below)
 
 The `default` section applies to all techniques. The `techniques` section allows per-technique overrides, keyed by technique ID. Overrides are merged on top of defaults, you only need to specify the keys you want to change.
 
 ### Template variables
 
-Any string value in the config can reference the current detonation's correlation ID using `%%correlation_id%%`. The substitution is applied whenever Stratus reads the config to build a resource (at warmup for Terraform-built prerequisites, and at detonation for resources created directly by the technique's Go code):
+Any string value in the config can reference the current detonation's correlation ID using `<%.CorrelationID%>`. The substitution is applied whenever Stratus reads the config to build a resource (at warmup for Terraform-built prerequisites, and at detonation for resources created directly by the technique's Go code):
 
 ```yaml
 kubernetes:
   default:
     pod:
       labels:
-        detonation_id: "%%correlation_id%%"
+        detonation_id: "<% .CorrelationID %>"
 ```
 
 !!! note

--- a/docs/user-guide/getting-started.md
+++ b/docs/user-guide/getting-started.md
@@ -248,6 +248,6 @@ kubernetes:
 
 Encountering issues? See our [troubleshooting](./troubleshooting.md) page, or [open an issue](https://github.com/DataDog/stratus-red-team/issues/new/choose).
 
-\*[TTP]: Tactics, techniques and procedures
+*[TTP]: Tactics, techniques and procedures
 
 [^1]: While Stratus Red Team uses Terraform under the hood, it doesn't mess with your current Terraform install nor does it require you to install Terraform as a prerequisite. Stratus Red Team will download its own Terraform binary in `$HOME/.stratus-red-team`.

--- a/v2/internal/providers/kubernetes.go
+++ b/v2/internal/providers/kubernetes.go
@@ -138,6 +138,7 @@ func (m *K8sProvider) ApplyPodConfig(techniqueID string, pod *v1.Pod) {
 		return
 	}
 
-	techniqueConfig := cfg.GetKubernetesConfig().GetTechniquePodConfig(techniqueID)
+	vars := config.SubstitutionVars{CorrelationID: m.UniqueCorrelationId.String()}
+	techniqueConfig := cfg.GetKubernetesConfig().GetTechniquePodConfig(techniqueID, vars)
 	techniqueConfig.ApplyToPod(pod)
 }

--- a/v2/pkg/stratus/config/config.go
+++ b/v2/pkg/stratus/config/config.go
@@ -33,7 +33,7 @@ func newViper() *viper.Viper {
 // directly in the technique code.
 type Config interface {
 	GetKubernetesConfig() KubernetesConfig
-	GetTerraformVariables(techniqueID string) map[string]string
+	GetTerraformVariables(techniqueID string, vars SubstitutionVars) map[string]string
 }
 
 type ConfigImpl struct {
@@ -101,12 +101,12 @@ func (c *ConfigImpl) GetKubernetesConfig() KubernetesConfig {
 
 // buildMergedViper produces a Viper containing the merged technique config.
 // Each provider populates its own subtree via populateViperOverride.
-func (c *ConfigImpl) buildMergedViper(techniqueID string) *viper.Viper {
+func (c *ConfigImpl) buildMergedViper(techniqueID string, vars SubstitutionVars) *viper.Viper {
 	v := newViper()
 	if c == nil || c.kubernetes == nil {
 		return v
 	}
-	c.kubernetes.populateViperOverride(c.v, v, techniqueID)
+	c.kubernetes.populateViperOverride(c.v, v, techniqueID, vars)
 	// Add here other providers config
 	return v
 }
@@ -114,13 +114,14 @@ func (c *ConfigImpl) buildMergedViper(techniqueID string) *viper.Viper {
 // GetTerraformVariables returns the full merged config (defaults + technique overrides)
 // as a Terraform variable. The returned map contains a single key "config" whose value is
 // a JSON object that Terraform can decode into its variable "config" type.
+// Template variables (e.g. %%correlation_id%%) in string values are substituted from vars.
 // Returns nil if no config is loaded.
-func (c *ConfigImpl) GetTerraformVariables(techniqueID string) map[string]string {
+func (c *ConfigImpl) GetTerraformVariables(techniqueID string, vars SubstitutionVars) map[string]string {
 	if c == nil {
 		return nil
 	}
 
-	merged := c.buildMergedViper(techniqueID)
+	merged := c.buildMergedViper(techniqueID, vars)
 	settings := merged.AllSettings()
 	if len(settings) == 0 {
 		return nil

--- a/v2/pkg/stratus/config/config.go
+++ b/v2/pkg/stratus/config/config.go
@@ -114,7 +114,7 @@ func (c *ConfigImpl) buildMergedViper(techniqueID string, vars SubstitutionVars)
 // GetTerraformVariables returns the full merged config (defaults + technique overrides)
 // as a Terraform variable. The returned map contains a single key "config" whose value is
 // a JSON object that Terraform can decode into its variable "config" type.
-// Template variables (e.g. %%correlation_id%%) in string values are substituted from vars.
+// Template variables (e.g. <% .CorrelationID %>) in string values are substituted from vars.
 // Returns nil if no config is loaded.
 func (c *ConfigImpl) GetTerraformVariables(techniqueID string, vars SubstitutionVars) map[string]string {
 	if c == nil {

--- a/v2/pkg/stratus/config/config_test.go
+++ b/v2/pkg/stratus/config/config_test.go
@@ -141,7 +141,7 @@ kubernetes:
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			cfg := newTestConfig(tc.yaml)
-			actual := cfg.GetTerraformVariables(tc.techniqueID)
+			actual := cfg.GetTerraformVariables(tc.techniqueID, SubstitutionVars{})
 
 			if tc.expected == nil {
 				assert.Nil(t, actual)

--- a/v2/pkg/stratus/config/kubernetes.go
+++ b/v2/pkg/stratus/config/kubernetes.go
@@ -10,7 +10,7 @@ import (
 
 // KubernetesConfig holds Kubernetes-specific configuration
 type KubernetesConfig interface {
-	GetTechniquePodConfig(techniqueID string) K8sPodConfig
+	GetTechniquePodConfig(techniqueID string, vars SubstitutionVars) K8sPodConfig
 }
 
 type KubernetesConfigImpl struct {
@@ -21,8 +21,9 @@ var _ KubernetesConfig = &KubernetesConfigImpl{}
 
 // populateViperOverride creates a kubernetes config object from a source viper config.
 // It deep-merges the default settings with technique-specific overrides. Technique values
-// take precedence, but unset keys fall through to the default.
-func (k *KubernetesConfigImpl) populateViperOverride(src *viper.Viper, dst *viper.Viper, techniqueID string) {
+// take precedence, but unset keys fall through to the default. Template variables
+// (e.g. %%correlation_id%%) in string values are substituted before the result is stored.
+func (k *KubernetesConfigImpl) populateViperOverride(src *viper.Viper, dst *viper.Viper, techniqueID string, vars SubstitutionVars) {
 	defaultRaw := src.Get("kubernetes" + keyDelimiter + "default")
 	if defaultRaw == nil {
 		return
@@ -33,7 +34,7 @@ func (k *KubernetesConfigImpl) populateViperOverride(src *viper.Viper, dst *vipe
 		deepMerge(merged, toStringMap(techniqueRaw))
 	}
 
-	dst.Set("kubernetes", merged)
+	dst.Set("kubernetes", substituteMap(merged, vars))
 }
 
 // deepMerge recursively merges src into dst. Values in src take precedence.
@@ -65,13 +66,14 @@ func toStringMap(v any) map[string]any {
 	return make(map[string]any)
 }
 
-// GetTechniquePodConfig returns the merged pod configuration for a specific technique.
-func (k *KubernetesConfigImpl) GetTechniquePodConfig(techniqueID string) K8sPodConfig {
+// GetTechniquePodConfig returns the merged pod configuration for a specific technique,
+// with template variables (e.g. %%correlation_id%%) substituted from vars.
+func (k *KubernetesConfigImpl) GetTechniquePodConfig(techniqueID string, vars SubstitutionVars) K8sPodConfig {
 	if k == nil || k.v == nil {
 		return K8sPodConfig{}
 	}
 	merged := newViper()
-	k.populateViperOverride(k.v, merged, techniqueID)
+	k.populateViperOverride(k.v, merged, techniqueID, vars)
 
 	var podConfig K8sPodConfig
 	if sub := merged.Sub("kubernetes" + keyDelimiter + "pod"); sub != nil {

--- a/v2/pkg/stratus/config/kubernetes.go
+++ b/v2/pkg/stratus/config/kubernetes.go
@@ -22,7 +22,7 @@ var _ KubernetesConfig = &KubernetesConfigImpl{}
 // populateViperOverride creates a kubernetes config object from a source viper config.
 // It deep-merges the default settings with technique-specific overrides. Technique values
 // take precedence, but unset keys fall through to the default. Template variables
-// (e.g. %%correlation_id%%) in string values are substituted before the result is stored.
+// (e.g. <% .CorrelationID %>) in string values are substituted before the result is stored.
 func (k *KubernetesConfigImpl) populateViperOverride(src *viper.Viper, dst *viper.Viper, techniqueID string, vars SubstitutionVars) {
 	defaultRaw := src.Get("kubernetes" + keyDelimiter + "default")
 	if defaultRaw == nil {
@@ -67,7 +67,7 @@ func toStringMap(v any) map[string]any {
 }
 
 // GetTechniquePodConfig returns the merged pod configuration for a specific technique,
-// with template variables (e.g. %%correlation_id%%) substituted from vars.
+// with template variables (e.g. <% .CorrelationID %>) substituted from vars.
 func (k *KubernetesConfigImpl) GetTechniquePodConfig(techniqueID string, vars SubstitutionVars) K8sPodConfig {
 	if k == nil || k.v == nil {
 		return K8sPodConfig{}
@@ -86,10 +86,10 @@ func (k *KubernetesConfigImpl) GetTechniquePodConfig(techniqueID string, vars Su
 
 // K8sPodConfig holds pod-level configuration that can be applied to k8s pods.
 type K8sPodConfig struct {
-	Image       string            `yaml:"image"`
-	Labels      map[string]string `yaml:"labels"`
-	Annotations map[string]string `yaml:"annotations"`
-	Tolerations []v1.Toleration   `yaml:"tolerations"`
+	Image           string              `yaml:"image"`
+	Labels          map[string]string   `yaml:"labels"`
+	Annotations     map[string]string   `yaml:"annotations"`
+	Tolerations     []v1.Toleration     `yaml:"tolerations"`
 	NodeSelector    map[string]string   `yaml:"node_selector"`
 	SecurityContext *v1.SecurityContext `yaml:"security_context"`
 }

--- a/v2/pkg/stratus/config/kubernetes_test.go
+++ b/v2/pkg/stratus/config/kubernetes_test.go
@@ -118,8 +118,37 @@ kubernetes:
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			cfg := newTestConfig(tc.yaml)
-			actual := cfg.GetKubernetesConfig().GetTechniquePodConfig(tc.techniqueID)
+			actual := cfg.GetKubernetesConfig().GetTechniquePodConfig(tc.techniqueID, SubstitutionVars{})
 			assert.Equal(t, tc.expected, actual)
 		})
 	}
+}
+
+// TestGetTechniquePodConfig_TemplateSubstitution verifies that %%correlation_id%%
+// is resolved end-to-end (YAML → merged map → unmarshaled struct), that unknown
+// template variables (e.g. Datadog Agent's %%kube_namespace%%) survive untouched
+// for downstream resolution, and that substitution applies to any string value
+// not just annotations.
+func TestGetTechniquePodConfig_TemplateSubstitution(t *testing.T) {
+	yaml := `
+kubernetes:
+  default:
+    namespace: stratus-%%correlation_id%%
+    pod:
+      image: registry/img:%%correlation_id%%
+      labels:
+        team: red
+      annotations:
+        ad.datadoghq.com/tags: '{"detonation_id":"%%correlation_id%%","ns":"%%kube_namespace%%"}'
+`
+	cfg := newTestConfig(yaml)
+	vars := SubstitutionVars{CorrelationID: "abc-123"}
+	actual := cfg.GetKubernetesConfig().GetTechniquePodConfig("k8s.any.technique", vars)
+
+	assert.Equal(t, "registry/img:abc-123", actual.Image, "substitution applies to image")
+	assert.Equal(t, map[string]string{"team": "red"}, actual.Labels, "label without template untouched")
+	assert.Equal(t,
+		`{"detonation_id":"abc-123","ns":"%%kube_namespace%%"}`,
+		actual.Annotations["ad.datadoghq.com/tags"],
+		"correlation_id substituted, kube_namespace passed through for DD agent")
 }

--- a/v2/pkg/stratus/config/kubernetes_test.go
+++ b/v2/pkg/stratus/config/kubernetes_test.go
@@ -124,22 +124,23 @@ kubernetes:
 	}
 }
 
-// TestGetTechniquePodConfig_TemplateSubstitution verifies that %%correlation_id%%
-// is resolved end-to-end (YAML → merged map → unmarshaled struct), that unknown
-// template variables (e.g. Datadog Agent's %%kube_namespace%%) survive untouched
-// for downstream resolution, and that substitution applies to any string value
-// not just annotations.
+// TestGetTechniquePodConfig_TemplateSubstitution verifies that <% .CorrelationID %>
+// is resolved end-to-end (YAML -> merged map -> unmarshaled struct), that content
+// that doesn't use Stratus's <% %> template syntax (e.g. Datadog Agent's
+// %%kube_namespace%% autodiscovery markers) survives untouched for downstream
+// resolution, and that substitution applies to any string value not just
+// annotations.
 func TestGetTechniquePodConfig_TemplateSubstitution(t *testing.T) {
 	yaml := `
 kubernetes:
   default:
-    namespace: stratus-%%correlation_id%%
+    namespace: stratus-<% .CorrelationID %>
     pod:
-      image: registry/img:%%correlation_id%%
+      image: registry/img:<%.CorrelationID%> # without spaces between delims and field
       labels:
         team: red
       annotations:
-        ad.datadoghq.com/tags: '{"detonation_id":"%%correlation_id%%","ns":"%%kube_namespace%%"}'
+        ad.datadoghq.com/tags: '{"detonation_id":"<% .CorrelationID %>","ns":"%%kube_namespace%%"}'
 `
 	cfg := newTestConfig(yaml)
 	vars := SubstitutionVars{CorrelationID: "abc-123"}
@@ -150,5 +151,5 @@ kubernetes:
 	assert.Equal(t,
 		`{"detonation_id":"abc-123","ns":"%%kube_namespace%%"}`,
 		actual.Annotations["ad.datadoghq.com/tags"],
-		"correlation_id substituted, kube_namespace passed through for DD agent")
+		"CorrelationID substituted, DD-Agent autodiscovery marker passed through")
 }

--- a/v2/pkg/stratus/config/mocks/Config.go
+++ b/v2/pkg/stratus/config/mocks/Config.go
@@ -32,17 +32,17 @@ func (_m *Config) GetKubernetesConfig() config.KubernetesConfig {
 	return r0
 }
 
-// GetTerraformVariables provides a mock function with given fields: techniqueID
-func (_m *Config) GetTerraformVariables(techniqueID string) map[string]string {
-	ret := _m.Called(techniqueID)
+// GetTerraformVariables provides a mock function with given fields: techniqueID, vars
+func (_m *Config) GetTerraformVariables(techniqueID string, vars config.SubstitutionVars) map[string]string {
+	ret := _m.Called(techniqueID, vars)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetTerraformVariables")
 	}
 
 	var r0 map[string]string
-	if rf, ok := ret.Get(0).(func(string) map[string]string); ok {
-		r0 = rf(techniqueID)
+	if rf, ok := ret.Get(0).(func(string, config.SubstitutionVars) map[string]string); ok {
+		r0 = rf(techniqueID, vars)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(map[string]string)

--- a/v2/pkg/stratus/config/substitution.go
+++ b/v2/pkg/stratus/config/substitution.go
@@ -1,0 +1,81 @@
+package config
+
+import "regexp"
+
+// templateVarPattern matches %%name%% where name is lowercase letters and underscores.
+// The chosen syntax aligns with Datadog Agent's tag autodiscovery template variables
+// (e.g. %%kube_namespace%%).
+var templateVarPattern = regexp.MustCompile(`%%([a-z_]+)%%`)
+
+// SubstitutionVars holds the values Stratus substitutes into config string values.
+// Unknown names — and names whose value is empty — are left untouched (passed
+// through verbatim). Treating empty values as unknown prevents missing context
+// from silently collapsing %%correlation_id%% into "" downstream, which would
+// risk resource-name collisions across detonations.
+type SubstitutionVars struct {
+	CorrelationID string
+}
+
+// varNameCorrelationID is the whitelisted name accepted in %%...%% markers for
+// the correlation ID. Kept as a constant so the whitelist string lives in exactly
+// one place alongside the SubstitutionVars field it resolves from.
+const varNameCorrelationID = "correlation_id"
+
+// lookup returns the substitution for a named variable and whether it should be
+// applied. See SubstitutionVars for the empty-value semantics.
+func (v SubstitutionVars) lookup(name string) (string, bool) {
+	switch name {
+	case varNameCorrelationID:
+		if v.CorrelationID == "" {
+			return "", false
+		}
+		return v.CorrelationID, true
+	default:
+		return "", false
+	}
+}
+
+// substitute replaces %%name%% occurrences whose name is in the whitelist; other
+// occurrences are returned verbatim.
+func (v SubstitutionVars) substitute(s string) string {
+	return templateVarPattern.ReplaceAllStringFunc(s, func(match string) string {
+		// FindStringSubmatch keeps the name extraction tied to the regex; if the
+		// pattern is widened or its delimiters change, this code keeps working.
+		sub := templateVarPattern.FindStringSubmatch(match)
+		if value, ok := v.lookup(sub[1]); ok {
+			return value
+		}
+		return match
+	})
+}
+
+// substituteMap returns a new map with the same shape as m and all string leaves
+// substituted via vars. The caller's map is not mutated.
+func substituteMap(m map[string]any, vars SubstitutionVars) map[string]any {
+	result := make(map[string]any, len(m))
+	for k, val := range m {
+		result[k] = substituteValue(val, vars)
+	}
+	return result
+}
+
+// substituteValue walks a parsed-YAML value tree and applies substitution to
+// every string leaf. Map keys are intentionally not substituted. The walker
+// handles the shapes Viper produces (string, map[string]any, []any); other Go
+// types are passed through unchanged.
+func substituteValue(v any, vars SubstitutionVars) any {
+	switch x := v.(type) {
+	case string:
+		return vars.substitute(x)
+	case map[string]any:
+		return substituteMap(x, vars)
+	case []any:
+		result := make([]any, len(x))
+		for i, item := range x {
+			result[i] = substituteValue(item, vars)
+		}
+		return result
+	default:
+		return v
+	}
+}

--- a/v2/pkg/stratus/config/substitution.go
+++ b/v2/pkg/stratus/config/substitution.go
@@ -1,56 +1,44 @@
 package config
 
-import "regexp"
+import (
+	"bytes"
+	"log"
+	"text/template"
+)
 
-// templateVarPattern matches %%name%% where name is lowercase letters and underscores.
-// The chosen syntax aligns with Datadog Agent's tag autodiscovery template variables
-// (e.g. %%kube_namespace%%).
-var templateVarPattern = regexp.MustCompile(`%%([a-z_]+)%%`)
-
-// SubstitutionVars holds the values Stratus substitutes into config string values.
-// Unknown names — and names whose value is empty — are left untouched (passed
-// through verbatim). Treating empty values as unknown prevents missing context
-// from silently collapsing %%correlation_id%% into "" downstream, which would
-// risk resource-name collisions across detonations.
+// SubstitutionVars holds values substituted into config string values. Users
+// reference each variable in YAML via Go's text/template syntax with <% %>
+// delimiters — e.g. <%.CorrelationID%>. Adding a new variable: add a field
+// below and have callers populate it; users reference it by the exported field
+// name.
+//
+// The non-default <% %> delimiters were chosen to avoid (a) YAML parsers
+// interpreting [[ ]] as nested flow sequences, and (b) some editors (VSCode,
+// Cursor) splitting the default {{ }} markers into "{ {" on save.
 type SubstitutionVars struct {
 	CorrelationID string
 }
 
-// varNameCorrelationID is the whitelisted name accepted in %%...%% markers for
-// the correlation ID. Kept as a constant so the whitelist string lives in exactly
-// one place alongside the SubstitutionVars field it resolves from.
-const varNameCorrelationID = "correlation_id"
-
-// lookup returns the substitution for a named variable and whether it should be
-// applied. See SubstitutionVars for the empty-value semantics.
-func (v SubstitutionVars) lookup(name string) (string, bool) {
-	switch name {
-	case varNameCorrelationID:
-		if v.CorrelationID == "" {
-			return "", false
-		}
-		return v.CorrelationID, true
-	default:
-		return "", false
-	}
-}
-
-// substitute replaces %%name%% occurrences whose name is in the whitelist; other
-// occurrences are returned verbatim.
+// substitute returns s with template expressions resolved from v. Parse or
+// execute errors (malformed delimiters, unknown field references) leave s
+// unchanged and log the cause so typos surface as literal <% %> markers in
+// the output rather than aborting warmup.
 func (v SubstitutionVars) substitute(s string) string {
-	return templateVarPattern.ReplaceAllStringFunc(s, func(match string) string {
-		// FindStringSubmatch keeps the name extraction tied to the regex; if the
-		// pattern is widened or its delimiters change, this code keeps working.
-		sub := templateVarPattern.FindStringSubmatch(match)
-		if value, ok := v.lookup(sub[1]); ok {
-			return value
-		}
-		return match
-	})
+	tmpl, err := template.New("").Delims("<%", "%>").Parse(s)
+	if err != nil {
+		log.Printf("config substitution: parse %q: %v", s, err)
+		return s
+	}
+	var buf bytes.Buffer
+	if err := tmpl.Execute(&buf, v); err != nil {
+		log.Printf("config substitution: execute %q: %v", s, err)
+		return s
+	}
+	return buf.String()
 }
 
-// substituteMap returns a new map with the same shape as m and all string leaves
-// substituted via vars. The caller's map is not mutated.
+// substituteMap returns a new map with the same shape as m and all string
+// leaves substituted via vars. The caller's map is not mutated.
 func substituteMap(m map[string]any, vars SubstitutionVars) map[string]any {
 	result := make(map[string]any, len(m))
 	for k, val := range m {

--- a/v2/pkg/stratus/config/substitution_test.go
+++ b/v2/pkg/stratus/config/substitution_test.go
@@ -1,0 +1,105 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+const testCorrelationID = "11111111-2222-3333-4444-555555555555"
+
+func TestSubstitutionVars_substitute(t *testing.T) {
+	tests := []struct {
+		name     string
+		vars     SubstitutionVars
+		input    string
+		expected string
+	}{
+		{
+			name:     "no template markers",
+			vars:     SubstitutionVars{CorrelationID: testCorrelationID},
+			input:    "plain string",
+			expected: "plain string",
+		},
+		{
+			name:     "known variable",
+			vars:     SubstitutionVars{CorrelationID: testCorrelationID},
+			input:    "id=%%correlation_id%%",
+			expected: "id=" + testCorrelationID,
+		},
+		{
+			name:     "unknown variable passes through (e.g. DD Agent autodiscovery)",
+			vars:     SubstitutionVars{CorrelationID: testCorrelationID},
+			input:    `{"ns":"%%kube_namespace%%"}`,
+			expected: `{"ns":"%%kube_namespace%%"}`,
+		},
+		{
+			name:     "known and unknown coexist",
+			vars:     SubstitutionVars{CorrelationID: testCorrelationID},
+			input:    `{"id":"%%correlation_id%%","ns":"%%kube_namespace%%"}`,
+			expected: `{"id":"` + testCorrelationID + `","ns":"%%kube_namespace%%"}`,
+		},
+		{
+			name:     "multiple occurrences",
+			vars:     SubstitutionVars{CorrelationID: testCorrelationID},
+			input:    "%%correlation_id%%-%%correlation_id%%",
+			expected: testCorrelationID + "-" + testCorrelationID,
+		},
+		{
+			name:     "empty placeholder is not a match",
+			vars:     SubstitutionVars{CorrelationID: testCorrelationID},
+			input:    "%%%%",
+			expected: "%%%%",
+		},
+		{
+			name:     "stray double percent without closing is not a match",
+			vars:     SubstitutionVars{CorrelationID: testCorrelationID},
+			input:    "100%% sure",
+			expected: "100%% sure",
+		},
+		{
+			name:     "uppercase variable name does not match (lowercase whitelist only)",
+			vars:     SubstitutionVars{CorrelationID: testCorrelationID},
+			input:    "%%CORRELATION_ID%%",
+			expected: "%%CORRELATION_ID%%",
+		},
+		{
+			name:     "empty correlation_id leaves placeholder intact",
+			vars:     SubstitutionVars{},
+			input:    "id=%%correlation_id%%",
+			expected: "id=%%correlation_id%%",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, tc.vars.substitute(tc.input))
+		})
+	}
+}
+
+func TestSubstituteMap(t *testing.T) {
+	vars := SubstitutionVars{CorrelationID: "uuid-1"}
+
+	input := map[string]any{
+		"top":                         "%%correlation_id%%",
+		"nested":                      map[string]any{"deep": "id=%%correlation_id%%", "passthrough": "%%kube_namespace%%"},
+		"slice":                       []any{"a-%%correlation_id%%", "b"},
+		"non_str":                     42,
+		"key_with_%%correlation_id%%": "value",
+	}
+
+	result := substituteMap(input, vars)
+
+	assert.Equal(t, "uuid-1", result["top"], "top-level string substituted")
+	assert.Equal(t, "id=uuid-1", result["nested"].(map[string]any)["deep"], "nested string substituted")
+	assert.Equal(t, "%%kube_namespace%%", result["nested"].(map[string]any)["passthrough"], "unknown var passed through")
+	assert.Equal(t, []any{"a-uuid-1", "b"}, result["slice"], "slice elements substituted")
+	assert.Equal(t, 42, result["non_str"], "non-string leaf left untouched")
+
+	_, keyPreserved := result["key_with_%%correlation_id%%"]
+	assert.True(t, keyPreserved, "map keys are not substituted")
+	assert.Len(t, result, len(input), "no extra keys introduced (would happen if keys were substituted alongside the originals)")
+
+	assert.Equal(t, "%%correlation_id%%", input["top"], "input map not mutated")
+}

--- a/v2/pkg/stratus/config/substitution_test.go
+++ b/v2/pkg/stratus/config/substitution_test.go
@@ -22,52 +22,52 @@ func TestSubstitutionVars_substitute(t *testing.T) {
 			expected: "plain string",
 		},
 		{
-			name:     "known variable",
+			name:     "known field",
 			vars:     SubstitutionVars{CorrelationID: testCorrelationID},
-			input:    "id=%%correlation_id%%",
+			input:    "id=<% .CorrelationID %>",
 			expected: "id=" + testCorrelationID,
 		},
 		{
-			name:     "unknown variable passes through (e.g. DD Agent autodiscovery)",
+			name:     "known field, no spaces between delims and field",
+			vars:     SubstitutionVars{CorrelationID: testCorrelationID},
+			input:    "id=<%.CorrelationID%>",
+			expected: "id=" + testCorrelationID,
+		},
+		{
+			name:     "multiple occurrences",
+			vars:     SubstitutionVars{CorrelationID: testCorrelationID},
+			input:    "<%.CorrelationID%>-<%.CorrelationID%>",
+			expected: testCorrelationID + "-" + testCorrelationID,
+		},
+		{
+			name:     "embedded in JSON",
+			vars:     SubstitutionVars{CorrelationID: testCorrelationID},
+			input:    `{"id":"<%.CorrelationID%>"}`,
+			expected: `{"id":"` + testCorrelationID + `"}`,
+		},
+		{
+			name:     "DD Agent autodiscovery vars are not template syntax, pass through",
 			vars:     SubstitutionVars{CorrelationID: testCorrelationID},
 			input:    `{"ns":"%%kube_namespace%%"}`,
 			expected: `{"ns":"%%kube_namespace%%"}`,
 		},
 		{
-			name:     "known and unknown coexist",
+			name:     "unknown field renders as no-value-with-empty-fallback",
 			vars:     SubstitutionVars{CorrelationID: testCorrelationID},
-			input:    `{"id":"%%correlation_id%%","ns":"%%kube_namespace%%"}`,
-			expected: `{"id":"` + testCorrelationID + `","ns":"%%kube_namespace%%"}`,
+			input:    "<%.Unknown%>",
+			expected: "<%.Unknown%>", // Execute errors → return original
 		},
 		{
-			name:     "multiple occurrences",
+			name:     "malformed template passes through",
 			vars:     SubstitutionVars{CorrelationID: testCorrelationID},
-			input:    "%%correlation_id%%-%%correlation_id%%",
-			expected: testCorrelationID + "-" + testCorrelationID,
+			input:    "<%.unterminated",
+			expected: "<%.unterminated", // Parse errors → return original
 		},
 		{
-			name:     "empty placeholder is not a match",
-			vars:     SubstitutionVars{CorrelationID: testCorrelationID},
-			input:    "%%%%",
-			expected: "%%%%",
-		},
-		{
-			name:     "stray double percent without closing is not a match",
-			vars:     SubstitutionVars{CorrelationID: testCorrelationID},
-			input:    "100%% sure",
-			expected: "100%% sure",
-		},
-		{
-			name:     "uppercase variable name does not match (lowercase whitelist only)",
-			vars:     SubstitutionVars{CorrelationID: testCorrelationID},
-			input:    "%%CORRELATION_ID%%",
-			expected: "%%CORRELATION_ID%%",
-		},
-		{
-			name:     "empty correlation_id leaves placeholder intact",
+			name:     "empty CorrelationID renders empty",
 			vars:     SubstitutionVars{},
-			input:    "id=%%correlation_id%%",
-			expected: "id=%%correlation_id%%",
+			input:    "id=<%.CorrelationID%>",
+			expected: "id=",
 		},
 	}
 
@@ -82,24 +82,24 @@ func TestSubstituteMap(t *testing.T) {
 	vars := SubstitutionVars{CorrelationID: "uuid-1"}
 
 	input := map[string]any{
-		"top":                         "%%correlation_id%%",
-		"nested":                      map[string]any{"deep": "id=%%correlation_id%%", "passthrough": "%%kube_namespace%%"},
-		"slice":                       []any{"a-%%correlation_id%%", "b"},
+		"top":                         "<%.CorrelationID%>",
+		"nested":                      map[string]any{"deep": "id=<%.CorrelationID%>", "passthrough": "%%kube_namespace%%"},
+		"slice":                       []any{"a-<%.CorrelationID%>", "b"},
 		"non_str":                     42,
-		"key_with_%%correlation_id%%": "value",
+		"key_with_<%.CorrelationID%>": "value",
 	}
 
 	result := substituteMap(input, vars)
 
 	assert.Equal(t, "uuid-1", result["top"], "top-level string substituted")
 	assert.Equal(t, "id=uuid-1", result["nested"].(map[string]any)["deep"], "nested string substituted")
-	assert.Equal(t, "%%kube_namespace%%", result["nested"].(map[string]any)["passthrough"], "unknown var passed through")
+	assert.Equal(t, "%%kube_namespace%%", result["nested"].(map[string]any)["passthrough"], "non-template content untouched")
 	assert.Equal(t, []any{"a-uuid-1", "b"}, result["slice"], "slice elements substituted")
 	assert.Equal(t, 42, result["non_str"], "non-string leaf left untouched")
 
-	_, keyPreserved := result["key_with_%%correlation_id%%"]
+	_, keyPreserved := result["key_with_<%.CorrelationID%>"]
 	assert.True(t, keyPreserved, "map keys are not substituted")
-	assert.Len(t, result, len(input), "no extra keys introduced (would happen if keys were substituted alongside the originals)")
+	assert.Len(t, result, len(input), "no extra keys introduced")
 
-	assert.Equal(t, "%%correlation_id%%", input["top"], "input map not mutated")
+	assert.Equal(t, "<%.CorrelationID%>", input["top"], "input map not mutated")
 }

--- a/v2/pkg/stratus/runner/runner.go
+++ b/v2/pkg/stratus/runner/runner.go
@@ -393,11 +393,12 @@ func (m *runnerImpl) GetUniqueExecutionId() string {
 // buildTerraformVariables returns the terraform variables to use,
 // including the correlation metadata and any config-file overrides.
 func (m *runnerImpl) buildTerraformVariables() map[string]string {
-	vars := m.Config.GetTerraformVariables(m.Technique.ID)
+	correlationID := m.UniqueCorrelationID.String()
+	vars := m.Config.GetTerraformVariables(m.Technique.ID, config.SubstitutionVars{CorrelationID: correlationID})
 	if vars == nil {
 		vars = make(map[string]string)
 	}
-	vars[state.TerraformCorrelationVarName] = state.MarshalCorrelation(m.UniqueCorrelationID.String())
+	vars[state.TerraformCorrelationVarName] = state.MarshalCorrelation(correlationID)
 	return vars
 }
 

--- a/v2/pkg/stratus/runner/runner_test.go
+++ b/v2/pkg/stratus/runner/runner_test.go
@@ -547,7 +547,7 @@ func TestNewRunnerWithProviderFactory(t *testing.T) {
 	stateMock.On("SetTechniqueState", mock.Anything).Return(nil)
 	stateMock.On("WriteTerraformOutputs", mock.Anything).Return(nil)
 	stateMock.On("WriteTerraformVariables", mock.Anything).Return(nil)
-	configMock.On("GetTerraformVariables", mock.Anything).Return(map[string]string{})
+	configMock.On("GetTerraformVariables", mock.Anything, mock.Anything).Return(map[string]string{})
 	tfMock.On("TerraformInitAndApply", mock.Anything, mock.Anything).Return(map[string]string{}, nil)
 
 	r := NewRunnerWithContext(
@@ -584,7 +584,7 @@ func TestProviderCredentialInjection(t *testing.T) {
 	stateMock.On("SetTechniqueState", mock.Anything).Return(nil)
 	stateMock.On("WriteTerraformOutputs", mock.Anything).Return(nil)
 	stateMock.On("WriteTerraformVariables", mock.Anything).Return(nil)
-	configMock.On("GetTerraformVariables", mock.Anything).Return(map[string]string{})
+	configMock.On("GetTerraformVariables", mock.Anything, mock.Anything).Return(map[string]string{})
 	tfMock.On("TerraformInitAndApply", mock.Anything, mock.Anything).Return(map[string]string{}, nil)
 
 	// Build an AWS provider with explicit static credentials using the


### PR DESCRIPTION
### What does this PR do?

Enhancement: add a template variable mechanism in the config to use the correlation id in config.
This for instance allows to tag all the pods with annotations/tags containing the correlation ID to make the K8S attacks discoverable when using [Threatest](https://github.com/DataDog/threatest)

### Motivation

To ease the discovery of signals generated by stratus, we want to inject the correlation ID in multiple places.

In our case, one of the interesting places is in the `ad.datadoghq.com/tags` pod [annotation](https://docs.datadoghq.com/containers/kubernetes/tag/?tab=datadogoperator#tag-autodiscovery). The config allows users to control many things, but until now users couldn't inject the correlation id wherever they wanted.

#827 added a _label_ with the correlation id for the pods at detonation time, but the users might want to put the correlation id in annotations, tolerations, maybe even in the image when the id is controlled by the user with the env var...

### Implementation notes

- Substitution is implemented with stdlib `text/template`, using `<% %>` as delimiters instead of the default `{{ }}`. Reasons:
  - `{{ }}` triggers reformatting (split into `{ {`) on save in some YAML editors (VSCode, Cursor).
  - `[[ ]]` would be ambiguous with YAML flow sequences (`[[ ]]` parses as a list of lists) and would require users to quote every templated value.
  - `<% %>` is YAML-safe unquoted (`<`/`>` are only special at the very start of a value or after `<<:`), familiar from ERB/JSP, and doesn't collide with the Datadog Agent's `%%var%%` autodiscovery syntax — so a user can mix `<%.CorrelationID%>` (Stratus-resolved at warmup/detonation) with `%%kube_namespace%%` (Agent-resolved at scrape time) in the same annotation value.
- Because `text/template` references struct fields directly (`<%.CorrelationID%>`), there is no separate name↔field mapping to keep in sync. Adding a new variable is one struct field on `SubstitutionVars`; callers populate it, users reference it by the exported field name.
- Parse and execute errors leave the original string unchanged and log the cause, so typos surface as visible literal `<% %>` markers in the resource rather than aborting warmup.