### PR TITLE
feat(aws): add configurable resource tags and prefixes

### DIFF
--- a/docs/dev-guide/configuration.md
+++ b/docs/dev-guide/configuration.md
@@ -2,7 +2,7 @@
 
 Stratus Red Team has a configuration system that lets users customize how techniques create resources (namespace, images, tolerations, etc.). This page explains how to consume the configuration in your technique.
 
-For now, only Kubernetes-specific keys are available, but it can be easily extended to handle other providers.
+AWS and Kubernetes configuration keys are currently available.
 
 ## In Terraform (recommended for prerequisites)
 
@@ -12,6 +12,14 @@ A shared `variable "config"` is automatically injected alongside your `main.tf` 
 locals {
   namespace = var.config.kubernetes.namespace != "" ? var.config.kubernetes.namespace : kubernetes_namespace.ns[0].metadata[0].name
   image     = var.config.kubernetes.pod.image != "" ? var.config.kubernetes.pod.image : "alpine:3.15"
+}
+
+provider "aws" {
+  default_tags {
+    tags = merge(var.config.aws.tags, {
+      StratusRedTeam = true
+    })
+  }
 }
 
 resource "kubernetes_pod" "pod" {
@@ -47,7 +55,7 @@ func detonate(params map[string]string, providers stratus.CloudProviders) error 
 
 ## Adding new config keys
 
-To add support for a new configuration section (e.g. AWS-specific config):
+To add support for a new configuration section:
 
 1. Add the new properties to the JSON schema (`pkg/stratus/config/config.schema.json`)
 2. Add the corresponding Terraform variable type to `pkg/stratus/config/config.tf`

--- a/docs/dev-guide/configuration.md
+++ b/docs/dev-guide/configuration.md
@@ -53,6 +53,10 @@ func detonate(params map[string]string, providers stratus.CloudProviders) error 
 }
 ```
 
+!!! warning
+
+    AWS `tags` and `prefix` settings currently apply only to Terraform-managed prerequisites. Resources created directly by technique Go code during detonation do not yet receive these tags or prefixed names. This is a known issue tracked in [#942](https://github.com/DataDog/stratus-red-team/issues/942).
+
 ## Adding new config keys
 
 To add support for a new configuration section:

--- a/docs/user-guide/getting-started.md
+++ b/docs/user-guide/getting-started.md
@@ -239,6 +239,10 @@ For AWS techniques, it allows you to:
 - **Add custom tags** to Terraform-managed prerequisites supported by the AWS provider's `default_tags`
 - **Prefix resource names** with a service-compatible value, including through templating
 
+!!! warning
+
+    AWS `tags` and `prefix` settings currently apply only to Terraform-managed prerequisites. Resources created directly by technique Go code during detonation do not yet receive these tags or prefixed names. This is a known issue tracked in [#942](https://github.com/DataDog/stratus-red-team/issues/942).
+
 For Kubernetes techniques, it allows you to:
 
 - **Use a specific namespace** instead of creating one, when your user cannot create namespaces

--- a/docs/user-guide/getting-started.md
+++ b/docs/user-guide/getting-started.md
@@ -194,6 +194,21 @@ Tested with Minikube and AWS EKS.
 You can create a configuration file at `~/.stratus-red-team/config.yaml` (or use the `STRATUS_CONFIG_PATH` env var) to customize how Stratus Red Team creates resources. The configuration file is validated at startup.
 
 ```yaml
+aws:
+  # Default configuration applied to all AWS techniques
+  default:
+    # Prepended to the names of Terraform-managed prerequisites
+    prefix: "security-testing-"
+    tags:
+      Environment: "test"
+      Owner: "security"
+      StratusCorrelationID: "<% .CorrelationID %>"
+
+  techniques:
+    "aws.persistence.lambda-backdoor-function":
+      tags:
+        Purpose: "lambda-detection-validation"
+
 kubernetes:
   # Default configuration applied to all Kubernetes techniques
   default:
@@ -219,7 +234,12 @@ kubernetes:
         tolerations: ...
 ```
 
-This is currently used for Kubernetes techniques and allows you to:
+For AWS techniques, it allows you to:
+
+- **Add custom tags** to Terraform-managed prerequisites supported by the AWS provider's `default_tags`
+- **Prefix resource names** with a service-compatible value, including through templating
+
+For Kubernetes techniques, it allows you to:
 
 - **Use a specific namespace** instead of creating one, when your user cannot create namespaces
 - **Override container images**, when only images from private registries are allowed
@@ -235,11 +255,10 @@ The `default` section applies to all techniques. The `techniques` section allows
 Any string value in the config can reference the current detonation's correlation ID using `<%.CorrelationID%>`. The substitution is applied whenever Stratus reads the config to build a resource (at warmup for Terraform-built prerequisites, and at detonation for resources created directly by the technique's Go code):
 
 ```yaml
-kubernetes:
+aws:
   default:
