### PR TITLE
Map IAM role backdooring to AWS TTC T1098.003

### DIFF
--- a/docs/attack-techniques/AWS/aws.persistence.iam-backdoor-role.md
+++ b/docs/attack-techniques/AWS/aws.persistence.iam-backdoor-role.md
@@ -15,6 +15,11 @@ Platform: AWS
     - Persistence
 
 
+- Threat Technique Catalog for AWS:
+  
+    - [Account Manipulation: Additional Cloud Roles](https://aws-samples.github.io/threat-technique-catalog-for-aws/Techniques/T1098.003.html) (T1098.003)
+  
+
 
 ## Description
 

--- a/docs/index.yaml
+++ b/docs/index.yaml
@@ -326,6 +326,12 @@ AWS:
           isSlow: false
           mitreAttackTactics:
             - Persistence
+          frameworkmappings:
+            - framework: Threat Technique Catalog for AWS
+              techniques:
+                - name: 'Account Manipulation: Additional Cloud Roles'
+                  id: T1098.003
+                  url: https://aws-samples.github.io/threat-technique-catalog-for-aws/Techniques/T1098.003.html
           platform: AWS
           isIdempotent: true
         - id: aws.persistence.iam-backdoor-user

--- a/v2/internal/attacktechniques/aws/persistence/iam-backdoor-role/main.go
+++ b/v2/internal/attacktechniques/aws/persistence/iam-backdoor-role/main.go
@@ -44,9 +44,21 @@ Detonation:
 - Through [IAM Access Analyzer](https://docs.aws.amazon.com/IAM/latest/UserGuide/access-analyzer-resources.html#access-analyzer-iam-role),
 which generates a finding when a role can be assumed from a new AWS account or publicly.
 `,
-		Platform:                   stratus.AWS,
-		IsIdempotent:               true,
-		MitreAttackTactics:         []mitreattack.Tactic{mitreattack.Persistence},
+		Platform:           stratus.AWS,
+		IsIdempotent:       true,
+		MitreAttackTactics: []mitreattack.Tactic{mitreattack.Persistence},
+		FrameworkMappings: []stratus.FrameworkMappings{
+			{
+				Framework: stratus.ThreatTechniqueCatalogAWS,
+				Techniques: []stratus.TechniqueMapping{
+					{
+						Name: "Account Manipulation: Additional Cloud Roles",
+						ID:   "T1098.003",
+						URL:  "https://aws-samples.github.io/threat-technique-catalog-for-aws/Techniques/T1098.003.html",
+					},
+				},
+			},
+		},
 		PrerequisitesTerraformCode: tf,
 		Detonate:                   detonate,
 		Revert:                     revert,


### PR DESCRIPTION
### What does this PR do?

- Adds the AWS Threat Technique Catalog mapping `T1098.003` to the existing `aws.persistence.iam-backdoor-role` technique.
- Regenerates the associated technique documentation and YAML index.
- Documents the March 2026 AWS Threat Technique Catalog coverage outcome:
  - `T1098.003` is covered by `aws.persistence.iam-backdoor-role`;
  - `T1098.A006` is tracked in #910;
  - `T1485.A002` is tracked in #911.

### Motivation

The March 2026 AWS Threat Technique Catalog update added `iam:UpdateAssumeRolePolicy` to **Account Manipulation: Additional Cloud Roles (`T1098.003`)**.

Stratus Red Team already performs this exact action in `aws.persistence.iam-backdoor-role`, but the technique did not expose the corresponding AWS TTC framework mapping.

The Cognito refresh-token abuse and AMI deregistration behaviors are separate atomic attack steps and are intentionally not implemented in this pull request. Follow-up issues #910 and #911 were created for those gaps; the proposed labels could not be applied with contributor permissions.

Refs #863.

## Why

Adding the missing framework metadata makes the existing implementation discoverable as coverage for AWS TTC `T1098.003` without duplicating or changing its attack behavior.

## Changes

- Add the `ThreatTechniqueCatalogAWS` mapping for `T1098.003` to `aws.persistence.iam-backdoor-role`.
- Regenerate `docs/attack-techniques/AWS/aws.persistence.iam-backdoor-role.md`.
- Regenerate the corresponding entry in `docs/index.yaml`.

## Validation

- [x] `gofmt -w v2/internal/attacktechniques/aws/persistence/iam-backdoor-role/main.go`
- [x] `make SHELL='C:/Program Files/Git/bin/bash.exe'`
- [x] `go test ./internal/attacktechniques/aws/persistence/iam-backdoor-role -v`
- [x] `make docs`
- [ ] `make SHELL='C:/Program Files/Git/bin/bash.exe' test` — the full suite compiles the changed package, then three existing `pkg/stratus/runner` assertions fail on Windows because they expect `/root/foo` while `filepath.Join` produces `\root\foo`.
- [ ] `git diff --check origin/main...HEAD` — the generated Markdown contains the same two whitespace-only lines emitted by the existing `v2/tools/doc.tpl` framework-mapping block.

### Checklist

The new-attack-technique checklist is not applicable because this pull request only adds framework metadata to an existing technique.
