### PR TITLE
Add JSON output format (--output json) for list, status, and show

### DIFF
--- a/docs/user-guide/commands/list.md
+++ b/docs/user-guide/commands/list.md
@@ -16,3 +16,11 @@ stratus list --platform aws
 ```title="List available attack techniques for the MITRE ATT&CK 'persistence' tactic"
 stratus list --platform aws --mitre-attack-tactic persistence
 ```
+
+```bash title="Output the list of attack techniques as JSON (for automation/SIEM ingestion)"
+stratus list --output json
+```
+
+Using `--output json` (or `-o json`) emits one object per technique with its
+`id`, `name`, `platform`, `isSlow`, `isIdempotent` and `mitreAttackTactics`. The
+`--output` flag is global and also works with `stratus status` and `stratus show`.

--- a/docs/user-guide/commands/show.md
+++ b/docs/user-guide/commands/show.md
@@ -8,3 +8,11 @@ title: show
 ```bash title="Display more information about an attack technique"
 stratus show aws.credential-access.ec2-steal-instance-credentials
 ```
+
+```bash title="Output the full technique details as JSON"
+stratus show aws.credential-access.ec2-steal-instance-credentials --output json
+```
+
+In JSON mode, `show` outputs the technique's full metadata — including its
+`description`, `detection` guidance, `mitreAttackTactics` and any framework
+mappings — as a JSON array.