-    pod:
-      labels:
-        detonation_id: "<% .CorrelationID %>"
+    tags:
+      StratusCorrelationID: "<% .CorrelationID %>"
 ```
 
 !!! note

--- a/v2/internal/attacktechniques/aws/credential-access/ec2-get-password-data/main.tf
+++ b/v2/internal/attacktechniques/aws/credential-access/ec2-get-password-data/main.tf
@@ -11,14 +11,14 @@ provider "aws" {
   skip_credentials_validation = true
   skip_get_ec2_platforms      = true
   default_tags {
-    tags = {
+    tags = merge(var.config.aws.tags, {
       StratusRedTeam = true
-    }
+    })
   }
 }
 
 locals {
-  resource_prefix = "stratus-red-team-ec2-get-password-data"
+  resource_prefix = "${var.config.aws.prefix}stratus-red-team-ec2-get-password-data"
 }
 
 data "aws_caller_identity" "current" {}

--- a/v2/internal/attacktechniques/aws/credential-access/ec2-steal-instance-credentials/main.tf
+++ b/v2/internal/attacktechniques/aws/credential-access/ec2-steal-instance-credentials/main.tf
@@ -12,14 +12,14 @@ provider "aws" {
   skip_credentials_validation = true
   skip_get_ec2_platforms      = true
   default_tags {
-    tags = {
+    tags = merge(var.config.aws.tags, {
       StratusRedTeam = true
-    }
+    })
   }
 }
 
 locals {
-  resource_prefix = "stratus-red-team-ec2-steal-credentials"
+  resource_prefix = "${var.config.aws.prefix}stratus-red-team-ec2-steal-credentials"
 }
 
 data "aws_availability_zones" "available" {

--- a/v2/internal/attacktechniques/aws/credential-access/secretsmanager-batch-retrieve-secrets/main.tf
+++ b/v2/internal/attacktechniques/aws/credential-access/secretsmanager-batch-retrieve-secrets/main.tf
@@ -11,15 +11,15 @@ provider "aws" {
   skip_credentials_validation = true
   skip_get_ec2_platforms      = true
   default_tags {
-    tags = {
+    tags = merge(var.config.aws.tags, {
       StratusRedTeam = true
-    }
+    })
   }
 }
 
 locals {
   num_secrets     = 42
-  resource_prefix = "stratus-red-team-retrieve--batch-secret"
+  resource_prefix = "${var.config.aws.prefix}stratus-red-team-retrieve--batch-secret"
 }
 
 resource "random_string" "secrets" {

--- a/v2/internal/attacktechniques/aws/credential-access/secretsmanager-retrieve-secrets/main.tf
+++ b/v2/internal/attacktechniques/aws/credential-access/secretsmanager-retrieve-secrets/main.tf
@@ -11,15 +11,15 @@ provider "aws" {
   skip_credentials_validation = true
   skip_get_ec2_platforms      = true
   default_tags {
-    tags = {
+    tags = merge(var.config.aws.tags, {
       StratusRedTeam = true
-    }
+    })
   }
 }
 
 locals {
   num_secrets     = 20
-  resource_prefix = "stratus-red-team-retrieve-secret"
+  resource_prefix = "${var.config.aws.prefix}stratus-red-team-retrieve-secret"
 }
 
 resource "random_string" "secrets" {

--- a/v2/internal/attacktechniques/aws/credential-access/ssm-retrieve-securestring-parameters/main.go
+++ b/v2/internal/attacktechniques/aws/credential-access/ssm-retrieve-securestring-parameters/main.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/ssm"
+	"github.com/aws/aws-sdk-go-v2/service/ssm/types"
 	"github.com/datadog/stratus-red-team/v2/pkg/stratus"
 	"github.com/datadog/stratus-red-team/v2/pkg/stratus/log"
 	"github.com/datadog/stratus-red-team/v2/pkg/stratus/mitreattack"
@@ -51,7 +52,12 @@ The following may be used to tune the detection, or validate findings:
 	})
 }
 
-func detonate(_ map[string]string, providers stratus.CloudProviders) error {
+func detonate(params map[string]string, providers stratus.CloudProviders) error {
+	ssmParameterPath := params["ssm_parameter_path"]
+	if ssmParameterPath == "" {
+		return errors.New("missing required Terraform output: ssm_parameter_path")
+	}
+
 	ssmClient := ssm.NewFromConfig(providers.AWS().GetConnection())
 
 	log.Println("Running ssm:DescribeParameters and ssm:GetParameters by batch of 10 to find all SSM Parameters in the current region")
@@ -65,13 +71,7 @@ func detonate(_ map[string]string, providers stratus.CloudProviders) error {
 		}
 
 		// Retrieve the value of SSM parameters by batch of 10 (maximum value supported by ssm:GetParameters)
-		var names []string
-		for i := range result.Parameters {
-			// only take into account parameters created by Stratus Red Team
-			if name := *result.Parameters[i].Name; strings.Index(name, "/credentials/stratus-red-team") == 0 {
-				names = append(names, name)
-			}
-		}
+		names := parameterNamesWithPrefix(result.Parameters, ssmParameterPath)
 
 		if len(names) == 0 {
 			continue
@@ -87,4 +87,14 @@ func detonate(_ map[string]string, providers stratus.CloudProviders) error {
 		log.Println("Successfully retrieved " + strconv.Itoa(len(response.Parameters)) + " SSM Parameters")
 	}
 	return nil
+}
+
+func parameterNamesWithPrefix(parameters []types.ParameterMetadata, prefix string) []string {
+	var names []string
+	for i := range parameters {
+		if name := aws.ToString(parameters[i].Name); strings.HasPrefix(name, prefix) {
+			names = append(names, name)
+		}
+	}
+	return names
 }

--- a/v2/internal/attacktechniques/aws/credential-access/ssm-retrieve-securestring-parameters/main.tf
+++ b/v2/internal/attacktechniques/aws/credential-access/ssm-retrieve-securestring-parameters/main.tf
@@ -11,15 +11,15 @@ provider "aws" {
   skip_credentials_validation = true
   skip_get_ec2_platforms      = true
   default_tags {
-    tags = {
+    tags = merge(var.config.aws.tags, {
       StratusRedTeam = true
-    }
+    })
   }
 }
 
 locals {
   num_parameters = 42 // arbitrary
-  prefix         = "/credentials/stratus-red-team/"
+  prefix         = "/credentials/${var.config.aws.prefix}stratus-red-team/"
 }
 
 resource "random_password" "secret" {

--- a/v2/internal/attacktechniques/aws/credential-access/ssm-retrieve-securestring-parameters/main.tf
+++ b/v2/internal/attacktechniques/aws/credential-access/ssm-retrieve-securestring-parameters/main.tf
@@ -38,3 +38,7 @@ resource "aws_ssm_parameter" "parameters" {
 output "display" {
   value = "${local.num_parameters} SSM parameters ready under the SSM path ${local.prefix}"
 }
+
+output "ssm_parameter_path" {
+  value = local.prefix
+}

--- a/v2/internal/attacktechniques/aws/credential-access/ssm-retrieve-securestring-parameters/main_test.go
+++ b/v2/internal/attacktechniques/aws/credential-access/ssm-retrieve-securestring-parameters/main_test.go
@@ -1,0 +1,46 @@
+package aws
+
+import (
+	"testing"
+
+	awsSdk "github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ssm/types"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParameterNamesWithPrefix(t *testing.T) {
+	parameters := []types.ParameterMetadata{
+		{Name: awsSdk.String("/credentials/team-stratus-red-team/credentials-0")},
+		{Name: awsSdk.String("/credentials/stratus-red-team/credentials-1")},
+		{Name: awsSdk.String("/application/database-password")},
+	}
+
+	testCases := []struct {
+		name     string
+		prefix   string
+		expected []string
+	}{
+		{
+			name:     "custom prefix",
+			prefix:   "/credentials/team-stratus-red-team/",
+			expected: []string{"/credentials/team-stratus-red-team/credentials-0"},
+		},
+		{
+			name:     "default prefix",
+			prefix:   "/credentials/stratus-red-team/",
+			expected: []string{"/credentials/stratus-red-team/credentials-1"},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			assert.Equal(t, testCase.expected, parameterNamesWithPrefix(parameters, testCase.prefix))
+		})
+	}
+}
+
+func TestDetonateRequiresSSMParameterPath(t *testing.T) {
+	err := detonate(nil, nil)
+
+	assert.EqualError(t, err, "missing required Terraform output: ssm_parameter_path")
+}

--- a/v2/internal/attacktechniques/aws/defense-evasion/cloudtrail-delete/main.tf
+++ b/v2/internal/attacktechniques/aws/defense-evasion/cloudtrail-delete/main.tf
@@ -11,9 +11,9 @@ provider "aws" {
   skip_credentials_validation = true
   skip_get_ec2_platforms      = true
   default_tags {
-    tags = {
+    tags = merge(var.config.aws.tags, {
       StratusRedTeam = true
-    }
+    })
   }
 }
 
@@ -24,7 +24,7 @@ resource "random_string" "suffix" {
 }
 
 locals {
-  resource_prefix = "stratus-red-team-cloudtraild"
+  resource_prefix = "${var.config.aws.prefix}stratus-red-team-cloudtraild"
 }
 
 locals {

--- a/v2/internal/attacktechniques/aws/defense-evasion/cloudtrail-event-selectors/main.tf
+++ b/v2/internal/attacktechniques/aws/defense-evasion/cloudtrail-event-selectors/main.tf
@@ -11,9 +11,9 @@ provider "aws" {
   skip_credentials_validation = true
   skip_get_ec2_platforms      = true
   default_tags {
-    tags = {
+    tags = merge(var.config.aws.tags, {
       StratusRedTeam = true
-    }
+    })
   }
 }
 
@@ -24,7 +24,7 @@ resource "random_string" "suffix" {
 }
 
 locals {
-  resource_prefix = "stratus-red-team-ctes" # cloudtrail event selectors
+  resource_prefix = "${var.config.aws.prefix}stratus-red-team-ctes" # cloudtrail event selectors
 }
 
 locals {

--- a/v2/internal/attacktechniques/aws/defense-evasion/cloudtrail-lifecycle-rule/main.tf
+++ b/v2/internal/attacktechniques/aws/defense-evasion/cloudtrail-lifecycle-rule/main.tf
@@ -11,9 +11,9 @@ provider "aws" {
   skip_credentials_validation = true
   skip_get_ec2_platforms      = true
   default_tags {
-    tags = {
+    tags = merge(var.config.aws.tags, {
       StratusRedTeam = true
-    }
+    })
   }
 }
 
@@ -24,7 +24,7 @@ resource "random_string" "suffix" {
 }
 
 locals {
-  resource_prefix = "stratus-red-team-ctlr" # cloudtrail lifecycle rule
+  resource_prefix = "${var.config.aws.prefix}stratus-red-team-ctlr" # cloudtrail lifecycle rule
 }
 
 locals {

--- a/v2/internal/attacktechniques/aws/defense-evasion/cloudtrail-stop/main.tf
+++ b/v2/internal/attacktechniques/aws/defense-evasion/cloudtrail-stop/main.tf
@@ -11,9 +11,9 @@ provider "aws" {
   skip_credentials_validation = true
   skip_get_ec2_platforms      = true
   default_tags {
-    tags = {
+    tags = merge(var.config.aws.tags, {
       StratusRedTeam = true
-    }
+    })
   }
 }
 
@@ -24,7 +24,7 @@ resource "random_string" "suffix" {
 }
 
 locals {
-  resource_prefix = "stratus-red-team-ct-stop"
+  resource_prefix = "${var.config.aws.prefix}stratus-red-team-ct-stop"
 }
 
 locals {

--- a/v2/internal/attacktechniques/aws/defense-evasion/dns-delete-logs/main.tf
+++ b/v2/internal/attacktechniques/aws/defense-evasion/dns-delete-logs/main.tf
@@ -10,9 +10,9 @@ provider "aws" {
   skip_region_validation      = true
   skip_credentials_validation = true
   default_tags {
-    tags = {
+    tags = merge(var.config.aws.tags, {
       StratusRedTeam = true
-    }
+    })
   }
 }
 
@@ -23,7 +23,7 @@ resource "random_string" "suffix" {
 }
 
 locals {
-  resource_prefix = "stratus-red-team-dns-delete"
+  resource_prefix = "${var.config.aws.prefix}stratus-red-team-dns-delete"
 }
 
 locals {

--- a/v2/internal/attacktechniques/aws/defense-evasion/organizations-leave/main.tf
+++ b/v2/internal/attacktechniques/aws/defense-evasion/organizations-leave/main.tf
@@ -11,14 +11,14 @@ provider "aws" {
   skip_credentials_validation = true
   skip_get_ec2_platforms      = true
   default_tags {
-    tags = {
+    tags = merge(var.config.aws.tags, {
       StratusRedTeam = true
-    }
+    })
   }
 }
 
 locals {
-  resource_prefix = "stratus-red-team-leave-org"
+  resource_prefix = "${var.config.aws.prefix}stratus-red-team-leave-org"
 }
 
 data "aws_caller_identity" "current" {}

--- a/v2/internal/attacktechniques/aws/defense-evasion/vpc-remove-flow-logs/main.tf
+++ b/v2/internal/attacktechniques/aws/defense-evasion/vpc-remove-flow-logs/main.tf
@@ -11,14 +11,14 @@ provider "aws" {
   skip_credentials_validation = true
   skip_get_ec2_platforms      = true
   default_tags {
-    tags = {
+    tags = merge(var.config.aws.tags, {
       StratusRedTeam = true
-    }
+    })
   }
 }
 
 locals {
-  resource_prefix = "stratus-red-team-remove-flow-logs"
+  resource_prefix = "${var.config.aws.prefix}stratus-red-team-remove-flow-logs"
 }
 
 resource "aws_vpc" "vpc" {
@@ -33,7 +33,7 @@ resource "aws_flow_log" "flow-logs" {
 }
 
 resource "aws_cloudwatch_log_group" "logs" {
-  name = "/stratus-red-team/vpc-flow-logs"
+  name = "/${var.config.aws.prefix}stratus-red-team/vpc-flow-logs"
 }
 
 resource "aws_iam_role" "role" {

--- a/v2/internal/attacktechniques/aws/discovery/ec2-enumerate-from-instance/main.tf
+++ b/v2/internal/attacktechniques/aws/discovery/ec2-enumerate-from-instance/main.tf
@@ -12,14 +12,14 @@ provider "aws" {
   skip_credentials_validation = true
   skip_get_ec2_platforms      = true
   default_tags {
-    tags = {
+    tags = merge(var.config.aws.tags, {
       StratusRedTeam = true
-    }
+    })
   }
 }
 
 locals {
-  resource_prefix = "stratus-red-team-ec2-enumerate"
+  resource_prefix = "${var.config.aws.prefix}stratus-red-team-ec2-enumerate"
 }
 
 data "aws_availability_zones" "available" {

--- a/v2/internal/attacktechniques/aws/discovery/ec2-get-user-data/main.tf
+++ b/v2/internal/attacktechniques/aws/discovery/ec2-get-user-data/main.tf
@@ -11,14 +11,14 @@ provider "aws" {
   skip_credentials_validation = true
   skip_get_ec2_platforms      = true
   default_tags {
-    tags = {
+    tags = merge(var.config.aws.tags, {
       StratusRedTeam = true
-    }
+    })
   }
 }
 
 locals {
-  resource_prefix = "stratus-red-team-get-usr-data"
+  resource_prefix = "${var.config.aws.prefix}stratus-red-team-get-usr-data"
 }
 
 data "aws_caller_identity" "current" {}

--- a/v2/internal/attacktechniques/aws/execution/ec2-launch-unusual-instances/main.tf
+++ b/v2/internal/attacktechniques/aws/execution/ec2-launch-unusual-instances/main.tf
@@ -11,9 +11,9 @@ provider "aws" {
   skip_credentials_validation = true
   skip_get_ec2_platforms      = true
   default_tags {
-    tags = {
+    tags = merge(var.config.aws.tags, {
       StratusRedTeam = true
-    }
+    })
   }
 }
 
@@ -26,7 +26,7 @@ resource "random_string" "suffix" {
 }
 
 locals {
-  resource_prefix = "stratus-red-team-ec2lui" # ec2 launch unusual instance
+  resource_prefix = "${var.config.aws.prefix}stratus-red-team-ec2lui" # ec2 launch unusual instance
 }
 
 resource "aws_iam_role" "role" {

--- a/v2/internal/attacktechniques/aws/execution/ec2-user-data/main.tf
+++ b/v2/internal/attacktechniques/aws/execution/ec2-user-data/main.tf
@@ -12,14 +12,14 @@ provider "aws" {
   skip_credentials_validation = true
   skip_get_ec2_platforms      = true
   default_tags {
-    tags = {
+    tags = merge(var.config.aws.tags, {
       StratusRedTeam = true
-    }
+    })
   }
 }
 
 locals {
-  resource_prefix = "stratus-red-team-usr-data"
+  resource_prefix = "${var.config.aws.prefix}stratus-red-team-usr-data"
 }
 
 data "aws_availability_zones" "available" {

--- a/v2/internal/attacktechniques/aws/execution/sagemaker-lifecycle-config/main.tf
+++ b/v2/internal/attacktechniques/aws/execution/sagemaker-lifecycle-config/main.tf
@@ -10,9 +10,9 @@ provider "aws" {
   skip_region_validation      = true
   skip_credentials_validation = true
   default_tags {
-    tags = {
+    tags = merge(var.config.aws.tags, {
       StratusRedTeam = true
-    }
+    })
   }
 }
 
@@ -21,7 +21,7 @@ provider "aws" {
 data "aws_caller_identity" "current" {}
 
 locals {
-  resource_prefix = "stratus-red-team-update-sagemaker-config-profile"
+  resource_prefix = "${var.config.aws.prefix}stratus-red-team-update-sagemaker-config-profile"
 }
 
 # --- 1. High-Privilege Target Role (The Goal of the Attack) ---

--- a/v2/internal/attacktechniques/aws/execution/ssm-send-command/main.tf
+++ b/v2/internal/attacktechniques/aws/execution/ssm-send-command/main.tf
@@ -11,14 +11,14 @@ provider "aws" {
   skip_region_validation      = true
   skip_credentials_validation = true
   default_tags {
-    tags = {
+    tags = merge(var.config.aws.tags, {
       StratusRedTeam = true
-    }
+    })
   }
 }
 
 locals {
-  resource_prefix = "stratus-red-team-ssm-send-command-execution"
+  resource_prefix = "${var.config.aws.prefix}stratus-red-team-ssm-send-command-execution"
 }
 
 variable "instance_count" {

--- a/v2/internal/attacktechniques/aws/execution/ssm-start-session/main.tf
+++ b/v2/internal/attacktechniques/aws/execution/ssm-start-session/main.tf
@@ -11,14 +11,14 @@ provider "aws" {
   skip_region_validation      = true
   skip_credentials_validation = true
   default_tags {
-    tags = {
+    tags = merge(var.config.aws.tags, {
       StratusRedTeam = true
-    }
+    })
   }
 }
 
 locals {
-  resource_prefix = "stratus-red-team-ssm-start-session-lateral-movement"
+  resource_prefix = "${var.config.aws.prefix}stratus-red-team-ssm-start-session-lateral-movement"
 }
 
 variable "instance_count" {

--- a/v2/internal/attacktechniques/aws/exfiltration/ec2-security-group-open-port-22-ingress/main.tf
+++ b/v2/internal/attacktechniques/aws/exfiltration/ec2-security-group-open-port-22-ingress/main.tf
@@ -11,20 +11,20 @@ provider "aws" {
   skip_credentials_validation = true
   skip_get_ec2_platforms      = true
   default_tags {
-    tags = {
+    tags = merge(var.config.aws.tags, {
       StratusRedTeam = true
-    }
+    })
   }
 }
 
 locals {
-  resource_prefix = "stratus-red-team-open-sg"
+  resource_prefix = "${var.config.aws.prefix}stratus-red-team-open-sg"
 }
 
 resource "aws_vpc" "vpc" {
   cidr_block = "10.0.0.0/16"
   tags = {
-    Name = "StratusRedTeamVpc",
+    Name = "${var.config.aws.prefix}StratusRedTeamVpc",
   }
 }
 

--- a/v2/internal/attacktechniques/aws/exfiltration/ec2-share-ami/main.tf
+++ b/v2/internal/attacktechniques/aws/exfiltration/ec2-share-ami/main.tf
@@ -11,14 +11,14 @@ provider "aws" {
   skip_credentials_validation = true
   skip_get_ec2_platforms      = true
   default_tags {
-    tags = {
+    tags = merge(var.config.aws.tags, {
       StratusRedTeam = true
-    }
+    })
   }
 }
 
 locals {
-  resource_prefix = "stratus-red-team-share-ami"
+  resource_prefix = "${var.config.aws.prefix}stratus-red-team-share-ami"
 }
 
 data "aws_availability_zones" "available" {

--- a/v2/internal/attacktechniques/aws/exfiltration/ec2-share-ebs-snapshot/main.tf
+++ b/v2/internal/attacktechniques/aws/exfiltration/ec2-share-ebs-snapshot/main.tf
@@ -11,9 +11,9 @@ provider "aws" {
   skip_credentials_validation = true
   skip_get_ec2_platforms      = true
   default_tags {
-    tags = {
+    tags = merge(var.config.aws.tags, {
       StratusRedTeam = true
-    }
+    })
   }
 }
 
@@ -26,7 +26,7 @@ resource "aws_ebs_volume" "volume" {
   size              = 1
 
   tags = {
-    Name = "StratusRedTeamVolume"
+    Name = "${var.config.aws.prefix}StratusRedTeamVolume"
   }
 }
 

--- a/v2/internal/attacktechniques/aws/exfiltration/rds-share-snapshot/main.tf
+++ b/v2/internal/attacktechniques/aws/exfiltration/rds-share-snapshot/main.tf
@@ -11,9 +11,9 @@ provider "aws" {
   skip_credentials_validation = true
   skip_get_ec2_platforms      = true
   default_tags {
-    tags = {
+    tags = merge(var.config.aws.tags, {
       StratusRedTeam = true
-    }
+    })
   }
 }
 
@@ -24,7 +24,7 @@ resource "random_password" "password" {
 }
 
 locals {
-  resource_prefix = "stratus-red-team-share-snap"
+  resource_prefix = "${var.config.aws.prefix}stratus-red-team-share-snap"
 }
 
 data "aws_availability_zones" "available" {

--- a/v2/internal/attacktechniques/aws/exfiltration/s3-backdoor-bucket-policy/main.tf
+++ b/v2/internal/attacktechniques/aws/exfiltration/s3-backdoor-bucket-policy/main.tf
@@ -11,9 +11,9 @@ provider "aws" {
   skip_credentials_validation = true
   skip_get_ec2_platforms      = true
   default_tags {
-    tags = {
+    tags = merge(var.config.aws.tags, {
       StratusRedTeam = true
-    }
+    })
   }
 }
 
@@ -24,7 +24,7 @@ resource "random_string" "suffix" {
 }
 
 locals {
-  resource_prefix = "stratus-red-team-bdbp" # backdoor bucket policy
+  resource_prefix = "${var.config.aws.prefix}stratus-red-team-bdbp" # backdoor bucket policy
 }
 
 resource "aws_s3_bucket" "bucket" {

--- a/v2/internal/attacktechniques/aws/impact/s3-ransomware-batch-deletion/main.tf
+++ b/v2/internal/attacktechniques/aws/impact/s3-ransomware-batch-deletion/main.tf
@@ -10,6 +10,11 @@ provider "aws" {
   skip_region_validation      = true
   skip_credentials_validation = true
   skip_get_ec2_platforms      = true
+  default_tags {
+    tags = merge(var.config.aws.tags, {
+      StratusRedTeam = true
+    })
+  }
 }
 
 resource "random_string" "suffix" {
@@ -19,7 +24,7 @@ resource "random_string" "suffix" {
 }
 
 locals {
-  resource_prefix = "stratus-red-team-ransomware-bucket"
+  resource_prefix = "${var.config.aws.prefix}stratus-red-team-ransomware-bucket"
   bucket_name     = format("%s-%s", local.resource_prefix, random_string.suffix.result)
   num-files       = 51
   min-size-bytes  = 1

--- a/v2/internal/attacktechniques/aws/impact/s3-ransomware-client-side-encryption/main.tf
+++ b/v2/internal/attacktechniques/aws/impact/s3-ransomware-client-side-encryption/main.tf
@@ -10,6 +10,11 @@ provider "aws" {
   skip_region_validation      = true
   skip_credentials_validation = true
   skip_get_ec2_platforms      = true
+  default_tags {
+    tags = merge(var.config.aws.tags, {
+      StratusRedTeam = true
+    })
+  }
 }
 
 resource "random_string" "suffix" {
@@ -19,7 +24,7 @@ resource "random_string" "suffix" {
 }
 
 locals {
-  resource_prefix = "stratus-red-team-ransomware-bucket"
+  resource_prefix = "${var.config.aws.prefix}stratus-red-team-ransomware-bucket"
   bucket_name     = format("%s-%s", local.resource_prefix, random_string.suffix.result)
   num-files       = 51
   min-size-bytes  = 1

--- a/v2/internal/attacktechniques/aws/impact/s3-ransomware-individual-deletion/main.tf
+++ b/v2/internal/attacktechniques/aws/impact/s3-ransomware-individual-deletion/main.tf
@@ -10,6 +10,11 @@ provider "aws" {
   skip_region_validation      = true
   skip_credentials_validation = true
   skip_get_ec2_platforms      = true
+  default_tags {
+    tags = merge(var.config.aws.tags, {
+      StratusRedTeam = true
+    })
+  }
 }
 
 resource "random_string" "suffix" {
@@ -19,7 +24,7 @@ resource "random_string" "suffix" {
 }
 
 locals {
-  resource_prefix = "stratus-red-team-ransomware-bucket"
+  resource_prefix = "${var.config.aws.prefix}stratus-red-team-ransomware-bucket"
   bucket_name     = format("%s-%s", local.resource_prefix, random_string.suffix.result)
   num-files       = 51
   min-size-bytes  = 1

--- a/v2/internal/attacktechniques/aws/initial-access/console-login-without-mfa/main.tf
+++ b/v2/internal/attacktechniques/aws/initial-access/console-login-without-mfa/main.tf
@@ -10,6 +10,11 @@ provider "aws" {
   skip_region_validation      = true
   skip_credentials_validation = true
   skip_get_ec2_platforms      = true
+  default_tags {
+    tags = merge(var.config.aws.tags, {
+      StratusRedTeam = true
+    })
+  }
 }
 
 data "aws_caller_identity" "current" {}
@@ -21,7 +26,7 @@ resource "random_string" "suffix" {
 }
 
 locals {
-  resource_prefix = "stratus-red-team-nmfalu" # non-mfa login user
+  resource_prefix = "${var.config.aws.prefix}stratus-red-team-nmfalu" # non-mfa login user
 }
 
 resource "aws_iam_user" "console-user" {

--- a/v2/internal/attacktechniques/aws/lateral-movement/ec2-send-serial-console-send-ssh-public-key/main.tf
+++ b/v2/internal/attacktechniques/aws/lateral-movement/ec2-send-serial-console-send-ssh-public-key/main.tf
@@ -11,14 +11,14 @@ provider "aws" {
   skip_region_validation      = true
   skip_credentials_validation = true
   default_tags {
-    tags = {
+    tags = merge(var.config.aws.tags, {
       StratusRedTeam = true
-    }
+    })
   }
 }
 
 locals {
-  resource_prefix = "stratus-red-team-ec2-serialconsole-ssh-lateral-movement"
+  resource_prefix = "${var.config.aws.prefix}stratus-red-team-ec2-serialconsole-ssh-lateral-movement"
 }
 
 variable "instance_count" {

--- a/v2/internal/attacktechniques/aws/lateral-movement/ec2-send-ssh-public-key/main.tf
+++ b/v2/internal/attacktechniques/aws/lateral-movement/ec2-send-ssh-public-key/main.tf
@@ -11,14 +11,14 @@ provider "aws" {
   skip_region_validation      = true
   skip_credentials_validation = true
   default_tags {
-    tags = {
+    tags = merge(var.config.aws.tags, {
       StratusRedTeam = true
-    }
+    })
   }
 }
 
 locals {
-  resource_prefix = "stratus-red-team-ec2-sshpublickey-lateral-movement"
+  resource_prefix = "${var.config.aws.prefix}stratus-red-team-ec2-sshpublickey-lateral-movement"
 }
 
 variable "instance_count" {

--- a/v2/internal/attacktechniques/aws/persistence/iam-backdoor-role/main.tf
+++ b/v2/internal/attacktechniques/aws/persistence/iam-backdoor-role/main.tf
@@ -10,10 +10,15 @@ provider "aws" {
   skip_region_validation      = true
   skip_credentials_validation = true
   skip_get_ec2_platforms      = true
+  default_tags {
+    tags = merge(var.config.aws.tags, {
+      StratusRedTeam = true
+    })
+  }
 }
 
 locals {
-  resource_prefix = "stratus-red-team-backdoor-r"
+  resource_prefix = "${var.config.aws.prefix}stratus-red-team-backdoor-r"
 }
 
 resource "aws_iam_role" "legit-role" {

--- a/v2/internal/attacktechniques/aws/persistence/iam-backdoor-user/main.tf
+++ b/v2/internal/attacktechniques/aws/persistence/iam-backdoor-user/main.tf
@@ -11,14 +11,14 @@ provider "aws" {
   skip_credentials_validation = true
   skip_get_ec2_platforms      = true
   default_tags {
-    tags = {
+    tags = merge(var.config.aws.tags, {
       StratusRedTeam = true
-    }
+    })
   }
 }
 
 locals {
-  resource_prefix = "stratus-red-team-backdoor-u"
+  resource_prefix = "${var.config.aws.prefix}stratus-red-team-backdoor-u"
 }
 
 resource "aws_iam_user" "legit-user" {

--- a/v2/internal/attacktechniques/aws/persistence/iam-create-user-login-profile/main.tf
+++ b/v2/internal/attacktechniques/aws/persistence/iam-create-user-login-profile/main.tf
@@ -11,14 +11,14 @@ provider "aws" {
   skip_credentials_validation = true
   skip_get_ec2_platforms      = true
   default_tags {
-    tags = {
+    tags = merge(var.config.aws.tags, {
       StratusRedTeam = true
-    }
+    })
   }
 }
 
 locals {
-  resource_prefix = "stratus-red-team-login-profile"
+  resource_prefix = "${var.config.aws.prefix}stratus-red-team-login-profile"
 }
 
 resource "aws_iam_user" "legit-user" {

--- a/v2/internal/attacktechniques/aws/persistence/lambda-backdoor-function/main.tf
+++ b/v2/internal/attacktechniques/aws/persistence/lambda-backdoor-function/main.tf
@@ -11,14 +11,14 @@ provider "aws" {
   skip_credentials_validation = true
   skip_get_ec2_platforms      = true
   default_tags {
-    tags = {
+    tags = merge(var.config.aws.tags, {
       StratusRedTeam = true
-    }
+    })
   }
 }
 
 locals {
-  resource_prefix = "stratus-red-team-backdoor-f"
+  resource_prefix = "${var.config.aws.prefix}stratus-red-team-backdoor-f"
 }
 
 resource "aws_iam_role" "lambda" {

--- a/v2/internal/attacktechniques/aws/persistence/lambda-layer-extension/main.tf
+++ b/v2/internal/attacktechniques/aws/persistence/lambda-layer-extension/main.tf
@@ -11,14 +11,14 @@ provider "aws" {
   skip_credentials_validation = true
   skip_get_ec2_platforms      = true
   default_tags {
-    tags = {
+    tags = merge(var.config.aws.tags, {
       StratusRedTeam = true
-    }
+    })
   }
 }
 
 locals {
-  resource_prefix = "stratus-red-team-lambda-layer"
+  resource_prefix = "${var.config.aws.prefix}stratus-red-team-lambda-layer"
 }
 
 resource "aws_iam_role" "lambda_role" {

--- a/v2/internal/attacktechniques/aws/persistence/lambda-overwrite-code/main.tf
+++ b/v2/internal/attacktechniques/aws/persistence/lambda-overwrite-code/main.tf
@@ -11,9 +11,9 @@ provider "aws" {
   skip_credentials_validation = true
   skip_get_ec2_platforms      = true
   default_tags {
-    tags = {
+    tags = merge(var.config.aws.tags, {
       StratusRedTeam = true
-    }
+    })
   }
 }
 
@@ -24,7 +24,7 @@ resource "random_string" "suffix" {
 }
 
 locals {
-  resource_prefix = "stratus-red-team-olc" # stratus red team overwrite lambda code 
+  resource_prefix = "${var.config.aws.prefix}stratus-red-team-olc" # stratus red team overwrite lambda code
 }
 
 resource "aws_iam_role" "lambda-update" {

--- a/v2/internal/attacktechniques/aws/persistence/rolesanywhere-create-trust-anchor/main.tf
+++ b/v2/internal/attacktechniques/aws/persistence/rolesanywhere-create-trust-anchor/main.tf
@@ -11,14 +11,14 @@ provider "aws" {
   skip_credentials_validation = true
   skip_get_ec2_platforms      = true
   default_tags {
-    tags = {
+    tags = merge(var.config.aws.tags, {
       StratusRedTeam = true
-    }
+    })
   }
 }
 
 locals {
-  resource_prefix = "stratus-red-team-trust-anchor"
+  resource_prefix = "${var.config.aws.prefix}stratus-red-team-trust-anchor"
 }
 
 resource "aws_iam_role" "role" {

--- a/v2/internal/attacktechniques/aws/persistence/sts-federation-token/main.tf
+++ b/v2/internal/attacktechniques/aws/persistence/sts-federation-token/main.tf
@@ -11,14 +11,14 @@ provider "aws" {
   skip_credentials_validation = true
   skip_get_ec2_platforms      = true
   default_tags {
-    tags = {
+    tags = merge(var.config.aws.tags, {
       StratusRedTeam = true
-    }
+    })
   }
 }
 
 locals {
-  resource_prefix = "stratus-red-team-user-federation"
+  resource_prefix = "${var.config.aws.prefix}stratus-red-team-user-federation"
 }
 
 resource "aws_iam_user" "legit-user" {

--- a/v2/internal/attacktechniques/aws/privilege-escalation/change-iam-user-password/main.tf
+++ b/v2/internal/attacktechniques/aws/privilege-escalation/change-iam-user-password/main.tf
@@ -10,14 +10,14 @@ provider "aws" {
   skip_region_validation      = true
   skip_credentials_validation = true
   default_tags {
-    tags = {
+    tags = merge(var.config.aws.tags, {
       StratusRedTeam = true
-    }
+    })
   }
 }
 
 locals {
-  resource_prefix = "stratus-red-team-update-login-profile"
+  resource_prefix = "${var.config.aws.prefix}stratus-red-team-update-login-profile"
 }
 
 resource "aws_iam_user" "legit-user" {

--- a/v2/pkg/stratus/config/aws.go
+++ b/v2/pkg/stratus/config/aws.go
@@ -1,0 +1,52 @@
+package config
+
+// AWSConfigImpl merges global AWS defaults with technique-specific settings
+// before they are passed to Terraform.
+type AWSConfigImpl struct {
+	raw map[string]any
+}
+
+func (a *AWSConfigImpl) getMergedConfig(techniqueID string, vars SubstitutionVars) map[string]any {
+	if a == nil || a.raw == nil {
+		return nil
+	}
+
+	awsRaw := toStringMap(a.raw["aws"])
+	merged := make(map[string]any)
+	if defaultRaw := awsRaw["default"]; defaultRaw != nil {
+		deepMerge(merged, cloneStringMap(defaultRaw))
+	}
+	techniques := toStringMap(awsRaw["techniques"])
+	if techniqueRaw := techniques[techniqueID]; techniqueRaw != nil {
+		deepMerge(merged, cloneStringMap(techniqueRaw))
+	}
+	if len(merged) == 0 {
+		return nil
+	}
+
+	return substituteMap(merged, vars)
+}
+
+func cloneStringMap(value any) map[string]any {
+	source := toStringMap(value)
+	result := make(map[string]any, len(source))
+	for key, item := range source {
+		result[key] = cloneValue(item)
+	}
+	return result
+}
+
+func cloneValue(value any) any {
+	switch typed := value.(type) {
+	case map[string]any:
+		return cloneStringMap(typed)
+	case []any:
+		result := make([]any, len(typed))
+		for index, item := range typed {
+			result[index] = cloneValue(item)
+		}
+		return result
+	default:
+		return value
+	}
+}

--- a/v2/pkg/stratus/config/aws_test.go
+++ b/v2/pkg/stratus/config/aws_test.go
@@ -1,0 +1,117 @@
+package config
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAWSConfigTerraformVariables(t *testing.T) {
+	cfg := newTestConfig(`
+aws:
+  default:
+    prefix: "team-<% .CorrelationID %>-"
+    tags:
+      Environment: test
+      ExecutionID: "<% .CorrelationID %>"
+  techniques:
+    "aws.test.technique":
+      prefix: technique-
+      tags:
+        Environment: production
+        Owner: security
+`)
+
+	actual := cfg.GetTerraformVariables(
+		"aws.test.technique",
+		SubstitutionVars{CorrelationID: "11111111-2222-3333-4444-555555555555"},
+	)
+	require.Contains(t, actual, "config")
+
+	var parsed map[string]any
+	require.NoError(t, json.Unmarshal([]byte(actual["config"]), &parsed))
+	assert.Equal(t, map[string]any{
+		"aws": map[string]any{
+			"prefix": "technique-",
+			"tags": map[string]any{
+				"Environment": "production",
+				"ExecutionID": "11111111-2222-3333-4444-555555555555",
+				"Owner":       "security",
+			},
+		},
+	}, parsed)
+}
+
+func TestAWSConfigTechniqueOnly(t *testing.T) {
+	cfg := newTestConfig(`
+aws:
+  techniques:
+    "aws.test.technique":
+      tags:
+        Owner: security
+`)
+
+	actual := cfg.GetTerraformVariables("aws.test.technique", SubstitutionVars{})
+	require.Contains(t, actual, "config")
+
+	var parsed map[string]any
+	require.NoError(t, json.Unmarshal([]byte(actual["config"]), &parsed))
+	assert.Equal(t, map[string]any{
+		"aws": map[string]any{
+			"tags": map[string]any{"Owner": "security"},
+		},
+	}, parsed)
+}
+
+func TestLoadConfigPreservesAWSTagKeyCase(t *testing.T) {
+	configPath := filepath.Join(t.TempDir(), "config.yaml")
+	require.NoError(t, os.WriteFile(configPath, []byte(`
+aws:
+  default:
+    tags:
+      CostCenter: security
+      StratusCorrelationID: "<% .CorrelationID %>"
+`), 0600))
+	t.Setenv(ConfigEnvVar, configPath)
+
+	cfg, err := LoadConfig()
+	require.NoError(t, err)
+	actual := cfg.GetTerraformVariables(
+		"aws.test.technique",
+		SubstitutionVars{CorrelationID: testCorrelationID},
+	)
+
+	var parsed map[string]any
+	require.NoError(t, json.Unmarshal([]byte(actual["config"]), &parsed))
+	assert.Equal(t, map[string]any{
+		"aws": map[string]any{
+			"tags": map[string]any{
+				"CostCenter":           "security",
+				"StratusCorrelationID": testCorrelationID,
+			},
+		},
+	}, parsed)
+}
+
+func TestAWSConfigTechniqueOverrideDoesNotMutateDefaults(t *testing.T) {
+	cfg := newTestConfig(`
+aws:
+  default:
+    tags:
+      Environment: test
+  techniques:
+    "aws.test.override":
+      tags:
+        Environment: production
+`)
+
+	override := cfg.aws.getMergedConfig("aws.test.override", SubstitutionVars{})
+	defaults := cfg.aws.getMergedConfig("aws.test.other", SubstitutionVars{})
+
+	assert.Equal(t, "production", override["tags"].(map[string]any)["Environment"])
+	assert.Equal(t, "test", defaults["tags"].(map[string]any)["Environment"])
+}

--- a/v2/pkg/stratus/config/config.example.yaml
+++ b/v2/pkg/stratus/config/config.example.yaml
@@ -2,6 +2,23 @@
 # Place this file at ~/.stratus-red-team/config.yaml
 # or set STRATUS_CONFIG_PATH environment variable to point to it
 
+aws:
+  # Default configuration applied to all AWS techniques
+  default:
+    # Prepended to the names of Terraform-managed prerequisites
+    prefix: "security-testing-"
+    # Applied through the AWS provider's default_tags configuration
+    tags:
+      Environment: "test"
+      Owner: "security"
+      StratusCorrelationID: "<% .CorrelationID %>"
+
+  # Per-technique overrides merged on top of the defaults
+  techniques:
+    "aws.persistence.lambda-backdoor-function":
+      tags:
+        Purpose: "lambda-detection-validation"
+
 kubernetes:
   # Default pod configuration applied to all k8s techniques
   default:

--- a/v2/pkg/stratus/config/config.go
+++ b/v2/pkg/stratus/config/config.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 
 	"github.com/spf13/viper"
+	"gopkg.in/yaml.v3"
 )
 
 const (
@@ -37,6 +38,7 @@ type Config interface {
 }
 
 type ConfigImpl struct {
+	aws        *AWSConfigImpl
 	kubernetes *KubernetesConfigImpl
 	v          *viper.Viper
 }
@@ -46,6 +48,7 @@ var _ Config = &ConfigImpl{}
 // LoadConfig loads configuration from file.
 func LoadConfig() (Config, error) {
 	v := newViper()
+	var raw map[string]any
 	configPath := getConfigPath()
 	if configPath != "" {
 		rawYAML, err := os.ReadFile(configPath)
@@ -55,13 +58,20 @@ func LoadConfig() (Config, error) {
 		if err := validateConfig(rawYAML); err != nil {
 			return nil, err
 		}
+		if err := yaml.Unmarshal(rawYAML, &raw); err != nil {
+			return nil, fmt.Errorf("parsing config YAML: %w", err)
+		}
 
 		v.SetConfigFile(configPath)
 		if err := v.ReadInConfig(); err != nil {
 			return nil, err
 		}
 	}
-	return &ConfigImpl{kubernetes: &KubernetesConfigImpl{v: v}, v: v}, nil
+	return &ConfigImpl{
+		aws:        &AWSConfigImpl{raw: raw},
+		kubernetes: &KubernetesConfigImpl{v: v},
+		v:          v,
+	}, nil
 }
 
 // getConfigPath returns the path to the config file, checking:
@@ -99,14 +109,16 @@ func (c *ConfigImpl) GetKubernetesConfig() KubernetesConfig {
 	return c.kubernetes
 }
 
-// buildMergedViper produces a Viper containing the merged technique config.
-// Each provider populates its own subtree via populateViperOverride.
+// buildMergedViper produces a Viper containing configuration for providers
+// whose keys are case-insensitive.
 func (c *ConfigImpl) buildMergedViper(techniqueID string, vars SubstitutionVars) *viper.Viper {
 	v := newViper()
-	if c == nil || c.kubernetes == nil {
+	if c == nil {
 		return v
 	}
-	c.kubernetes.populateViperOverride(c.v, v, techniqueID, vars)
+	if c.kubernetes != nil {
+		c.kubernetes.populateViperOverride(c.v, v, techniqueID, vars)
+	}
 	// Add here other providers config
 	return v
 }
@@ -123,6 +135,9 @@ func (c *ConfigImpl) GetTerraformVariables(techniqueID string, vars Substitution
 
 	merged := c.buildMergedViper(techniqueID, vars)
 	settings := merged.AllSettings()
+	if awsConfig := c.aws.getMergedConfig(techniqueID, vars); len(awsConfig) > 0 {
+		settings["aws"] = awsConfig
+	}
 	if len(settings) == 0 {
 		return nil
 	}

--- a/v2/pkg/stratus/config/config.schema.json
+++ b/v2/pkg/stratus/config/config.schema.json
@@ -5,9 +5,33 @@
     "type": "object",
     "additionalProperties": false,
     "properties": {
+        "aws": { "$ref": "#/$defs/aws" },
         "kubernetes": { "$ref": "#/$defs/kubernetes" }
     },
     "$defs": {
+        "aws": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "default": { "$ref": "#/$defs/awsTechniqueConfig" },
+                "techniques": {
+                    "type": "object",
+                    "propertyNames": { "pattern": "^aws\\." },
+                    "additionalProperties": { "$ref": "#/$defs/awsTechniqueConfig" }
+                }
+            }
+        },
+        "awsTechniqueConfig": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "prefix": { "type": "string" },
+                "tags": {
+                    "type": "object",
+                    "additionalProperties": { "type": "string" }
+                }
+            }
+        },
         "kubernetes": {
             "type": "object",
             "additionalProperties": false,

--- a/v2/pkg/stratus/config/config.tf
+++ b/v2/pkg/stratus/config/config.tf
@@ -1,6 +1,10 @@
 variable "config" {
   type = object({
-    kubernetes = object({
+    aws = optional(object({
+      prefix = optional(string, "")
+      tags   = optional(map(string), {})
+    }), { prefix = "", tags = {} })
+    kubernetes = optional(object({
       namespace = optional(string, "")
       pod = optional(object({
         image            = optional(string, "")
@@ -15,9 +19,13 @@ variable "config" {
           effect   = string
         })), [])
       }), { image = "", labels = {}, annotations = {}, node_selector = {}, security_context = {}, tolerations = [] })
-    })
+    }), { namespace = "", pod = { image = "", labels = {}, annotations = {}, node_selector = {}, security_context = {}, tolerations = [] } })
   })
   default = {
+    aws = {
+      prefix = ""
+      tags   = {}
+    }
     kubernetes = {
       namespace = ""
       pod = {

--- a/v2/pkg/stratus/config/config_test.go
+++ b/v2/pkg/stratus/config/config_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
 )
 
 // TestKeyDelimiter documents the "::" Viper key delimiter used package-wide.
@@ -51,7 +52,13 @@ func newTestConfig(yamlStr string) *ConfigImpl {
 	v := newViper()
 	v.SetConfigType("yaml")
 	_ = v.ReadConfig(strings.NewReader(yamlStr))
-	return &ConfigImpl{kubernetes: &KubernetesConfigImpl{v: v}, v: v}
+	var raw map[string]any
+	_ = yaml.Unmarshal([]byte(yamlStr), &raw)
+	return &ConfigImpl{
+		aws:        &AWSConfigImpl{raw: raw},
+		kubernetes: &KubernetesConfigImpl{v: v},
+		v:          v,
+	}
 }
 
 func TestGetTerraformVariables(t *testing.T) {

--- a/v2/pkg/stratus/config/validate_test.go
+++ b/v2/pkg/stratus/config/validate_test.go
@@ -58,12 +58,48 @@ kubernetes:
 			wantError: false,
 		},
 		{
+			name: "valid-aws-config",
+			yaml: `
+aws:
+  default:
+    prefix: "team-<% .CorrelationID %>-"
+    tags:
+      Environment: test
+      ExecutionID: "<% .CorrelationID %>"
+  techniques:
+    "aws.persistence.lambda-backdoor-function":
+      tags:
+        Owner: security
+`,
+			wantError: false,
+		},
+		{
 			name: "wrong-type-for-annotations",
 			yaml: `
 kubernetes:
   default:
     pod:
       annotations: "not-a-map"
