### PR TITLE
fix(k8s): support KUBECONFIG with multiple colon-separated paths

### DIFF
--- a/v2/internal/providers/kubernetes.go
+++ b/v2/internal/providers/kubernetes.go
@@ -50,8 +50,7 @@ func NewK8sProvider(correlationId uuid.UUID, opts ...K8sProviderOption) *K8sProv
 	}
 
 	if p.RestConfig == nil {
-		kubeconfig := GetKubeConfigPath()
-		restConfig, err := clientcmd.BuildConfigFromFlags("", kubeconfig)
+		restConfig, err := buildKubeRestConfig()
 		if err != nil {
 			log.Fatalf("unable to build kube config: %v", err)
 		}
@@ -92,11 +91,23 @@ func getKubeConfigPath() string {
 		return kubeConfigFilePath
 	}
 
-	// Otherwise, return an empty string
-	// This will cause `clientcmd.BuildConfigFromFlags` called in `GetClient` will try to use
-	// in-cluster auth
-	// c.f. https://pkg.go.dev/k8s.io/client-go/tools/clientcmd#BuildConfigFromFlags
+	// Otherwise, return an empty string.
+	// This causes the loading rules used by buildKubeRestConfig to fall back to
+	// in-cluster auth.
 	return ""
+}
+
+// buildKubeRestConfig resolves the Kubernetes REST configuration the same way
+// kubectl does. It honors the KUBECONFIG environment variable - including when
+// it holds several ':'-separated paths, which are then merged together - and
+// otherwise falls back to $HOME/.kube/config, then to in-cluster credentials.
+// The current context is resolved across the merged files.
+func buildKubeRestConfig() (*rest.Config, error) {
+	loadingRules := clientcmd.NewDefaultClientConfigLoadingRules()
+	return clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
+		loadingRules,
+		&clientcmd.ConfigOverrides{},
+	).ClientConfig()
 }
 
 // GetClient is used to authenticate with Kubernetes and build the client from a kubeconfig

--- a/v2/internal/providers/kubernetes_test.go
+++ b/v2/internal/providers/kubernetes_test.go
@@ -1,0 +1,98 @@
+package providers
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func writeKubeconfig(t *testing.T, dir, name, contents string) string {
+	t.Helper()
+	path := filepath.Join(dir, name)
+	require.NoError(t, os.WriteFile(path, []byte(contents), 0o600))
+	return path
+}
+
+func TestBuildKubeRestConfig_SingleKubeconfigPath(t *testing.T) {
+	dir := t.TempDir()
+	kubeconfig := writeKubeconfig(t, dir, "config", `
+apiVersion: v1
+kind: Config
+current-context: ctx-a
+clusters:
+- name: cluster-a
+  cluster:
+    server: https://server-a:6443
+contexts:
+- name: ctx-a
+  context:
+    cluster: cluster-a
+    user: user-a
+users:
+- name: user-a
+  user:
+    token: token-a
+`)
+
+	t.Setenv("KUBECONFIG", kubeconfig)
+
+	restConfig, err := buildKubeRestConfig()
+	require.NoError(t, err)
+	assert.Equal(t, "https://server-a:6443", restConfig.Host)
+}
+
+// A KUBECONFIG environment variable may contain several ':'-separated paths that
+// are merged together, as documented at
+// https://kubernetes.io/docs/tasks/access-application-cluster/configure-access-multiple-clusters/#set-the-kubeconfig-environment-variable
+// The current context can then reference a context defined in any of the merged
+// files.
+func TestBuildKubeRestConfig_MergesMultipleKubeconfigPaths(t *testing.T) {
+	dir := t.TempDir()
+
+	// The first file sets the current context to one that is only defined in the
+	// second file, so resolution can only succeed if both files are merged.
+	first := writeKubeconfig(t, dir, "config-a", `
+apiVersion: v1
+kind: Config
+current-context: ctx-b
+clusters:
+- name: cluster-a
+  cluster:
+    server: https://server-a:6443
+contexts:
+- name: ctx-a
+  context:
+    cluster: cluster-a
+    user: user-a
+users:
+- name: user-a
+  user:
+    token: token-a
+`)
+	second := writeKubeconfig(t, dir, "config-b", `
+apiVersion: v1
+kind: Config
+clusters:
+- name: cluster-b
+  cluster:
+    server: https://server-b:6443
+contexts:
+- name: ctx-b
+  context:
+    cluster: cluster-b
+    user: user-b
+users:
+- name: user-b
+  user:
+    token: token-b
+`)
+
+	t.Setenv("KUBECONFIG", first+string(os.PathListSeparator)+second)
+
+	restConfig, err := buildKubeRestConfig()
+	require.NoError(t, err)
+	assert.Equal(t, "https://server-b:6443", restConfig.Host)
+}


### PR DESCRIPTION
### What does this PR do?

Fixes #162 - the Kubernetes provider now handles a `KUBECONFIG` environment variable that contains several `:`-separated paths.

### Motivation

Right now `getKubeConfigPath()` returns the raw `KUBECONFIG` value and hands it straight to `clientcmd.BuildConfigFromFlags("", kubeconfig)`. When someone sets `KUBECONFIG=/path/one:/path/two` (a fairly common setup, and the documented way to merge kubeconfigs), that whole string gets treated as a single filename and loading fails, even though `kubectl` works fine against the same environment.

I switched the resolution to go through `clientcmd.NewDefaultClientConfigLoadingRules()` wrapped in a deferred loading client config, which is what kubectl and most k8s tooling use. It splits and merges every path in `KUBECONFIG`, resolves the current context across the merged files, and still falls back to `~/.kube/config` and then in-cluster credentials, so the single-path and default cases behave exactly as before. `GetKubeConfigPath()` is kept as-is since it's still used for the credential-hint message.

Added a couple of unit tests: one covering the existing single-path case and one that sets `KUBECONFIG` to two files where the current context is only resolvable if both are merged.

### Checklist
- [x] `make test` / `go test ./internal/providers/...` passing
- [x] `go vet` and `gofmt` clean on the changed files