### PR TITLE
fix(state): write correlation.tf in S3 backend ExtractTechnique

### DIFF
--- a/v2/internal/state/s3_state.go
+++ b/v2/internal/state/s3_state.go
@@ -78,15 +78,8 @@ func (m *S3StateManager) GetRootDirectory() string {
 func (m *S3StateManager) ExtractTechnique() error {
 	dir := m.techniqueDir()
 
-	// Write main.tf (same as FileSystemStateManager)
-	mainTf := filepath.Join(dir, StratusStateTerraformFileName)
-	if err := m.fileSystem.WriteFile(mainTf, m.technique.PrerequisitesTerraformCode, 0644); err != nil {
-		return err
-	}
-
-	// Write shared config.tf (same as FileSystemStateManager)
-	configTf := filepath.Join(dir, "config.tf")
-	if err := m.fileSystem.WriteFile(configTf, config.SharedTerraformConfigVariable, 0644); err != nil {
+	// Write the shared scaffolding common to every backend.
+	if err := writeSharedTerraformFiles(m.fileSystem, dir, m.technique); err != nil {
 		return err
 	}
 

--- a/v2/internal/state/s3_state_test.go
+++ b/v2/internal/state/s3_state_test.go
@@ -53,6 +53,11 @@ func TestS3StateManagerExtractTechniqueWritesBackendTf(t *testing.T) {
 	configTf, err := sm.fileSystem.ReadFile(sm.techniqueDir() + "/config.tf")
 	assert.Nil(t, err)
 	assert.NotEmpty(t, configTf)
+
+	// Check correlation.tf
+	correlationTf, err := sm.fileSystem.ReadFile(sm.techniqueDir() + "/correlation.tf")
+	assert.Nil(t, err)
+	assert.Contains(t, string(correlationTf), `variable "correlation"`)
 }
 
 func TestS3StateManagerBackendConfigs(t *testing.T) {

--- a/v2/internal/state/state.go
+++ b/v2/internal/state/state.go
@@ -122,26 +122,29 @@ func (m *FileSystemStateManager) Initialize() {
 	}
 }
 
-func (m *FileSystemStateManager) ExtractTechnique() error {
-	terraformDirectory := m.getTechniqueStateDirectory()
-	terraformFile := filepath.Join(terraformDirectory, StratusStateTerraformFileName)
-
-	if err := m.FileSystem.WriteFile(terraformFile, m.Technique.PrerequisitesTerraformCode, 0644); err != nil {
-		return err
+// writeSharedTerraformFiles writes the Terraform source files common to every
+// state backend into dir. Backend-specific files (e.g. the S3 backend.tf) stay
+// with the caller, keeping this the single source of truth for the shared
+// scaffolding so every StateManager stays in sync.
+func writeSharedTerraformFiles(fileSystem FileSystem, directory string, technique *stratus.AttackTechnique) error {
+	files := []struct {
+		name    string
+		content []byte
+	}{
+		{StratusStateTerraformFileName, technique.PrerequisitesTerraformCode},
+		{"config.tf", config.SharedTerraformConfigVariable},
+		{"correlation.tf", sharedCorrelationVariable},
 	}
-
-	// Inject shared variable definitions alongside the technique's main.tf
-	configFile := filepath.Join(terraformDirectory, "config.tf")
-	if err := m.FileSystem.WriteFile(configFile, config.SharedTerraformConfigVariable, 0644); err != nil {
-		return err
+	for _, file := range files {
+		if err := fileSystem.WriteFile(filepath.Join(directory, file.name), file.content, 0644); err != nil {
+			return err
+		}
 	}
-
-	correlationFile := filepath.Join(terraformDirectory, "correlation.tf")
-	if err := m.FileSystem.WriteFile(correlationFile, sharedCorrelationVariable, 0644); err != nil {
-		return err
-	}
-
 	return nil
+}
+
+func (m *FileSystemStateManager) ExtractTechnique() error {
+	return writeSharedTerraformFiles(m.FileSystem, m.getTechniqueStateDirectory(), m.Technique)
 }
 
 func (m *FileSystemStateManager) CleanupTechnique() error {


### PR DESCRIPTION
### What does this PR do?

<!--
* New attack technique
* Bug fix
* Enhancement
-->

Bug Fix: The S3StateManager omitted the correlation.tf declaration that the runner's unconditional "correlation" variable and techniques referencing var.correlation.id require, causing S3-backed warm-ups to fail.

When using a remote S3 state, this only impacts the 4 k8s techniques that use var.correlation id. Other techniques logged a warning.
When using the local state, there was no error

Solution: Extract the shared scaffolding into writeSharedTerraformFiles so both backends stay in sync.