+`,
+			wantError: true,
+		},
+		{
+			name: "wrong-type-for-aws-tags",
+			yaml: `
+aws:
+  default:
+    tags: "not-a-map"
+`,
+			wantError: true,
+		},
+		{
+			name: "non-aws-technique-key",
+			yaml: `
+aws:
+  techniques:
+    "gcp.test.technique":
+      tags:
+        Owner: security
 `,
 			wantError: true,
 		},


### PR DESCRIPTION
## Why

Organizations can require consistent AWS tags and naming prefixes for governance, cost allocation, and execution tracing. Stratus Red Team configuration supported Kubernetes customization but could not apply equivalent defaults or per-technique overrides to Terraform-managed AWS prerequisites.

Closes #885.

## Changes

- add global and per-technique AWS configuration for resource prefixes and tags
- preserve case-sensitive AWS tag keys while merging defaults and technique overrides
- support correlation ID templating in AWS configuration values
- apply configured tags and prefixes across all Terraform-backed AWS techniques while preserving the mandatory `StratusRedTeam` tag
- extend the configuration schema, Terraform variable contract, examples, documentation, and unit tests

## Validation

- `go test ./pkg/stratus/config -count=1` — passed
- `go vet ./pkg/stratus/config` — passed
- `terraform fmt -check -recursive internal/attacktechniques/aws` — passed
- `terraform fmt -check pkg/stratus/config/config.tf` — passed
- isolated `terraform validate` and console checks for custom tags, case preservation, prefix values, and mandatory tag precedence — passed
- targeted multi-package tests: config and utils passed; runner and state hit existing Windows path-separator assertions (`/root/...` versus `\root\...`)
- full Docker build did not complete within the local ten-minute validation window; CI remains the Linux build authority

### What does this PR do?

Enhancement.

### Motivation

Provide AWS resource tagging and naming customization through the existing configuration file, including execution-specific templating.

### Checklist

- [x] This PR does not add a new attack technique; the attack-technique checklist is not applicable