### PR TITLE
Add MITRE ATLAS as a first-class framework mapping (Cost Harvesting -> bedrock-invoke-model)

### DIFF
--- a/docs/attack-techniques/AWS/aws.impact.bedrock-invoke-model.md
+++ b/docs/attack-techniques/AWS/aws.impact.bedrock-invoke-model.md
@@ -15,6 +15,11 @@ Platform: AWS
     - Impact
 
 
+- MITRE ATLAS:
+  
+    - [Cost Harvesting](https://atlas.mitre.org/techniques/AML.T0034) (AML.T0034)
+  
+
 
 ## Description
 

--- a/docs/index.yaml
+++ b/docs/index.yaml
@@ -250,6 +250,12 @@ AWS:
           isSlow: false
           mitreAttackTactics:
             - Impact
+          frameworkmappings:
+            - framework: MITRE ATLAS
+              techniques:
+                - name: Cost Harvesting
+                  id: AML.T0034
+                  url: https://atlas.mitre.org/techniques/AML.T0034
           platform: AWS
           isIdempotent: true
         - id: aws.impact.s3-ransomware-batch-deletion

--- a/v2/internal/attacktechniques/aws/impact/bedrock-invoke-model/main.go
+++ b/v2/internal/attacktechniques/aws/impact/bedrock-invoke-model/main.go
@@ -88,7 +88,19 @@ References:
 		Platform:           stratus.AWS,
 		IsIdempotent:       true,
 		MitreAttackTactics: []mitreattack.Tactic{mitreattack.Impact},
-		Detonate:           detonate,
+		FrameworkMappings: []stratus.FrameworkMappings{
+			{
+				Framework: stratus.MitreAtlas,
+				Techniques: []stratus.TechniqueMapping{
+					{
+						Name: "Cost Harvesting",
+						ID:   "AML.T0034",
+						URL:  "https://atlas.mitre.org/techniques/AML.T0034",
+					},
+				},
+			},
+		},
+		Detonate: detonate,
 	})
 }
 

--- a/v2/pkg/stratus/framework.go
+++ b/v2/pkg/stratus/framework.go
@@ -6,6 +6,9 @@ type Framework string
 const (
 	// ThreatTechniqueCatalogAWS is the Threat Technique Catalog for AWS
 	ThreatTechniqueCatalogAWS Framework = "Threat Technique Catalog for AWS"
+
+	// MitreAtlas is the MITRE ATLAS framework for adversarial threats against AI systems
+	MitreAtlas Framework = "MITRE ATLAS"
 )
 
 // TechniqueMapping represents a mapping to a specific technique in a framework.


### PR DESCRIPTION
### What does this PR do?

- Enhancement

Adds **MITRE ATLAS** as a first-class `Framework` in `v2/pkg/stratus/framework.go`, alongside the existing `Threat Technique Catalog for AWS`, and maps the existing `aws.impact.bedrock-invoke-model` technique to ATLAS **Cost Harvesting (`AML.T0034`)**. Documentation is regenerated via `make docs`.

### Motivation

Stratus Red Team already models the AI/LLM attack surface (`aws.impact.bedrock-invoke-model` emulates LLMjacking), and the framework-mapping machinery (`FrameworkMappings`, `TechniqueMapping`, the docs template, and `index.yaml`) is fully generic. The only thing missing is the ATLAS framework constant.

MITRE ATT&CK does not have techniques specific to adversarial AI systems; that is precisely the gap [MITRE ATLAS](https://atlas.mitre.org/) fills. LLMjacking -- using stolen cloud credentials to run inference on a victim's account -- maps cleanly to ATLAS **Cost Harvesting (`AML.T0034`)** under the Impact tactic, where an adversary deliberately drives a victim's AI service beyond normal operating capacity to inflate cost. Documented incidents have reached ~$46K/day on a single compromised account.

Adding the framework as a constant is the one-line unlock that lets every current and future AI technique carry an ATLAS tag, exactly as AWS techniques already carry Threat Technique Catalog for AWS tags. This PR ships the constant plus the first concrete mapping as a worked example.

### Change

Following the repo's existing conventions exactly:

1. `v2/pkg/stratus/framework.go` -- add `MitreAtlas Framework = "MITRE ATLAS"` to the `Framework` enum block, with a doc comment mirroring `ThreatTechniqueCatalogAWS`. No struct or template changes were needed -- `FrameworkMappings`/`TechniqueMapping` and the docs renderer are framework-agnostic.
2. `v2/internal/attacktechniques/aws/impact/bedrock-invoke-model/main.go` -- add a `FrameworkMappings` entry pointing at ATLAS `AML.T0034` (Cost Harvesting), using the same struct shape as the existing `ThreatTechniqueCatalogAWS` mappings.
3. `docs/attack-techniques/AWS/aws.impact.bedrock-invoke-model.md` and `docs/index.yaml` -- regenerated with `make docs` (no manual edits).

The mapping renders under the existing **## Mappings** section with no template change.

### Security rationale

`aws.impact.bedrock-invoke-model` emulates LLMjacking (per Sysdig / Permiso research already cited in the technique). In ATT&CK terms this is tagged `Impact`; ATLAS makes it precise: **Cost Harvesting (`AML.T0034`)** in the ATLAS Impact tactic -- an adversary monetizing a victim's foundation-model entitlement, driving up spend and consuming model quota. The closest ATT&CK analogue, `T1496 Resource Hijacking`, does not capture the inference/quota dimension.

This also aligns with **OWASP LLM Top 10 -- LLM10: Unbounded Consumption** (formerly Model Denial of Service), which calls out exactly this abuse. Giving the technique an ATLAS handle lets detection and threat-modeling teams pivot between Stratus emulation, ATLAS case studies, and OWASP LLM controls without a manual crosswalk.

`AML.T0034` was selected deliberately over `AML.T0049` (which is *Exploit Public-Facing Application*, not resource hijacking) after verifying technique IDs against the published [`mitre-atlas/atlas-data`](https://github.com/mitre-atlas/atlas-data) dataset.

### Testing / validation

Run against a fresh clone of `main` (Go 1.26.2):

- `gofmt -l` on both touched `.go` files -- clean (no diff).
- `go build ./...` -- succeeds.
- `go vet ./pkg/stratus/... ./internal/attacktechniques/aws/impact/bedrock-invoke-model/...` -- clean.
- `go test ./pkg/stratus/...` -- all packages pass (`pkg/stratus`, `config`, `runner`).
- `make docs` -- regenerates docs deterministically; the only diff is the new ATLAS mapping in the Bedrock technique's page and in `index.yaml`. No unrelated files changed.

No live AWS target or credentials are required -- this change is purely declarative metadata plus generated docs; detonation behavior is untouched.
