### PR TITLE
Fix documentation typos

### DIFF
--- a/docs/attack-techniques/philosophy.md
+++ b/docs/attack-techniques/philosophy.md
@@ -27,7 +27,7 @@ Examples:
     - While attackers might use this API call, it is in no way indicative of attacker activity, as it's used by many services and client applications.
     - It isn't emulating activity that could reasonably be thought to be malicious.
 
-Stratus Red Team's goal is *not* to re-implement all AWS API calls that may be used by an attacker, neither to emulate all possible theoritical attack vectors.
+Stratus Red Team's goal is *not* to re-implement all AWS API calls that may be used by an attacker, neither to emulate all possible theoretical attack vectors.
 
 ## Be Self-Sufficient
 

--- a/examples/basic/README.md
+++ b/examples/basic/README.md
@@ -1,4 +1,4 @@
-# Example: programatically detonating a Stratus Red Team attack technique
+# Example: programmatically detonating a Stratus Red Team attack technique
 
 ```
 go get github.com/datadog/stratus-red-team


### PR DESCRIPTION
## Summary
I fix spelling mistakes in documentation and changelog text.

Changed files:
- `docs/attack-techniques/philosophy.md`
- `examples/basic/README.md`

## Testing
I run `git diff --check`.
