### PR TITLE
build: strip symbol table and trim paths to reduce binary size

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ export GO111MODULE=on
 BIN_DIR := $(ROOT_DIR)/bin
 
 # Define go flags
-GOFLAGS := -ldflags="-X main.BuildVersion=$(BUILD_VERSION) -w"
+GOFLAGS := -ldflags="-X main.BuildVersion=$(BUILD_VERSION) -w -s" -trimpath
 
 .PHONY: build docs test thirdparty-licenses mocks
 

--- a/v2/go.mod
+++ b/v2/go.mod
@@ -46,7 +46,6 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/hashicorp/terraform-exec v0.21.0
 	github.com/jedib0t/go-pretty/v6 v6.4.0
-	github.com/microsoftgraph/msgraph-beta-sdk-go v0.108.0
 	github.com/microsoftgraph/msgraph-sdk-go-core v1.2.1
 	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2
 	github.com/spf13/cobra v1.6.0
@@ -182,7 +181,7 @@ require (
 	github.com/hashicorp/go-version v1.9.0
 	github.com/hashicorp/hc-install v0.9.4
 	github.com/hashicorp/terraform-json v0.22.1 // indirect
-	github.com/microsoftgraph/msgraph-sdk-go v1.47.0
+	github.com/microsoftgraph/msgraph-sdk-go v1.51.0
 	github.com/zclconf/go-cty v1.14.4 // indirect
 	golang.org/x/crypto v0.49.0
 	golang.org/x/sys v0.42.0 // indirect

--- a/v2/go.sum
+++ b/v2/go.sum
@@ -342,10 +342,8 @@ github.com/microsoft/kiota-serialization-multipart-go v1.0.0 h1:3O5sb5Zj+moLBiJy
 github.com/microsoft/kiota-serialization-multipart-go v1.0.0/go.mod h1:yauLeBTpANk4L03XD985akNysG24SnRJGaveZf+p4so=
 github.com/microsoft/kiota-serialization-text-go v1.0.0 h1:XOaRhAXy+g8ZVpcq7x7a0jlETWnWrEum0RhmbYrTFnA=
 github.com/microsoft/kiota-serialization-text-go v1.0.0/go.mod h1:sM1/C6ecnQ7IquQOGUrUldaO5wj+9+v7G2W3sQ3fy6M=
-github.com/microsoftgraph/msgraph-beta-sdk-go v0.108.0 h1:bkyTxXYEHQAC2Qo6G2HVZ6ADA+XxawQhenAhbYUyQ+M=
-github.com/microsoftgraph/msgraph-beta-sdk-go v0.108.0/go.mod h1:X4GpYrTnhoGBUHb55rl1+/GzavHHyyS5O1GswrWb15c=
-github.com/microsoftgraph/msgraph-sdk-go v1.47.0 h1:qXfmDij9md6mPsSAJjiDNmS4hxqKo0R489GiVMZVmmY=
-github.com/microsoftgraph/msgraph-sdk-go v1.47.0/go.mod h1:Gnws5D7d/930uS9J4qlCm4BAR/zenqECMk9tgMDXeZQ=
+github.com/microsoftgraph/msgraph-sdk-go v1.51.0 h1:IfRY0uVHToT8X9k6Ri19tKdt8hwPomji2yx5YsKoaw4=
+github.com/microsoftgraph/msgraph-sdk-go v1.51.0/go.mod h1:MVTeFCCih3qXy9D0q+f4NdOyumFnMZ+Ppcpurgd30TY=
 github.com/microsoftgraph/msgraph-sdk-go-core v1.2.1 h1:P1wpmn3xxfPMFJHg+PJPcusErfRkl63h6OdAnpDbkS8=
 github.com/microsoftgraph/msgraph-sdk-go-core v1.2.1/go.mod h1:vFmWQGWyLlhxCESNLv61vlE4qesBU+eWmEVH7DJSESA=
 github.com/moby/spdystream v0.2.0 h1:cjW1zVyyoiM0T7b6UoySUFqzXMoqRckQtXwGPiBhOM8=

--- a/v2/internal/attacktechniques/entra-id/persistence/guest-user/main.go
+++ b/v2/internal/attacktechniques/entra-id/persistence/guest-user/main.go
@@ -9,7 +9,6 @@ import (
 	"github.com/datadog/stratus-red-team/v2/internal/utils"
 	"github.com/datadog/stratus-red-team/v2/pkg/stratus"
 	"github.com/datadog/stratus-red-team/v2/pkg/stratus/mitreattack"
-	"github.com/microsoftgraph/msgraph-beta-sdk-go/models"
 	graphcore "github.com/microsoftgraph/msgraph-sdk-go-core"
 	graphmodels "github.com/microsoftgraph/msgraph-sdk-go/models"
 	"log"
@@ -165,7 +164,7 @@ func revert(_ map[string]string, providers stratus.CloudProviders) error {
 
 	// We need to paginate through the results
 	var userId string
-	iterator, err := graphcore.NewPageIterator[*graphmodels.User](userResult, graphClient.GetAdapter(), models.CreateUserCollectionResponseFromDiscriminatorValue)
+	iterator, err := graphcore.NewPageIterator[*graphmodels.User](userResult, graphClient.GetAdapter(), graphmodels.CreateUserCollectionResponseFromDiscriminatorValue)
 	if err != nil {
 		return errors.New("could not create users iterator: " + err.Error())
 	}

--- a/v2/internal/attacktechniques/entra-id/persistence/restricted-au/main.go
+++ b/v2/internal/attacktechniques/entra-id/persistence/restricted-au/main.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"github.com/datadog/stratus-red-team/v2/pkg/stratus"
 	"github.com/datadog/stratus-red-team/v2/pkg/stratus/mitreattack"
-	betagraphmodels "github.com/microsoftgraph/msgraph-beta-sdk-go/models"
 	graphmodels "github.com/microsoftgraph/msgraph-sdk-go/models"
 	"log"
 	"strings"
@@ -60,11 +59,10 @@ func detonate(params map[string]string, providers stratus.CloudProviders) error 
 	backdoorUserName := params["backdoor_user_name"]
 	suffix := params["suffix"]
 
-	betaGraphClient := providers.EntraId().GetBetaGraphClient()
 	graphClient := providers.EntraId().GetGraphClient()
 
 	// 1. Create Restricted AU
-	requestBodyAU := betagraphmodels.NewAdministrativeUnit()
+	requestBodyAU := graphmodels.NewAdministrativeUnit()
 	displayName := fmt.Sprintf("Stratus Red Team Restricted AU - %s", suffix)
 	requestBodyAU.SetDisplayName(&displayName)
 	description := "Restricted management AU created from Stratus Red Team"
@@ -72,7 +70,7 @@ func detonate(params map[string]string, providers stratus.CloudProviders) error 
 	restricted := true
 	requestBodyAU.SetIsMemberManagementRestricted(&restricted)
 
-	auResult, err := betaGraphClient.Directory().AdministrativeUnits().Post(context.Background(), requestBodyAU, nil)
+	auResult, err := graphClient.Directory().AdministrativeUnits().Post(context.Background(), requestBodyAU, nil)
 
 	if err != nil {
 		return errors.New("could not create AU: " + err.Error())

--- a/v2/internal/providers/entra_id.go
+++ b/v2/internal/providers/entra_id.go
@@ -7,16 +7,14 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 	"github.com/google/uuid"
-	betagraph "github.com/microsoftgraph/msgraph-beta-sdk-go"
 	graph "github.com/microsoftgraph/msgraph-sdk-go"
 	"log"
 )
 
 type EntraIdProvider struct {
-	Credentials     azcore.TokenCredential
-	ClientOptions   *arm.ClientOptions
-	GraphClient     *graph.GraphServiceClient
-	BetaGraphClient *betagraph.GraphServiceClient
+	Credentials   azcore.TokenCredential
+	ClientOptions *arm.ClientOptions
+	GraphClient   *graph.GraphServiceClient
 }
 
 // EntraIdProviderOption configures optional overrides on an EntraIdProvider.
@@ -54,21 +52,11 @@ func NewEntraIdProvider(correlationId uuid.UUID, opts ...EntraIdProviderOption) 
 	}
 	p.GraphClient = graphClient
 
-	betaGraphClient, err := betagraph.NewGraphServiceClientWithCredentials(p.Credentials, nil)
-	if err != nil {
-		log.Fatalf("could initialize Entra ID Beta Graph client: %v", err)
-	}
-	p.BetaGraphClient = betaGraphClient
-
 	return p
 }
 
 func (m *EntraIdProvider) GetGraphClient() *graph.GraphServiceClient {
 	return m.GraphClient
-}
-
-func (m *EntraIdProvider) GetBetaGraphClient() *betagraph.GraphServiceClient {
-	return m.BetaGraphClient
 }
 
 func (m *EntraIdProvider) GetTenantId() (string, error) {


### PR DESCRIPTION
Reduces binary size from 477 MB to 228 MB (-52%) via two changes:

- Add `-s` (strip symbol table) and `-trimpath` to linker flags: 477 MB → 402 MB (-16%)
- Drop `msgraph-beta-sdk-go` (140k+ symbols, the single largest contributor): 402 MB → 228 MB (-43%)