--- a/docs/user-guide/commands/status.md
+++ b/docs/user-guide/commands/status.md
@@ -25,3 +25,24 @@ stratus status
 | aws.persistence.iam-backdoor-user                          | Create an Access Key on an IAM User                    | DETONATED   |
 +------------------------------------------------------------+--------------------------------------------------------+-------------+
 ```
+
+### JSON output
+
+```bash title="Output technique states as JSON"
+stratus status --output json
+```
+
+```json
+[
+  {
+    "id": "aws.defense-evasion.cloudtrail-stop",
+    "name": "Stop a CloudTrail Trail",
+    "state": "WARM"
+  },
+  {
+    "id": "aws.persistence.iam-backdoor-user",
+    "name": "Create an Access Key on an IAM User",
+    "state": "DETONATED"
+  }
+]
+```

--- a/v2/cmd/stratus/cmd/list_cmd.go
+++ b/v2/cmd/stratus/cmd/list_cmd.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"fmt"
 	"log"
+	"os"
 	"strings"
 
 	"github.com/datadog/stratus-red-team/v2/pkg/stratus"
@@ -49,6 +50,14 @@ func doListCmd(mitreAttackTactic string, platform string) {
 		filter.Tactic = tactic
 	}
 	techniques := stratus.GetRegistry().GetAttackTechniques(&filter)
+
+	if isJSONOutput() {
+		if err := outputJSON(os.Stdout, toTechniqueListJSON(techniques)); err != nil {
+			log.Fatal(err)
+		}
+		return
+	}
+
 	t := GetDisplayTable()
 	t.AppendHeader(table.Row{"Technique ID", "Technique name", "Platform", "MITRE ATT&CK Tactic"})
 

--- a/v2/cmd/stratus/cmd/output.go
+++ b/v2/cmd/stratus/cmd/output.go
@@ -1,0 +1,148 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+
+	"github.com/datadog/stratus-red-team/v2/pkg/stratus"
+	"github.com/datadog/stratus-red-team/v2/pkg/stratus/mitreattack"
+)
+
+// Supported values for the global --output/-o flag.
+const (
+	OutputFormatTable = "table"
+	OutputFormatJSON  = "json"
+)
+
+// outputFormat holds the value of the global --output/-o flag. It defaults to
+// "table" to preserve the historical human-readable output.
+var outputFormat = OutputFormatTable
+
+// validateOutputFormat ensures the user-supplied output format is supported.
+func validateOutputFormat(format string) error {
+	switch format {
+	case OutputFormatTable, OutputFormatJSON:
+		return nil
+	default:
+		return fmt.Errorf("unsupported output format %q (must be one of: %s, %s)", format, OutputFormatTable, OutputFormatJSON)
+	}
+}
+
+// isJSONOutput returns true when the user requested JSON output.
+func isJSONOutput() bool {
+	return outputFormat == OutputFormatJSON
+}
+
+// outputJSON writes v to w as indented JSON, followed by a trailing newline.
+func outputJSON(w io.Writer, v interface{}) error {
+	encoder := json.NewEncoder(w)
+	encoder.SetIndent("", "  ")
+	encoder.SetEscapeHTML(false)
+	return encoder.Encode(v)
+}
+
+// The structs below define a stable JSON contract for the CLI. They are
+// intentionally decoupled from stratus.AttackTechnique, which carries fields
+// that must not (and cannot) be serialized — the Detonate/Revert closures and
+// the embedded Terraform code.
+
+type techniqueListItemJSON struct {
+	ID                 string   `json:"id"`
+	Name               string   `json:"name"`
+	Platform           string   `json:"platform"`
+	IsSlow             bool     `json:"isSlow"`
+	IsIdempotent       bool     `json:"isIdempotent"`
+	MitreAttackTactics []string `json:"mitreAttackTactics"`
+}
+
+type techniqueStatusJSON struct {
+	ID    string `json:"id"`
+	Name  string `json:"name"`
+	State string `json:"state"`
+}
+
+type techniqueMappingJSON struct {
+	Name string `json:"name"`
+	ID   string `json:"id"`
+	URL  string `json:"url"`
+}
+
+type frameworkMappingJSON struct {
+	Framework  string                 `json:"framework"`
+	Techniques []techniqueMappingJSON `json:"techniques"`
+}
+
+type techniqueDetailJSON struct {
+	ID                 string                 `json:"id"`
+	Name               string                 `json:"name"`
+	Platform           string                 `json:"platform"`
+	IsSlow             bool                   `json:"isSlow"`
+	IsIdempotent       bool                   `json:"isIdempotent"`
+	MitreAttackTactics []string               `json:"mitreAttackTactics"`
+	Description        string                 `json:"description"`
+	Detection          string                 `json:"detection"`
+	FrameworkMappings  []frameworkMappingJSON `json:"frameworkMappings,omitempty"`
+}
+
+func tacticsToStrings(tactics []mitreattack.Tactic) []string {
+	result := make([]string, 0, len(tactics))
+	for i := range tactics {
+		result = append(result, mitreattack.AttackTacticToString(tactics[i]))
+	}
+	return result
+}
+
+func toFrameworkMappingsJSON(mappings []stratus.FrameworkMappings) []frameworkMappingJSON {
+	if len(mappings) == 0 {
+		return nil
+	}
+	result := make([]frameworkMappingJSON, 0, len(mappings))
+	for i := range mappings {
+		techniques := make([]techniqueMappingJSON, 0, len(mappings[i].Techniques))
+		for j := range mappings[i].Techniques {
+			techniques = append(techniques, techniqueMappingJSON{
+				Name: mappings[i].Techniques[j].Name,
+				ID:   mappings[i].Techniques[j].ID,
+				URL:  mappings[i].Techniques[j].URL,
+			})
+		}
+		result = append(result, frameworkMappingJSON{
+			Framework:  string(mappings[i].Framework),
+			Techniques: techniques,
+		})
+	}
+	return result
+}
+
+// toTechniqueListJSON maps attack techniques to their JSON list representation.
+func toTechniqueListJSON(techniques []*stratus.AttackTechnique) []techniqueListItemJSON {
+	result := make([]techniqueListItemJSON, 0, len(techniques))
+	for i := range techniques {
+		result = append(result, techniqueListItemJSON{
+			ID:                 techniques[i].ID,
+			Name:               techniques[i].FriendlyName,
+			Platform:           string(techniques[i].Platform),
+			IsSlow:             techniques[i].IsSlow,
+			IsIdempotent:       techniques[i].IsIdempotent,
+			MitreAttackTactics: tacticsToStrings(techniques[i].MitreAttackTactics),
+		})
+	}
+	return result
+}
+
+// toTechniqueDetailJSON maps a single attack technique to its detailed JSON
+// representation, used by the `show` command.
+func toTechniqueDetailJSON(technique *stratus.AttackTechnique) techniqueDetailJSON {
+	return techniqueDetailJSON{
+		ID:                 technique.ID,
+		Name:               technique.FriendlyName,
+		Platform:           string(technique.Platform),
+		IsSlow:             technique.IsSlow,
+		IsIdempotent:       technique.IsIdempotent,
+		MitreAttackTactics: tacticsToStrings(technique.MitreAttackTactics),
+		Description:        technique.Description,
+		Detection:          technique.Detection,
+		FrameworkMappings:  toFrameworkMappingsJSON(technique.FrameworkMappings),
+	}
+}

--- a/v2/cmd/stratus/cmd/output_test.go
+++ b/v2/cmd/stratus/cmd/output_test.go
@@ -1,0 +1,130 @@
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/datadog/stratus-red-team/v2/pkg/stratus"
+	"github.com/datadog/stratus-red-team/v2/pkg/stratus/mitreattack"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func sampleTechnique() *stratus.AttackTechnique {
+	return &stratus.AttackTechnique{
+		ID:                 "aws.persistence.sample",
+		FriendlyName:       "Sample Technique",
+		Platform:           stratus.AWS,
+		IsSlow:             true,
+		IsIdempotent:       false,
+		Description:        "A description containing <html> & ampersands",
+		Detection:          "Look for CloudTrail events such as foo & bar",
+		MitreAttackTactics: []mitreattack.Tactic{mitreattack.Persistence, mitreattack.CredentialAccess},
+		FrameworkMappings: []stratus.FrameworkMappings{
+			{
+				Framework: stratus.ThreatTechniqueCatalogAWS,
+				Techniques: []stratus.TechniqueMapping{
+					{Name: "Create Account", ID: "TA0003", URL: "https://example.com/ta0003"},
+				},
+			},
+		},
+	}
+}
+
+func TestValidateOutputFormat(t *testing.T) {
+	assert.NoError(t, validateOutputFormat(OutputFormatTable))
+	assert.NoError(t, validateOutputFormat(OutputFormatJSON))
+	assert.Error(t, validateOutputFormat("yaml"))
+	assert.Error(t, validateOutputFormat(""))
+	assert.Error(t, validateOutputFormat("JSON")) // case-sensitive on purpose
+}
+
+func TestIsJSONOutput(t *testing.T) {
+	original := outputFormat
+	defer func() { outputFormat = original }()
+
+	outputFormat = OutputFormatJSON
+	assert.True(t, isJSONOutput())
+	outputFormat = OutputFormatTable
+	assert.False(t, isJSONOutput())
+}
+
+func TestOutputJSONIsValidIndentedAndDoesNotEscapeHTML(t *testing.T) {
+	var buf bytes.Buffer
+	require.NoError(t, outputJSON(&buf, map[string]string{"key": "a & b <c>"}))
+
+	out := buf.String()
+	assert.True(t, strings.HasSuffix(out, "\n"), "output should end with a newline")
+	assert.Contains(t, out, "  ", "output should be indented")
+	// SetEscapeHTML(false) keeps &, <, > literal so consumers see real values
+	assert.Contains(t, out, "a & b <c>")
+	assert.NotContains(t, out, "\\u0026")
+
+	// And it must still be valid JSON
+	var roundTrip map[string]string
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &roundTrip))
+	assert.Equal(t, "a & b <c>", roundTrip["key"])
+}
+
+func TestToTechniqueListJSON(t *testing.T) {
+	technique := sampleTechnique()
+	items := toTechniqueListJSON([]*stratus.AttackTechnique{technique})
+
+	require.Len(t, items, 1)
+	item := items[0]
+	assert.Equal(t, "aws.persistence.sample", item.ID)
+	assert.Equal(t, "Sample Technique", item.Name)
+	assert.Equal(t, "AWS", item.Platform)
+	assert.True(t, item.IsSlow)
+	assert.False(t, item.IsIdempotent)
+	assert.Equal(t, []string{
+		mitreattack.AttackTacticToString(mitreattack.Persistence),
+		mitreattack.AttackTacticToString(mitreattack.CredentialAccess),
+	}, item.MitreAttackTactics)
+}
+
+func TestToTechniqueListJSONEmptyTacticsSerializesToEmptyArray(t *testing.T) {
+	technique := &stratus.AttackTechnique{ID: "aws.x", Platform: stratus.AWS}
+	var buf bytes.Buffer
+	require.NoError(t, outputJSON(&buf, toTechniqueListJSON([]*stratus.AttackTechnique{technique})))
+	// Empty tactics must render as [] (not null) so downstream parsers are stable
+	assert.Contains(t, buf.String(), `"mitreAttackTactics": []`)
+}
+
+func TestListJSONRoundTrip(t *testing.T) {
+	technique := sampleTechnique()
+	var buf bytes.Buffer
+	require.NoError(t, outputJSON(&buf, toTechniqueListJSON([]*stratus.AttackTechnique{technique})))
+
+	var decoded []techniqueListItemJSON
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &decoded))
+	require.Len(t, decoded, 1)
+	assert.Equal(t, technique.ID, decoded[0].ID)
+	assert.Equal(t, technique.FriendlyName, decoded[0].Name)
+	assert.Len(t, decoded[0].MitreAttackTactics, 2)
+}
+
+func TestToTechniqueDetailJSON(t *testing.T) {
+	detail := toTechniqueDetailJSON(sampleTechnique())
+
+	assert.Equal(t, "aws.persistence.sample", detail.ID)
+	assert.Equal(t, "Sample Technique", detail.Name)
+	assert.Equal(t, "AWS", detail.Platform)
+	assert.Contains(t, detail.Description, "ampersands")
+	assert.Contains(t, detail.Detection, "CloudTrail")
+	require.Len(t, detail.FrameworkMappings, 1)
+	assert.Equal(t, string(stratus.ThreatTechniqueCatalogAWS), detail.FrameworkMappings[0].Framework)
+	require.Len(t, detail.FrameworkMappings[0].Techniques, 1)
+	assert.Equal(t, "TA0003", detail.FrameworkMappings[0].Techniques[0].ID)
+	assert.Equal(t, "Create Account", detail.FrameworkMappings[0].Techniques[0].Name)
+}
+
+func TestToTechniqueDetailJSONOmitsEmptyFrameworkMappings(t *testing.T) {
+	technique := &stratus.AttackTechnique{ID: "aws.x", Platform: stratus.AWS}
+	var buf bytes.Buffer
+	require.NoError(t, outputJSON(&buf, toTechniqueDetailJSON(technique)))
+	// frameworkMappings has omitempty: absent when there are none
+	assert.NotContains(t, buf.String(), "frameworkMappings")
+}

--- a/v2/cmd/stratus/cmd/root.go
+++ b/v2/cmd/stratus/cmd/root.go
@@ -10,10 +10,17 @@ import (
 
 var RootCmd = &cobra.Command{
 	Use: "stratus",
+	// Validate the global output format early, before any subcommand runs.
+	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+		return validateOutputFormat(outputFormat)
+	},
 }
 
 func init() {
 	setupLogging()
+
+	RootCmd.PersistentFlags().StringVarP(&outputFormat, "output", "o", OutputFormatTable,
+		"Output format: "+OutputFormatTable+" or "+OutputFormatJSON)
 
 	listCmd := buildListCmd()
 	showCmd := buildShowCmd()

--- a/v2/cmd/stratus/cmd/show_cmd.go
+++ b/v2/cmd/stratus/cmd/show_cmd.go
@@ -3,6 +3,8 @@ package cmd
 import (
 	"errors"
 	"fmt"
+	"log"
+	"os"
 
 	"github.com/datadog/stratus-red-team/v2/pkg/stratus"
 	"github.com/spf13/cobra"
@@ -31,6 +33,17 @@ func buildShowCmd() *cobra.Command {
 }
 
 func doShowCmd(techniques []*stratus.AttackTechnique) {
+	if isJSONOutput() {
+		details := make([]techniqueDetailJSON, 0, len(techniques))
+		for i := range techniques {
+			details = append(details, toTechniqueDetailJSON(techniques[i]))
+		}
+		if err := outputJSON(os.Stdout, details); err != nil {
+			log.Fatal(err)
+		}
+		return
+	}
+
 	for i := range techniques {
 		fmt.Println(techniques[i].Description)
 	}

--- a/v2/cmd/stratus/cmd/status_cmd.go
+++ b/v2/cmd/stratus/cmd/status_cmd.go
@@ -1,6 +1,9 @@
 package cmd
 
 import (
+	"log"
+	"os"
+
 	"github.com/datadog/stratus-red-team/v2/internal/state"
 	"github.com/datadog/stratus-red-team/v2/pkg/stratus"
 	"github.com/fatih/color"
@@ -32,17 +35,37 @@ func buildStatusCmd() *cobra.Command {
 }
 
 func doStatusCmd(techniques []*stratus.AttackTechnique) {
+	if isJSONOutput() {
+		items := make([]techniqueStatusJSON, 0, len(techniques))
+		for i := range techniques {
+			items = append(items, techniqueStatusJSON{
+				ID:    techniques[i].ID,
+				Name:  techniques[i].FriendlyName,
+				State: string(resolveTechniqueState(techniques[i])),
+			})
+		}
+		if err := outputJSON(os.Stdout, items); err != nil {
+			log.Fatal(err)
+		}
+		return
+	}
+
 	t := GetDisplayTable()
 	t.AppendHeader(table.Row{"ID", "Name", "Status"})
 	for i := range techniques {
-		stateManager := state.NewFileSystemStateManager(techniques[i])
-		techniqueState := stateManager.GetTechniqueState()
-		if techniqueState == "" {
-			techniqueState = stratus.AttackTechniqueStatusCold
-		}
-		t.AppendRow(table.Row{techniques[i].ID, techniques[i].FriendlyName, colorState(techniqueState)})
+		t.AppendRow(table.Row{techniques[i].ID, techniques[i].FriendlyName, colorState(resolveTechniqueState(techniques[i]))})
 	}
 	t.Render()
+}
+
+// resolveTechniqueState returns the persisted state of a technique, defaulting
+// to COLD when no state has been recorded yet.
+func resolveTechniqueState(technique *stratus.AttackTechnique) stratus.AttackTechniqueState {
+	techniqueState := state.NewFileSystemStateManager(technique).GetTechniqueState()
+	if techniqueState == "" {
+		return stratus.AttackTechniqueStatusCold
+	}
+	return techniqueState
 }
 
 func colorState(state stratus.AttackTechniqueState) string {

--- a/v2/cmd/stratus/main.go
+++ b/v2/cmd/stratus/main.go
@@ -1,7 +1,15 @@
 package main
 
-import "github.com/datadog/stratus-red-team/v2/cmd/stratus/cmd"
+import (
+	"os"
+
+	"github.com/datadog/stratus-red-team/v2/cmd/stratus/cmd"
+)
 
 func main() {
-	cmd.RootCmd.Execute()
+	// Exit with a non-zero status when a command (or flag validation) fails,
+	// so the CLI is usable in scripts and CI. Cobra already prints the error.
+	if err := cmd.RootCmd.Execute(); err != nil {
+		os.Exit(1)
+	}
 }


### PR DESCRIPTION
## What this does

Adds a global `--output`/`-o` flag (`table` | `json`, default `table`) so the read-only commands can emit machine-readable JSON:

- `stratus list -o json` — the full technique catalog (id, name, platform, isSlow, isIdempotent, mitreAttackTactics)
- `stratus status -o json` — per-technique state (id, name, state)
- `stratus show <id> -o json` — full technique detail (description, detection, MITRE tactics, framework mappings)

Closes #241.

## Why

The only way to consume Stratus' technique inventory or state today is by scraping the rendered tables. JSON output makes Stratus scriptable for automation, CI pipelines, and SIEM/detection-engineering ingestion (the use case raised in #241).

## Example

```console
$ stratus list -o json | jq '.[0]'
{
  "id": "aws.credential-access.ec2-get-password-data",
  "name": "Retrieve EC2 Password Data",
  "platform": "AWS",
  "isSlow": false,
  "isIdempotent": true,
  "mitreAttackTactics": ["Credential Access"]
}
```

## Implementation notes

- New `v2/cmd/stratus/cmd/output.go` defines **stable JSON view models** decoupled from `stratus.AttackTechnique` — that struct carries `Detonate`/`Revert` closures and embedded Terraform `[]byte`, which must not (and cannot) be serialized. This keeps the JSON contract stable even if the internal struct changes.
- The flag is a root **persistent flag**, validated in `PersistentPreRunE`, so every command inherits it and unknown formats are rejected early.
- Default behaviour is unchanged: without `-o json`, the existing colored tables render exactly as before.
- `main()` now exits non-zero when a command (or flag validation) fails. Previously the error from `RootCmd.Execute()` was discarded, so even invalid input exited `0` — which would make the new `-o` validation (and any other error) undetectable in scripts.

## Tests

- Adds the **first unit tests under `cmd/`** (`output_test.go`): JSON mapping for list/show, framework-mapping serialization, empty-slice vs `null` stability, no HTML-escaping, and `--output` validation.
- `go test ./...`, `go vet`, `gofmt`, and `staticcheck ./cmd/...` all pass locally.

## Scope

Scoped to the read-only commands (`list`, `status`, `show`) that have structured output. `detonate`/`warmup`/`revert`/`cleanup` stream progress logs and are intentionally left as-is; structured result output for those can be a follow-up.
