### PR TITLE
feat(attacktechniques): Concurrent detonation: unique resource names

### DIFF
--- a/.claude/skills/create-attack-technique/SKILL.md
+++ b/.claude/skills/create-attack-technique/SKILL.md
@@ -10,10 +10,12 @@ description: >
 ## Overview
 
 Each attack technique is composed of two files, which should be stored in `v2/internal/attacktechniques/<platform>/<mitre-attack-tactic>/<name>` (e.g., `v2/internal/attacktechniques/aws/defense-evasion/cloudtrail-delete/`):
+
 - `main.go`, containing the imperative attack logic
 - most of the time, `main.tf` containing prerequisite infrastructure.
 
 The lifecycle of an attack technique in Stratus Red Team is:
+
 - COLD
 - WARM: The prerequisite infrastructure is ready.
 - DETONATED: The attack technique was detonated.
@@ -55,12 +57,6 @@ resource "aws_iam_role" "role" {
   name = "${local.resource_prefix}-role"
 }
 ```
-
-Do **not** use `random_string` for name uniqueness — use `var.correlation.short` instead. Content-only randoms (secret values, ransomware fake-file content) are fine.
-
-For AWS techniques that use `var.config.aws.prefix`, the prefix is schema-validated to a maximum of 17 characters (see `config.schema.json`). Keep the technique's base name plus resource suffix short enough that a 17-char prefix, the 8-char `var.correlation.short`, and the suffix all fit within the provider's name-length limit (64 chars for IAM/Lambda, 63 for S3). See [docs/dev-guide/configuration.md](../../../docs/dev-guide/configuration.md) for details.
-
-For resources scoped under an already-uniquely-named parent (e.g. a K8s namespace that already carries `var.correlation.short`), the child resources do not need their own suffix — the parent's uniqueness isolates them.
 
 #### Go-created detonation artifacts
 
@@ -126,11 +122,11 @@ If the detonation is reversible, implement a `revert` function that undoes the c
 
 #### Guideline for documentation fields
 
-* `ID` should always be of the form `platform.mitre-attack-tactic.name`, e.g. `aws.defense-evasion.cloudtrail-delete`
-* `FriendlyName` should always start with a verb, and be in the infinitive form.
-  * Bad: `S3 ransomware`, `Creates S3 ransomware`
-  * Good: `Simulate S3 ransomware`
-* `Description` should contain at least an intro sentence and a Warm-up, Detonation, References section. "References" should ideally be examples of usage/sightings of this technique in the wild, or relevant cloud provider documentation. Example:
+- `ID` should always be of the form `platform.mitre-attack-tactic.name`, e.g. `aws.defense-evasion.cloudtrail-delete`
+- `FriendlyName` should always start with a verb, and be in the infinitive form.
+  - Bad: `S3 ransomware`, `Creates S3 ransomware`
+  - Good: `Simulate S3 ransomware`
+- `Description` should contain at least an intro sentence and a Warm-up, Detonation, References section. "References" should ideally be examples of usage/sightings of this technique in the wild, or relevant cloud provider documentation. Example:
 
 ```
 Establishes persistence by creating a service account key on an existing service account.
@@ -149,7 +145,7 @@ References:
 - https://rhinosecuritylabs.com/gcp/privilege-escalation-google-cloud-platform-part-1/
 ```
 
-* `Detection` should describe how to detect this technique, including relevant CloudTrail/audit log event names and any managed detection rules (e.g. GuardDuty finding types). Use HTML for formatting since it renders in the docs. Example:
+- `Detection` should describe how to detect this technique, including relevant CloudTrail/audit log event names and any managed detection rules (e.g. GuardDuty finding types). Use HTML for formatting since it renders in the docs. Example:
 
 ```
 Identify when a CloudTrail trail is disabled, through CloudTrail's <code>StopLogging</code> event.
@@ -157,7 +153,7 @@ Identify when a CloudTrail trail is disabled, through CloudTrail's <code>StopLog
 GuardDuty also provides a dedicated finding type, <a href="https://docs.aws.amazon.com/guardduty/latest/ug/guardduty_finding-types-iam.html#stealth-iam-cloudtrailloggingdisabled">Stealth:IAMUser/CloudTrailLoggingDisabled</a>.
 ```
 
-* `IsIdempotent`: set to `true` if the detonation can be called multiple times without side effects.
+- `IsIdempotent`: set to `true` if the detonation can be called multiple times without side effects.
 
 #### Add your new Go file to the imported attack techniques
 

--- a/.claude/skills/create-attack-technique/SKILL.md
+++ b/.claude/skills/create-attack-technique/SKILL.md
@@ -37,6 +37,51 @@ When **creating** a new technique, follow the workflow below step by step. When 
 
 See [references/provider-configs.md](references/provider-configs.md) for the required Terraform provider blocks for each platform (AWS, Azure, Entra ID, GCP, Kubernetes).
 
+#### Concurrent detonation: use var.correlation.short in resource names
+
+A `variable "correlation"` block is **automatically injected** alongside your `main.tf` at warmup time — you do not need to declare it. It provides:
+
+- `var.correlation.id` — the full correlation UUID (used in tags/labels for signal matching)
+- `var.correlation.short` — an 8-character short form, safe to embed in resource names
+
+**Every resource with a globally or region-scoped name must embed `var.correlation.short`** so that concurrent executions of the same technique do not collide. The standard pattern is:
+
+```hcl
+locals {
+  resource_prefix = "stratus-red-team-<technique-name>-${var.correlation.short}"
+}
+
+resource "aws_iam_role" "role" {
+  name = "${local.resource_prefix}-role"
+}
+```
+
+Do **not** use `random_string` for name uniqueness — use `var.correlation.short` instead. Content-only randoms (secret values, ransomware fake-file content) are fine.
+
+For AWS techniques that use `var.config.aws.prefix`, the prefix is schema-validated to a maximum of 17 characters (see `config.schema.json`). Keep the technique's base name plus resource suffix short enough that a 17-char prefix, the 8-char `var.correlation.short`, and the suffix all fit within the provider's name-length limit (64 chars for IAM/Lambda, 63 for S3). See [docs/dev-guide/configuration.md](../../../docs/dev-guide/configuration.md) for details.
+
+For resources scoped under an already-uniquely-named parent (e.g. a K8s namespace that already carries `var.correlation.short`), the child resources do not need their own suffix — the parent's uniqueness isolates them.
+
+#### Go-created detonation artifacts
+
+If the technique creates resources **in Go** (not Terraform) during `detonate`, their names must also carry the correlation short ID. Since the Go code cannot access `var.correlation.short` directly, expose it as a Terraform output and read it from `params`:
+
+```hcl
+output "warmup_short_id" {
+  value = var.correlation.short
+}
+```
+
+```go
+func detonate(params map[string]string, providers stratus.CloudProviders) error {
+    shortID := params["warmup_short_id"]
+    resourceName := fmt.Sprintf("my-technique-%s", shortID)
+    // ...
+}
+```
+
+This value is persisted at warmup and read back at detonate/revert, so it stays stable across commands even when no correlation ID is set.
+
 When you're done, format your Terraform file using:
 
 ```bash

--- a/.claude/skills/create-attack-technique/references/provider-configs.md
+++ b/.claude/skills/create-attack-technique/references/provider-configs.md
@@ -27,6 +27,8 @@ provider "aws" {
 }
 ```
 
+For AWS techniques that use `var.config.aws.prefix`, the prefix is schema-validated to a maximum of 17 characters (see `config.schema.json`). Keep the technique's base name plus resource suffix short enough that a 17-char prefix, the 8-char `var.correlation.short`, and the suffix all fit within the provider's name-length limit (64 chars for IAM/Lambda, 63 for S3). See [docs/dev-guide/configuration.md](../../../../docs/dev-guide/configuration.md) for details.
+
 ## Azure
 
 ```hcl

--- a/.claude/skills/create-attack-technique/references/provider-configs.md
+++ b/.claude/skills/create-attack-technique/references/provider-configs.md
@@ -2,6 +2,8 @@
 
 Use the following provider blocks depending on the target platform.
 
+A `variable "correlation"` block is **automatically injected** alongside every technique's `main.tf` at warmup time — do not declare it yourself. It provides `var.correlation.id` (full UUID) and `var.correlation.short` (8-char short form). Embed `var.correlation.short` in all resource names for concurrent-detonation support. See the `create-attack-technique` skill for details.
+
 ## AWS / EKS
 
 ```hcl

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,6 +6,8 @@ Stratus Red Team is a CLI tool and Go library that allows you to easily detonate
 
 When you need to create or update new attack techniques, use the `create-attack-technique` skill.
 
+**All resource names must embed `var.correlation.short`** to support concurrent detonation. See the skill and [docs/dev-guide/configuration.md](docs/dev-guide/configuration.md) for details.
+
 ## Testing and developing locally
 
 To run locally:

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -10,7 +10,7 @@ To create a new attack technique:
 
 1. Create a new folder under `v2/internal/attacktechniques/your-cloud/your-mitre-attack-tactic/your-attack-name`
 2. Create a `main.go` file that contains the detonation (and optionally, the revert) behavior. See for example [cloudtrail-stop/main.go](https://github.com/DataDog/stratus-red-team/blob/main/v2/internal/attacktechniques/aws/defense-evasion/cloudtrail-stop/main.go)
-3. If your attack technique contains pre-requisites, create a `main.tf` file
+3. If your attack technique contains pre-requisites, create a `main.tf` file. **All resource names must embed `var.correlation.short`** so concurrent executions don't collide — see the `create-attack-technique` skill for details.
 4. Add your attack technique to the imports of `v2/internal/attacktechniques/main.go`
 
 To generate the logs dataset using [Grimoire](https://github.com/DataDog/grimoire):

--- a/docs/dev-guide/configuration.md
+++ b/docs/dev-guide/configuration.md
@@ -41,6 +41,10 @@ resource "kubernetes_pod" "pod" {
 
 The variable definition (in `pkg/stratus/config/config.tf`) provides defaults for all fields, so your Terraform code works with or without a user config file.
 
+!!! note "Prefix length limit"
+
+    AWS resources such as IAM users/roles, instance profiles, Lambda functions/layers and S3 buckets have name-length limits (63–64 characters). The `prefix` has a max length of 17 characters, to leave room for the resource name plus the short correlation ID (`var.correlation.short`, 8 characters). The `prefix` field does not support templating. When you write a technique that creates a length-limited resource, keep the technique's base name plus resource suffix short enough that a 17-char prefix and the 8-char correlation ID still fit within the resource's limit.
+
 ## In Go (for techniques that create resources at detonation time)
 
 For techniques that create resources in Go code (not Terraform), use `Apply[Resource]Config` (for K8S pod resources, it's `ApplyPodConfig`) to apply the user's configuration:

--- a/docs/user-guide/getting-started.md
+++ b/docs/user-guide/getting-started.md
@@ -238,6 +238,9 @@ For AWS techniques, it allows you to:
 
 - **Add custom tags** to Terraform-managed prerequisites supported by the AWS provider's `default_tags`
 - **Prefix resource names** with a service-compatible value, including through templating
+!!! note "Prefix length limit"
+
+    Some AWS resources have tight name-length limits (e.g. IAM users/roles and Lambda functions are capped at 64 characters, S3 buckets at 63). To guarantee that the names won't overflow once the various identifiers are added, the `prefix` is limited to **17** characters.
 
 !!! warning
 

--- a/v2/internal/attacktechniques/aws/credential-access/ec2-get-password-data/main.tf
+++ b/v2/internal/attacktechniques/aws/credential-access/ec2-get-password-data/main.tf
@@ -18,7 +18,7 @@ provider "aws" {
 }
 
 locals {
-  resource_prefix = "${var.config.aws.prefix}stratus-red-team-ec2-get-password-data"
+  resource_prefix = "${var.config.aws.prefix}stratus-red-team-ec2-get-pwd-${var.correlation.short}"
 }
 
 data "aws_caller_identity" "current" {}

--- a/v2/internal/attacktechniques/aws/credential-access/ec2-steal-instance-credentials/main.tf
+++ b/v2/internal/attacktechniques/aws/credential-access/ec2-steal-instance-credentials/main.tf
@@ -19,7 +19,7 @@ provider "aws" {
 }
 
 locals {
-  resource_prefix = "${var.config.aws.prefix}stratus-red-team-ec2-steal-credentials"
+  resource_prefix = "${var.config.aws.prefix}stratus-red-team-ec2-steal-creds-${var.correlation.short}"
 }
 
 data "aws_availability_zones" "available" {
@@ -102,7 +102,7 @@ resource "aws_iam_role_policy_attachment" "rolepolicy" {
 }
 
 resource "aws_iam_instance_profile" "instance" {
-  name = "${local.resource_prefix}-instance"
+  name = "${local.resource_prefix}-inst"
   role = aws_iam_role.instance-role.name
 }
 

--- a/v2/internal/attacktechniques/aws/credential-access/secretsmanager-batch-retrieve-secrets/main.tf
+++ b/v2/internal/attacktechniques/aws/credential-access/secretsmanager-batch-retrieve-secrets/main.tf
@@ -19,7 +19,7 @@ provider "aws" {
 
 locals {
   num_secrets     = 42
-  resource_prefix = "${var.config.aws.prefix}stratus-red-team-retrieve--batch-secret"
+  resource_prefix = "${var.config.aws.prefix}stratus-red-team-retrieve--batch-secret-${var.correlation.short}"
 }
 
 resource "random_string" "secrets" {

--- a/v2/internal/attacktechniques/aws/credential-access/secretsmanager-retrieve-secrets/main.tf
+++ b/v2/internal/attacktechniques/aws/credential-access/secretsmanager-retrieve-secrets/main.tf
@@ -19,7 +19,7 @@ provider "aws" {
 
 locals {
   num_secrets     = 20
-  resource_prefix = "${var.config.aws.prefix}stratus-red-team-retrieve-secret"
+  resource_prefix = "${var.config.aws.prefix}stratus-red-team-retrieve-secret-${var.correlation.short}"
 }
 
 resource "random_string" "secrets" {

--- a/v2/internal/attacktechniques/aws/credential-access/ssm-retrieve-securestring-parameters/main.tf
+++ b/v2/internal/attacktechniques/aws/credential-access/ssm-retrieve-securestring-parameters/main.tf
@@ -19,7 +19,7 @@ provider "aws" {
 
 locals {
   num_parameters = 42 // arbitrary
-  prefix         = "/credentials/${var.config.aws.prefix}stratus-red-team/"
+  prefix         = "/credentials/${var.config.aws.prefix}stratus-red-team-${var.correlation.short}/"
 }
 
 resource "random_password" "secret" {

--- a/v2/internal/attacktechniques/aws/defense-evasion/cloudtrail-delete/main.tf
+++ b/v2/internal/attacktechniques/aws/defense-evasion/cloudtrail-delete/main.tf
@@ -17,22 +17,17 @@ provider "aws" {
   }
 }
 
-resource "random_string" "suffix" {
-  length    = 10
-  min_lower = 10
-  special   = false
+
+locals {
+  resource_prefix = "${var.config.aws.prefix}stratus-red-team-cloudtraild-${var.correlation.short}"
 }
 
 locals {
-  resource_prefix = "${var.config.aws.prefix}stratus-red-team-cloudtraild"
-}
-
-locals {
-  bucket-name = "${local.resource_prefix}-bucket-${random_string.suffix.result}"
+  bucket-name = "${local.resource_prefix}-bucket"
 }
 
 resource "aws_cloudtrail" "trail" {
-  name           = "${local.resource_prefix}-trail-${random_string.suffix.result}"
+  name           = "${local.resource_prefix}-trail"
   s3_bucket_name = aws_s3_bucket.cloudtrail.id
 }
 

--- a/v2/internal/attacktechniques/aws/defense-evasion/cloudtrail-event-selectors/main.tf
+++ b/v2/internal/attacktechniques/aws/defense-evasion/cloudtrail-event-selectors/main.tf
@@ -17,22 +17,17 @@ provider "aws" {
   }
 }
 
-resource "random_string" "suffix" {
-  length    = 10
-  min_lower = 10
-  special   = false
+
+locals {
+  resource_prefix = "${var.config.aws.prefix}stratus-red-team-ctes-${var.correlation.short}" # cloudtrail event selectors
 }
 
 locals {
-  resource_prefix = "${var.config.aws.prefix}stratus-red-team-ctes" # cloudtrail event selectors
-}
-
-locals {
-  bucket-name = "${local.resource_prefix}-bucket-${random_string.suffix.result}"
+  bucket-name = "${local.resource_prefix}-bucket"
 }
 
 resource "aws_cloudtrail" "trail" {
-  name           = "${local.resource_prefix}-trail-${random_string.suffix.result}"
+  name           = "${local.resource_prefix}-trail"
   s3_bucket_name = aws_s3_bucket.cloudtrail.id
 }
 

--- a/v2/internal/attacktechniques/aws/defense-evasion/cloudtrail-lifecycle-rule/main.tf
+++ b/v2/internal/attacktechniques/aws/defense-evasion/cloudtrail-lifecycle-rule/main.tf
@@ -17,22 +17,17 @@ provider "aws" {
   }
 }
 
-resource "random_string" "suffix" {
-  length    = 10
-  min_lower = 10
-  special   = false
+
+locals {
+  resource_prefix = "${var.config.aws.prefix}stratus-red-team-ctlr-${var.correlation.short}" # cloudtrail lifecycle rule
 }
 
 locals {
-  resource_prefix = "${var.config.aws.prefix}stratus-red-team-ctlr" # cloudtrail lifecycle rule
-}
-
-locals {
-  bucket-name = "${local.resource_prefix}-bucket-${random_string.suffix.result}"
+  bucket-name = "${local.resource_prefix}-bucket"
 }
 
 resource "aws_cloudtrail" "trail" {
-  name           = "${local.resource_prefix}-trail-${random_string.suffix.result}"
+  name           = "${local.resource_prefix}-trail"
   s3_bucket_name = aws_s3_bucket.cloudtrail.id
 }
 

--- a/v2/internal/attacktechniques/aws/defense-evasion/cloudtrail-stop/main.tf
+++ b/v2/internal/attacktechniques/aws/defense-evasion/cloudtrail-stop/main.tf
@@ -17,22 +17,17 @@ provider "aws" {
   }
 }
 
-resource "random_string" "suffix" {
-  length    = 10
-  min_lower = 10
-  special   = false
+
+locals {
+  resource_prefix = "${var.config.aws.prefix}stratus-red-team-ct-stop-${var.correlation.short}"
 }
 
 locals {
-  resource_prefix = "${var.config.aws.prefix}stratus-red-team-ct-stop"
-}
-
-locals {
-  bucket-name = "${local.resource_prefix}-bucket-${random_string.suffix.result}"
+  bucket-name = "${local.resource_prefix}-bucket"
 }
 
 resource "aws_cloudtrail" "trail" {
-  name           = "${local.resource_prefix}-trail-${random_string.suffix.result}"
+  name           = "${local.resource_prefix}-trail"
   s3_bucket_name = aws_s3_bucket.cloudtrail.id
 }
 

--- a/v2/internal/attacktechniques/aws/defense-evasion/dns-delete-logs/main.tf
+++ b/v2/internal/attacktechniques/aws/defense-evasion/dns-delete-logs/main.tf
@@ -16,22 +16,17 @@ provider "aws" {
   }
 }
 
-resource "random_string" "suffix" {
-  length    = 10
-  min_lower = 10
-  special   = false
+
+locals {
+  resource_prefix = "${var.config.aws.prefix}stratus-red-team-dns-delete-${var.correlation.short}"
 }
 
 locals {
-  resource_prefix = "${var.config.aws.prefix}stratus-red-team-dns-delete"
-}
-
-locals {
-  bucket-name = "${local.resource_prefix}-bucket-${random_string.suffix.result}"
+  bucket-name = "${local.resource_prefix}-bucket"
 }
 
 resource "aws_route53_resolver_query_log_config" "config" {
-  name            = "${local.resource_prefix}-config-${random_string.suffix.result}"
+  name            = "${local.resource_prefix}-config"
   destination_arn = aws_s3_bucket.query_log.arn
 }
 

--- a/v2/internal/attacktechniques/aws/defense-evasion/organizations-leave/main.tf
+++ b/v2/internal/attacktechniques/aws/defense-evasion/organizations-leave/main.tf
@@ -18,7 +18,7 @@ provider "aws" {
 }
 
 locals {
-  resource_prefix = "${var.config.aws.prefix}stratus-red-team-leave-org"
+  resource_prefix = "${var.config.aws.prefix}stratus-red-team-leave-org-${var.correlation.short}"
 }
 
 data "aws_caller_identity" "current" {}

--- a/v2/internal/attacktechniques/aws/defense-evasion/vpc-remove-flow-logs/main.tf
+++ b/v2/internal/attacktechniques/aws/defense-evasion/vpc-remove-flow-logs/main.tf
@@ -33,7 +33,7 @@ resource "aws_flow_log" "flow-logs" {
 }
 
 resource "aws_cloudwatch_log_group" "logs" {
-  name = "/${var.config.aws.prefix}stratus-red-team/vpc-flow-logs"
+  name = "/${local.resource_prefix}/vpc-flow-logs"
 }
 
 resource "aws_iam_role" "role" {

--- a/v2/internal/attacktechniques/aws/defense-evasion/vpc-remove-flow-logs/main.tf
+++ b/v2/internal/attacktechniques/aws/defense-evasion/vpc-remove-flow-logs/main.tf
@@ -18,7 +18,7 @@ provider "aws" {
 }
 
 locals {
-  resource_prefix = "${var.config.aws.prefix}stratus-red-team-remove-flow-logs"
+  resource_prefix = "${var.config.aws.prefix}stratus-red-team-remove-flow-logs-${var.correlation.short}"
 }
 
 resource "aws_vpc" "vpc" {

--- a/v2/internal/attacktechniques/aws/discovery/ec2-enumerate-from-instance/main.tf
+++ b/v2/internal/attacktechniques/aws/discovery/ec2-enumerate-from-instance/main.tf
@@ -19,7 +19,7 @@ provider "aws" {
 }
 
 locals {
-  resource_prefix = "${var.config.aws.prefix}stratus-red-team-ec2-enumerate"
+  resource_prefix = "${var.config.aws.prefix}stratus-red-team-ec2-enumerate-${var.correlation.short}"
 }
 
 data "aws_availability_zones" "available" {
@@ -87,7 +87,7 @@ resource "aws_iam_role_policy_attachment" "rolepolicy" {
 }
 
 resource "aws_iam_instance_profile" "instance" {
-  name = "${local.resource_prefix}-instance"
+  name = "${local.resource_prefix}-inst"
   role = aws_iam_role.instance-role.name
 }
 

--- a/v2/internal/attacktechniques/aws/discovery/ec2-get-user-data/main.tf
+++ b/v2/internal/attacktechniques/aws/discovery/ec2-get-user-data/main.tf
@@ -18,7 +18,7 @@ provider "aws" {
 }
 
 locals {
-  resource_prefix = "${var.config.aws.prefix}stratus-red-team-get-usr-data"
+  resource_prefix = "${var.config.aws.prefix}stratus-red-team-get-usr-data-${var.correlation.short}"
 }
 
 data "aws_caller_identity" "current" {}

--- a/v2/internal/attacktechniques/aws/execution/ec2-launch-unusual-instances/main.tf
+++ b/v2/internal/attacktechniques/aws/execution/ec2-launch-unusual-instances/main.tf
@@ -19,18 +19,13 @@ provider "aws" {
 
 data "aws_caller_identity" "current" {}
 
-resource "random_string" "suffix" {
-  length    = 10
-  min_lower = 10
-  special   = false
-}
 
 locals {
-  resource_prefix = "${var.config.aws.prefix}stratus-red-team-ec2lui" # ec2 launch unusual instance
+  resource_prefix = "${var.config.aws.prefix}stratus-red-team-ec2lui-${var.correlation.short}" # ec2 launch unusual instance
 }
 
 resource "aws_iam_role" "role" {
-  name = "${local.resource_prefix}-role-${random_string.suffix.result}"
+  name = "${local.resource_prefix}-role"
   assume_role_policy = jsonencode({
     Version = "2012-10-17"
     Statement = [
@@ -47,7 +42,7 @@ resource "aws_iam_role" "role" {
 }
 
 resource "aws_iam_policy" "policy" {
-  name = "${local.resource_prefix}-policy-${random_string.suffix.result}"
+  name = "${local.resource_prefix}-policy"
   policy = jsonencode({
     Version = "2012-10-17"
     Statement = [
@@ -61,7 +56,7 @@ resource "aws_iam_policy" "policy" {
 }
 
 resource "aws_iam_policy_attachment" "attachment" {
-  name       = "${local.resource_prefix}-attachment-${random_string.suffix.result}"
+  name       = "${local.resource_prefix}-attachment"
   roles      = [aws_iam_role.role.name]
   policy_arn = aws_iam_policy.policy.arn
 }

--- a/v2/internal/attacktechniques/aws/execution/ec2-user-data/main.tf
+++ b/v2/internal/attacktechniques/aws/execution/ec2-user-data/main.tf
@@ -19,7 +19,7 @@ provider "aws" {
 }
 
 locals {
-  resource_prefix = "${var.config.aws.prefix}stratus-red-team-usr-data"
+  resource_prefix = "${var.config.aws.prefix}stratus-red-team-usr-data-${var.correlation.short}"
 }
 
 data "aws_availability_zones" "available" {
@@ -87,7 +87,7 @@ resource "aws_iam_role_policy_attachment" "rolepolicy" {
 }
 
 resource "aws_iam_instance_profile" "instance" {
-  name = "${local.resource_prefix}-instance"
+  name = "${local.resource_prefix}-inst"
   role = aws_iam_role.instance-role.name
 }
 

--- a/v2/internal/attacktechniques/aws/execution/sagemaker-lifecycle-config/main.tf
+++ b/v2/internal/attacktechniques/aws/execution/sagemaker-lifecycle-config/main.tf
@@ -21,13 +21,13 @@ provider "aws" {
 data "aws_caller_identity" "current" {}
 
 locals {
-  resource_prefix = "${var.config.aws.prefix}stratus-red-team-update-sagemaker-config-profile"
+  resource_prefix = "${var.config.aws.prefix}stratus-red-team-sagemaker-${var.correlation.short}"
 }
 
 # --- 1. High-Privilege Target Role (The Goal of the Attack) ---
 
 resource "aws_iam_role" "high_priv_execution_role" {
-  name        = "${local.resource_prefix}-high-priv-role"
+  name        = "${local.resource_prefix}-hi-role"
   description = "Execution role for SageMaker instance. Target for privilege escalation."
   assume_role_policy = jsonencode({
     Version = "2012-10-17",
@@ -98,7 +98,7 @@ resource "aws_iam_role_policy_attachment" "high_priv_attach" {
 # --- 2. Low-Privilege Attacker Role (The Enabler of the Attack) ---
 
 resource "aws_iam_role" "low_priv_attacker_role" {
-  name        = "${local.resource_prefix}-low-priv-role"
+  name        = "${local.resource_prefix}-lo-role"
   description = "Role with permissions to execute the SageMaker update attack."
   assume_role_policy = jsonencode({
     Version = "2012-10-17",
@@ -153,7 +153,7 @@ resource "aws_iam_role_policy_attachment" "low_priv_attach" {
 # --- 3. SageMaker Notebook Instance (The Target) ---
 
 resource "aws_sagemaker_notebook_instance" "target_notebook" {
-  name          = "${local.resource_prefix}-vuln-notebook"
+  name          = "${local.resource_prefix}-vuln-vm"
   role_arn      = aws_iam_role.high_priv_execution_role.arn
   instance_type = "ml.t2.medium"
   # Set to skip root access to ensure only the role is the entry point

--- a/v2/internal/attacktechniques/aws/execution/ssm-send-command/main.tf
+++ b/v2/internal/attacktechniques/aws/execution/ssm-send-command/main.tf
@@ -18,7 +18,7 @@ provider "aws" {
 }
 
 locals {
-  resource_prefix = "${var.config.aws.prefix}stratus-red-team-ssm-send-command-execution"
+  resource_prefix = "${var.config.aws.prefix}stratus-red-team-ssm-send-cmd-${var.correlation.short}"
 }
 
 variable "instance_count" {
@@ -93,7 +93,7 @@ resource "aws_iam_role_policy_attachment" "rolepolicy" {
 }
 
 resource "aws_iam_instance_profile" "instance" {
-  name = "${local.resource_prefix}-instance"
+  name = "${local.resource_prefix}-inst"
   role = aws_iam_role.instance-role.name
 }
 

--- a/v2/internal/attacktechniques/aws/execution/ssm-start-session/main.tf
+++ b/v2/internal/attacktechniques/aws/execution/ssm-start-session/main.tf
@@ -18,7 +18,7 @@ provider "aws" {
 }
 
 locals {
-  resource_prefix = "${var.config.aws.prefix}stratus-red-team-ssm-start-session-lateral-movement"
+  resource_prefix = "${var.config.aws.prefix}stratus-red-team-ssm-start-sess-${var.correlation.short}"
 }
 
 variable "instance_count" {
@@ -93,7 +93,7 @@ resource "aws_iam_role_policy_attachment" "rolepolicy" {
 }
 
 resource "aws_iam_instance_profile" "instance" {
-  name = "${local.resource_prefix}-instance"
+  name = "${local.resource_prefix}-inst"
   role = aws_iam_role.instance-role.name
 }
 

--- a/v2/internal/attacktechniques/aws/exfiltration/ec2-security-group-open-port-22-ingress/main.tf
+++ b/v2/internal/attacktechniques/aws/exfiltration/ec2-security-group-open-port-22-ingress/main.tf
@@ -18,7 +18,7 @@ provider "aws" {
 }
 
 locals {
-  resource_prefix = "${var.config.aws.prefix}stratus-red-team-open-sg"
+  resource_prefix = "${var.config.aws.prefix}stratus-red-team-open-sg-${var.correlation.short}"
 }
 
 resource "aws_vpc" "vpc" {

--- a/v2/internal/attacktechniques/aws/exfiltration/ec2-share-ami/main.tf
+++ b/v2/internal/attacktechniques/aws/exfiltration/ec2-share-ami/main.tf
@@ -18,7 +18,7 @@ provider "aws" {
 }
 
 locals {
-  resource_prefix = "${var.config.aws.prefix}stratus-red-team-share-ami"
+  resource_prefix = "${var.config.aws.prefix}stratus-red-team-share-ami-${var.correlation.short}"
 }
 
 data "aws_availability_zones" "available" {

--- a/v2/internal/attacktechniques/aws/exfiltration/rds-share-snapshot/main.tf
+++ b/v2/internal/attacktechniques/aws/exfiltration/rds-share-snapshot/main.tf
@@ -24,7 +24,7 @@ resource "random_password" "password" {
 }
 
 locals {
-  resource_prefix = "${var.config.aws.prefix}stratus-red-team-share-snap"
+  resource_prefix = "${var.config.aws.prefix}stratus-red-team-share-snap-${var.correlation.short}"
 }
 
 data "aws_availability_zones" "available" {

--- a/v2/internal/attacktechniques/aws/exfiltration/s3-backdoor-bucket-policy/main.tf
+++ b/v2/internal/attacktechniques/aws/exfiltration/s3-backdoor-bucket-policy/main.tf
@@ -17,18 +17,13 @@ provider "aws" {
   }
 }
 
-resource "random_string" "suffix" {
-  length    = 10
-  min_lower = 10
-  special   = false
-}
 
 locals {
-  resource_prefix = "${var.config.aws.prefix}stratus-red-team-bdbp" # backdoor bucket policy
+  resource_prefix = "${var.config.aws.prefix}stratus-red-team-bdbp-${var.correlation.short}" # backdoor bucket policy
 }
 
 resource "aws_s3_bucket" "bucket" {
-  bucket = "${local.resource_prefix}-${random_string.suffix.result}"
+  bucket = local.resource_prefix
 }
 
 output "bucket_name" {

--- a/v2/internal/attacktechniques/aws/impact/ec2-deregister-ami/main.tf
+++ b/v2/internal/attacktechniques/aws/impact/ec2-deregister-ami/main.tf
@@ -17,15 +17,10 @@ provider "aws" {
   }
 }
 
-resource "random_string" "suffix" {
-  length    = 6
-  min_lower = 6
-  special   = false
-}
 
 locals {
-  resource_prefix = "stratus-red-team-deregister-ami"
-  ami_name        = format("%s-ami-%s", local.resource_prefix, random_string.suffix.result)
+  resource_prefix = "stratus-red-team-deregister-ami-${var.correlation.short}"
+  ami_name        = format("%s-ami", local.resource_prefix)
 }
 
 data "aws_availability_zones" "available" {

--- a/v2/internal/attacktechniques/aws/impact/s3-ransomware-batch-deletion/main.tf
+++ b/v2/internal/attacktechniques/aws/impact/s3-ransomware-batch-deletion/main.tf
@@ -17,15 +17,10 @@ provider "aws" {
   }
 }
 
-resource "random_string" "suffix" {
-  length    = 6
-  min_lower = 6
-  special   = false
-}
 
 locals {
-  resource_prefix = "${var.config.aws.prefix}stratus-red-team-ransomware-bucket"
-  bucket_name     = format("%s-%s", local.resource_prefix, random_string.suffix.result)
+  resource_prefix = "${var.config.aws.prefix}stratus-red-team-ransomware-bucket-${var.correlation.short}"
+  bucket_name     = local.resource_prefix
   num-files       = 51
   min-size-bytes  = 1
   max-size-bytes  = 200

--- a/v2/internal/attacktechniques/aws/impact/s3-ransomware-client-side-encryption/main.tf
+++ b/v2/internal/attacktechniques/aws/impact/s3-ransomware-client-side-encryption/main.tf
@@ -17,15 +17,10 @@ provider "aws" {
   }
 }
 
-resource "random_string" "suffix" {
-  length    = 6
-  min_lower = 6
-  special   = false
-}
 
 locals {
-  resource_prefix = "${var.config.aws.prefix}stratus-red-team-ransomware-bucket"
-  bucket_name     = format("%s-%s", local.resource_prefix, random_string.suffix.result)
+  resource_prefix = "${var.config.aws.prefix}stratus-red-team-ransomware-bucket-${var.correlation.short}"
+  bucket_name     = local.resource_prefix
   num-files       = 51
   min-size-bytes  = 1
   max-size-bytes  = 200

--- a/v2/internal/attacktechniques/aws/impact/s3-ransomware-individual-deletion/main.tf
+++ b/v2/internal/attacktechniques/aws/impact/s3-ransomware-individual-deletion/main.tf
@@ -17,15 +17,10 @@ provider "aws" {
   }
 }
 
-resource "random_string" "suffix" {
-  length    = 6
-  min_lower = 6
-  special   = false
-}
 
 locals {
-  resource_prefix = "${var.config.aws.prefix}stratus-red-team-ransomware-bucket"
-  bucket_name     = format("%s-%s", local.resource_prefix, random_string.suffix.result)
+  resource_prefix = "${var.config.aws.prefix}stratus-red-team-ransomware-bucket-${var.correlation.short}"
+  bucket_name     = local.resource_prefix
   num-files       = 51
   min-size-bytes  = 1
   max-size-bytes  = 200

--- a/v2/internal/attacktechniques/aws/initial-access/console-login-without-mfa/main.tf
+++ b/v2/internal/attacktechniques/aws/initial-access/console-login-without-mfa/main.tf
@@ -19,18 +19,13 @@ provider "aws" {
 
 data "aws_caller_identity" "current" {}
 
-resource "random_string" "suffix" {
-  length    = 10
-  min_lower = 10
-  special   = false
-}
 
 locals {
-  resource_prefix = "${var.config.aws.prefix}stratus-red-team-nmfalu" # non-mfa login user
+  resource_prefix = "${var.config.aws.prefix}stratus-red-team-nmfalu-${var.correlation.short}" # non-mfa login user
 }
 
 resource "aws_iam_user" "console-user" {
-  name          = "${local.resource_prefix}-${random_string.suffix.result}"
+  name          = local.resource_prefix
   force_destroy = true
 }
 

--- a/v2/internal/attacktechniques/aws/lateral-movement/ec2-send-serial-console-send-ssh-public-key/main.tf
+++ b/v2/internal/attacktechniques/aws/lateral-movement/ec2-send-serial-console-send-ssh-public-key/main.tf
@@ -18,7 +18,7 @@ provider "aws" {
 }
 
 locals {
-  resource_prefix = "${var.config.aws.prefix}stratus-red-team-ec2-serialconsole-ssh-lateral-movement"
+  resource_prefix = "${var.config.aws.prefix}stratus-red-team-ec2-serialcon-${var.correlation.short}"
 }
 
 variable "instance_count" {
@@ -95,7 +95,7 @@ resource "aws_iam_role_policy_attachment" "rolepolicy" {
 }
 
 resource "aws_iam_instance_profile" "instance" {
-  name = "${local.resource_prefix}-instance"
+  name = "${local.resource_prefix}-inst"
   role = aws_iam_role.instance-role.name
 }
 

--- a/v2/internal/attacktechniques/aws/lateral-movement/ec2-send-ssh-public-key/main.tf
+++ b/v2/internal/attacktechniques/aws/lateral-movement/ec2-send-ssh-public-key/main.tf
@@ -18,7 +18,7 @@ provider "aws" {
 }
 
 locals {
-  resource_prefix = "${var.config.aws.prefix}stratus-red-team-ec2-sshpublickey-lateral-movement"
+  resource_prefix = "${var.config.aws.prefix}stratus-red-team-ec2-sshpubkey-${var.correlation.short}"
 }
 
 variable "instance_count" {
@@ -93,7 +93,7 @@ resource "aws_iam_role_policy_attachment" "rolepolicy" {
 }
 
 resource "aws_iam_instance_profile" "instance" {
-  name = "${local.resource_prefix}-instance"
+  name = "${local.resource_prefix}-inst"
   role = aws_iam_role.instance-role.name
 }
 

--- a/v2/internal/attacktechniques/aws/persistence/iam-backdoor-role/main.tf
+++ b/v2/internal/attacktechniques/aws/persistence/iam-backdoor-role/main.tf
@@ -18,7 +18,7 @@ provider "aws" {
 }
 
 locals {
-  resource_prefix = "${var.config.aws.prefix}stratus-red-team-backdoor-r"
+  resource_prefix = "${var.config.aws.prefix}stratus-red-team-backdoor-r-${var.correlation.short}"
 }
 
 resource "aws_iam_role" "legit-role" {

--- a/v2/internal/attacktechniques/aws/persistence/iam-backdoor-user/main.tf
+++ b/v2/internal/attacktechniques/aws/persistence/iam-backdoor-user/main.tf
@@ -18,11 +18,11 @@ provider "aws" {
 }
 
 locals {
-  resource_prefix = "${var.config.aws.prefix}stratus-red-team-backdoor-u"
+  resource_prefix = "${var.config.aws.prefix}stratus-red-team-backdoor-${var.correlation.short}"
 }
 
 resource "aws_iam_user" "legit-user" {
-  name          = "${local.resource_prefix}-user" # TODO parametrize
+  name          = "${local.resource_prefix}-usr" # TODO parametrize
   force_destroy = true
 }
 

--- a/v2/internal/attacktechniques/aws/persistence/iam-create-user-login-profile/main.tf
+++ b/v2/internal/attacktechniques/aws/persistence/iam-create-user-login-profile/main.tf
@@ -18,11 +18,11 @@ provider "aws" {
 }
 
 locals {
-  resource_prefix = "${var.config.aws.prefix}stratus-red-team-login-profile"
+  resource_prefix = "${var.config.aws.prefix}stratus-red-team-login-profile-${var.correlation.short}"
 }
 
 resource "aws_iam_user" "legit-user" {
-  name          = "${local.resource_prefix}-user"
+  name          = "${local.resource_prefix}-usr"
   force_destroy = true
 }
 

--- a/v2/internal/attacktechniques/aws/persistence/lambda-backdoor-function/main.tf
+++ b/v2/internal/attacktechniques/aws/persistence/lambda-backdoor-function/main.tf
@@ -18,7 +18,7 @@ provider "aws" {
 }
 
 locals {
-  resource_prefix = "${var.config.aws.prefix}stratus-red-team-backdoor-f"
+  resource_prefix = "${var.config.aws.prefix}stratus-red-team-backdoor-f-${var.correlation.short}"
 }
 
 resource "aws_iam_role" "lambda" {
@@ -41,14 +41,9 @@ resource "aws_iam_role" "lambda" {
 EOF
 }
 
-resource "random_string" "suffix" {
-  length    = 10
-  min_lower = 10
-  special   = false
-}
 
 resource "aws_s3_bucket" "bucket" {
-  bucket        = "${local.resource_prefix}-bucket-${random_string.suffix.result}"
+  bucket        = "${local.resource_prefix}-bucket"
   force_destroy = true
 }
 resource "aws_s3_bucket_object" "code" {

--- a/v2/internal/attacktechniques/aws/persistence/lambda-layer-extension/main.tf
+++ b/v2/internal/attacktechniques/aws/persistence/lambda-layer-extension/main.tf
@@ -18,11 +18,11 @@ provider "aws" {
 }
 
 locals {
-  resource_prefix = "${var.config.aws.prefix}stratus-red-team-lambda-layer"
+  resource_prefix = "${var.config.aws.prefix}stratus-red-team-lambda-layer-${var.correlation.short}"
 }
 
 resource "aws_iam_role" "lambda_role" {
-  name = "${local.resource_prefix}-lambda-role"
+  name = "${local.resource_prefix}-role"
 
   assume_role_policy = jsonencode({
     Version = "2012-10-17"
@@ -68,14 +68,9 @@ resource "aws_iam_role_policy_attachment" "lambda_logs_attach" {
 }
 
 
-resource "random_string" "suffix" {
-  length    = 6
-  min_lower = 6
-  special   = false
-}
 
 resource "aws_s3_bucket" "bucket" {
-  bucket        = "${local.resource_prefix}-${random_string.suffix.result}"
+  bucket        = local.resource_prefix
   force_destroy = true
 }
 
@@ -88,9 +83,9 @@ resource "aws_s3_bucket_object" "code" {
 resource "aws_lambda_function" "lambda" {
   s3_bucket     = aws_s3_bucket.bucket.id
   s3_key        = aws_s3_bucket_object.code.key
-  function_name = "${local.resource_prefix}-simpleLambda"
+  function_name = "${local.resource_prefix}-fn"
   role          = aws_iam_role.lambda_role.arn
-  handler       = "${local.resource_prefix}-simpleLambda.handler"
+  handler       = "${local.resource_prefix}-fn.handler"
   timeout       = 20
 
   runtime = "python3.10"
@@ -107,7 +102,7 @@ resource "aws_s3_bucket_object" "code_layer" {
 resource "aws_lambda_layer_version" "lambda_extension_layer" {
   s3_bucket  = aws_s3_bucket.bucket.id
   s3_key     = aws_s3_bucket_object.code_layer.key
-  layer_name = "${local.resource_prefix}-my-lambda-extension"
+  layer_name = "${local.resource_prefix}-ext"
 
   compatible_runtimes = ["python3.10"]
 }

--- a/v2/internal/attacktechniques/aws/persistence/lambda-overwrite-code/main.tf
+++ b/v2/internal/attacktechniques/aws/persistence/lambda-overwrite-code/main.tf
@@ -17,18 +17,13 @@ provider "aws" {
   }
 }
 
-resource "random_string" "suffix" {
-  length    = 10
-  min_lower = 10
-  special   = false
-}
 
 locals {
-  resource_prefix = "${var.config.aws.prefix}stratus-red-team-olc" # stratus red team overwrite lambda code
+  resource_prefix = "${var.config.aws.prefix}stratus-red-team-olc-${var.correlation.short}" # stratus red team overwrite lambda code
 }
 
 resource "aws_iam_role" "lambda-update" {
-  name = "${local.resource_prefix}-lambda-${random_string.suffix.result}"
+  name = "${local.resource_prefix}-lambda"
   assume_role_policy = jsonencode({
     "Version" : "2012-10-17",
     "Statement" : [
@@ -47,7 +42,7 @@ resource "aws_iam_role" "lambda-update" {
 
 
 resource "aws_s3_bucket" "bucket" {
-  bucket        = "${local.resource_prefix}-bucket-${random_string.suffix.result}"
+  bucket        = "${local.resource_prefix}-bucket"
   force_destroy = true
 }
 
@@ -58,7 +53,7 @@ resource "aws_s3_object" "lambda_zip" {
 }
 
 resource "aws_lambda_function" "lambda" {
-  function_name = "${local.resource_prefix}-func-${random_string.suffix.result}"
+  function_name = "${local.resource_prefix}-func"
   s3_bucket     = aws_s3_bucket.bucket.id
   s3_key        = aws_s3_object.lambda_zip.key
   role          = aws_iam_role.lambda-update.arn

--- a/v2/internal/attacktechniques/aws/persistence/rolesanywhere-create-trust-anchor/main.tf
+++ b/v2/internal/attacktechniques/aws/persistence/rolesanywhere-create-trust-anchor/main.tf
@@ -18,7 +18,7 @@ provider "aws" {
 }
 
 locals {
-  resource_prefix = "${var.config.aws.prefix}stratus-red-team-trust-anchor"
+  resource_prefix = "${var.config.aws.prefix}stratus-red-team-trust-anchor-${var.correlation.short}"
 }
 
 resource "aws_iam_role" "role" {

--- a/v2/internal/attacktechniques/aws/persistence/sts-federation-token/main.tf
+++ b/v2/internal/attacktechniques/aws/persistence/sts-federation-token/main.tf
@@ -18,11 +18,11 @@ provider "aws" {
 }
 
 locals {
-  resource_prefix = "${var.config.aws.prefix}stratus-red-team-user-federation"
+  resource_prefix = "${var.config.aws.prefix}stratus-red-team-user-federation-${var.correlation.short}"
 }
 
 resource "aws_iam_user" "legit-user" {
-  name          = "${local.resource_prefix}-user"
+  name          = "${local.resource_prefix}-usr"
   force_destroy = true
 }
 

--- a/v2/internal/attacktechniques/aws/privilege-escalation/change-iam-user-password/main.tf
+++ b/v2/internal/attacktechniques/aws/privilege-escalation/change-iam-user-password/main.tf
@@ -17,11 +17,11 @@ provider "aws" {
 }
 
 locals {
-  resource_prefix = "${var.config.aws.prefix}stratus-red-team-update-login-profile"
+  resource_prefix = "${var.config.aws.prefix}stratus-red-team-chg-pwd-${var.correlation.short}"
 }
 
 resource "aws_iam_user" "legit-user" {
-  name          = "${local.resource_prefix}-user"
+  name          = "${local.resource_prefix}-usr"
   force_destroy = true
 }
 

--- a/v2/internal/attacktechniques/azure/credential-access/app-service-publishing-credentials/main.tf
+++ b/v2/internal/attacktechniques/azure/credential-access/app-service-publishing-credentials/main.tf
@@ -11,14 +11,9 @@ provider "azurerm" {
   features {}
 }
 
-resource "random_string" "suffix" {
-  length  = 8
-  special = false
-  upper   = false
-}
 
 resource "azurerm_resource_group" "rg" {
-  name = "stratus-red-team-asp-cred-rg-${random_string.suffix.result}"
+  name = "stratus-red-team-asp-cred-rg-${var.correlation.short}"
   # West US 2 is used instead of West US: App Service plan quota in smaller
   # regions such as West US is frequently 0, causing deployment failures.
   # Larger regions like West US 2 have more spare capacity.
@@ -34,7 +29,7 @@ resource "azurerm_service_plan" "plan" {
 }
 
 resource "azurerm_linux_web_app" "app" {
-  name                = "srt-asp-cred-${random_string.suffix.result}"
+  name                = "srt-asp-cred-${var.correlation.short}"
   resource_group_name = azurerm_resource_group.rg.name
   location            = azurerm_service_plan.plan.location
   service_plan_id     = azurerm_service_plan.plan.id

--- a/v2/internal/attacktechniques/azure/execution/vm-custom-script-extension/main.tf
+++ b/v2/internal/attacktechniques/azure/execution/vm-custom-script-extension/main.tf
@@ -19,11 +19,6 @@ locals {
 # Random
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 
-resource "random_string" "lab_name" {
-  length  = 8
-  special = false
-  upper   = false
-}
 
 resource "random_password" "password" {
   length           = 64
@@ -36,7 +31,7 @@ resource "random_password" "password" {
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 
 resource "azurerm_resource_group" "lab_environment" {
-  name     = "${local.resource_prefix}-rg-${random_string.lab_name.result}"
+  name     = "${local.resource_prefix}-rg-${var.correlation.short}"
   location = "West US"
 }
 
@@ -45,26 +40,26 @@ resource "azurerm_resource_group" "lab_environment" {
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 
 resource "azurerm_virtual_network" "lab_vnet" {
-  name                = "${local.resource_prefix}-vnet-${random_string.lab_name.result}"
+  name                = "${local.resource_prefix}-vnet-${var.correlation.short}"
   address_space       = ["10.0.0.0/16"]
   location            = azurerm_resource_group.lab_environment.location
   resource_group_name = azurerm_resource_group.lab_environment.name
 }
 
 resource "azurerm_subnet" "lab_subnet" {
-  name                 = "${local.resource_prefix}-subnet-${random_string.lab_name.result}"
+  name                 = "${local.resource_prefix}-subnet-${var.correlation.short}"
   resource_group_name  = azurerm_resource_group.lab_environment.name
   virtual_network_name = azurerm_virtual_network.lab_vnet.name
   address_prefixes     = ["10.0.2.0/24"]
 }
 
 resource "azurerm_network_interface" "lab_nic" {
-  name                = "${local.resource_prefix}-nic-${random_string.lab_name.result}"
+  name                = "${local.resource_prefix}-nic-${var.correlation.short}"
   location            = azurerm_resource_group.lab_environment.location
   resource_group_name = azurerm_resource_group.lab_environment.name
 
   ip_configuration {
-    name                          = "${local.resource_prefix}-ip-${random_string.lab_name.result}"
+    name                          = "${local.resource_prefix}-ip-${var.correlation.short}"
     subnet_id                     = azurerm_subnet.lab_subnet.id
     private_ip_address_allocation = "Dynamic"
   }
@@ -81,7 +76,7 @@ resource "azurerm_windows_virtual_machine" "lab_windows_vm" {
   size                = "Standard_F2"
   admin_username      = "local_admin_user"
   admin_password      = random_password.password.result
-  user_data           = base64encode(random_string.lab_name.result)
+  user_data           = base64encode(var.correlation.short)
 
   network_interface_ids = [
     azurerm_network_interface.lab_nic.id,

--- a/v2/internal/attacktechniques/azure/execution/vm-run-command/main.tf
+++ b/v2/internal/attacktechniques/azure/execution/vm-run-command/main.tf
@@ -19,11 +19,6 @@ locals {
 # Random
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 
-resource "random_string" "lab_name" {
-  length  = 4
-  special = false
-  upper   = false
-}
 
 resource "random_password" "password" {
   length           = 64
@@ -36,7 +31,7 @@ resource "random_password" "password" {
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 
 resource "azurerm_resource_group" "lab_environment" {
-  name     = "${local.resource_prefix}-rg-${random_string.lab_name.result}"
+  name     = "${local.resource_prefix}-rg-${var.correlation.short}"
   location = "West US"
 }
 
@@ -45,26 +40,26 @@ resource "azurerm_resource_group" "lab_environment" {
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 
 resource "azurerm_virtual_network" "lab_vnet" {
-  name                = "${local.resource_prefix}-vnet-${random_string.lab_name.result}"
+  name                = "${local.resource_prefix}-vnet-${var.correlation.short}"
   address_space       = ["10.0.0.0/16"]
   location            = azurerm_resource_group.lab_environment.location
   resource_group_name = azurerm_resource_group.lab_environment.name
 }
 
 resource "azurerm_subnet" "lab_subnet" {
-  name                 = "${local.resource_prefix}-subnet-${random_string.lab_name.result}"
+  name                 = "${local.resource_prefix}-subnet-${var.correlation.short}"
   resource_group_name  = azurerm_resource_group.lab_environment.name
   virtual_network_name = azurerm_virtual_network.lab_vnet.name
   address_prefixes     = ["10.0.2.0/24"]
 }
 
 resource "azurerm_network_interface" "lab_nic" {
-  name                = "${local.resource_prefix}-nic-${random_string.lab_name.result}"
+  name                = "${local.resource_prefix}-nic-${var.correlation.short}"
   location            = azurerm_resource_group.lab_environment.location
   resource_group_name = azurerm_resource_group.lab_environment.name
 
   ip_configuration {
-    name                          = "${local.resource_prefix}-ip-${random_string.lab_name.result}"
+    name                          = "${local.resource_prefix}-ip-${var.correlation.short}"
     subnet_id                     = azurerm_subnet.lab_subnet.id
     private_ip_address_allocation = "Dynamic"
   }
@@ -81,7 +76,7 @@ resource "azurerm_windows_virtual_machine" "lab_windows_vm" {
   size                = "Standard_F2"
   admin_username      = "local_admin_user"
   admin_password      = random_password.password.result
-  user_data           = base64encode(random_string.lab_name.result)
+  user_data           = base64encode(var.correlation.short)
 
   network_interface_ids = [
     azurerm_network_interface.lab_nic.id,

--- a/v2/internal/attacktechniques/azure/exfiltration/disk-export/main.tf
+++ b/v2/internal/attacktechniques/azure/exfiltration/disk-export/main.tf
@@ -11,14 +11,9 @@ provider "azurerm" {
   features {}
 }
 
-resource "random_string" "suffix" {
-  length  = 4
-  special = false
-  upper   = false
-}
 
 resource "azurerm_resource_group" "rg" {
-  name     = "stratus-red-team-disk-export-rg-${random_string.suffix.result}"
+  name     = "stratus-red-team-disk-export-rg-${var.correlation.short}"
   location = "West US"
 }
 

--- a/v2/internal/attacktechniques/azure/exfiltration/storage-public-access/main.tf
+++ b/v2/internal/attacktechniques/azure/exfiltration/storage-public-access/main.tf
@@ -11,21 +11,16 @@ provider "azurerm" {
   features {}
 }
 
-resource "random_string" "suffix" {
-  length  = 4
-  special = false
-  upper   = false
-}
 
 locals {
   resource_prefix = "stratus-red-team-storage"
   # Storage account names must be between 3 and 24 characters in length and use numbers and lower-case letters only
-  storage_account_name = "stratusredteam${random_string.suffix.result}"
+  storage_account_name = "stratusredteam${var.correlation.short}"
   container_name       = "private-data"
 }
 
 resource "azurerm_resource_group" "rg" {
-  name     = "${local.resource_prefix}-storage-${random_string.suffix.result}"
+  name     = "${local.resource_prefix}-storage-${var.correlation.short}"
   location = "West US"
 }
 

--- a/v2/internal/attacktechniques/azure/exfiltration/storage-sas-export/main.tf
+++ b/v2/internal/attacktechniques/azure/exfiltration/storage-sas-export/main.tf
@@ -11,21 +11,16 @@ provider "azurerm" {
   features {}
 }
 
-resource "random_string" "suffix" {
-  length  = 4
-  special = false
-  upper   = false
-}
 
 locals {
   resource_prefix = "stratus-red-team-storage"
   # Storage account names must be between 3 and 24 characters in length and use numbers and lower-case letters only
-  storage_account_name = "stratusredteam${random_string.suffix.result}"
+  storage_account_name = "stratusredteam${var.correlation.short}"
   container_name       = "private-data"
 }
 
 resource "azurerm_resource_group" "rg" {
-  name     = "${local.resource_prefix}-storage-${random_string.suffix.result}"
+  name     = "${local.resource_prefix}-storage-${var.correlation.short}"
   location = "West US"
 }
 

--- a/v2/internal/attacktechniques/azure/impact/blob-ransomware-client-encryption-scope/main.tf
+++ b/v2/internal/attacktechniques/azure/impact/blob-ransomware-client-encryption-scope/main.tf
@@ -11,27 +11,17 @@ provider "azurerm" {
   features {}
 }
 
-resource "random_string" "suffix" {
-  length  = 6
-  special = false
-  upper   = false
-}
 
-resource "random_string" "keyvault_suffix" {
-  length  = 8
-  special = false
-  upper   = false
-}
 
 locals {
   resource_prefix      = "stratusrt"
-  storage_account_name = "${local.resource_prefix}${random_string.suffix.result}"
-  key_vault_name       = "${local.resource_prefix}${random_string.keyvault_suffix.result}"
+  storage_account_name = "${local.resource_prefix}${var.correlation.short}"
+  key_vault_name       = "${local.resource_prefix}${var.correlation.short}"
   num_containers       = 5
 }
 
 resource "azurerm_resource_group" "rg" {
-  name     = "stratus-red-team-blob-encryption-rg-${random_string.suffix.result}"
+  name     = "stratus-red-team-blob-encryption-rg-${var.correlation.short}"
   location = "West US"
 }
 

--- a/v2/internal/attacktechniques/azure/impact/blob-ransomware-cpek/main.tf
+++ b/v2/internal/attacktechniques/azure/impact/blob-ransomware-cpek/main.tf
@@ -11,15 +11,10 @@ provider "azurerm" {
   features {}
 }
 
-resource "random_string" "suffix" {
-  length  = 6
-  special = false
-  upper   = false
-}
 
 locals {
   resource_prefix      = "stratusrt"
-  storage_account_name = "${local.resource_prefix}${random_string.suffix.result}"
+  storage_account_name = "${local.resource_prefix}${var.correlation.short}"
   num_files            = 51
   num_containers       = 5
   min_size_bytes       = 1
@@ -331,7 +326,7 @@ EOW
 }
 
 resource "azurerm_resource_group" "rg" {
-  name     = "stratus-red-team-blob-cpek-rg-${random_string.suffix.result}"
+  name     = "stratus-red-team-blob-cpek-rg-${var.correlation.short}"
   location = "West US"
 }
 

--- a/v2/internal/attacktechniques/azure/impact/blob-ransomware-individual-file-deletion/main.tf
+++ b/v2/internal/attacktechniques/azure/impact/blob-ransomware-individual-file-deletion/main.tf
@@ -11,15 +11,10 @@ provider "azurerm" {
   features {}
 }
 
-resource "random_string" "suffix" {
-  length  = 6
-  special = false
-  upper   = false
-}
 
 locals {
   resource_prefix      = "stratusrt"
-  storage_account_name = "${local.resource_prefix}${random_string.suffix.result}"
+  storage_account_name = "${local.resource_prefix}${var.correlation.short}"
   num_files            = 51
   num_containers       = 5
   min_size_bytes       = 1
@@ -331,7 +326,7 @@ EOW
 }
 
 resource "azurerm_resource_group" "rg" {
-  name     = "stratus-red-team-storage-deletion-rg-${random_string.suffix.result}"
+  name     = "stratus-red-team-storage-deletion-rg-${var.correlation.short}"
   location = "West US"
 }
 

--- a/v2/internal/attacktechniques/azure/impact/blob-ransomware-service-storage-cmk/main.tf
+++ b/v2/internal/attacktechniques/azure/impact/blob-ransomware-service-storage-cmk/main.tf
@@ -11,27 +11,17 @@ provider "azurerm" {
   features {}
 }
 
-resource "random_string" "suffix" {
-  length  = 6
-  special = false
-  upper   = false
-}
 
-resource "random_string" "keyvault_suffix" {
-  length  = 8
-  special = false
-  upper   = false
-}
 
 locals {
   resource_prefix      = "stratusrt"
-  storage_account_name = "${local.resource_prefix}${random_string.suffix.result}"
-  key_vault_name       = "${local.resource_prefix}${random_string.keyvault_suffix.result}"
+  storage_account_name = "${local.resource_prefix}${var.correlation.short}"
+  key_vault_name       = "${local.resource_prefix}${var.correlation.short}"
   num_containers       = 5
 }
 
 resource "azurerm_resource_group" "rg" {
-  name     = "stratus-red-team-blob-cmk-rg-${random_string.suffix.result}"
+  name     = "stratus-red-team-blob-cmk-rg-${var.correlation.short}"
   location = "West US"
 }
 

--- a/v2/internal/attacktechniques/azure/impact/resource-lock/main.tf
+++ b/v2/internal/attacktechniques/azure/impact/resource-lock/main.tf
@@ -12,21 +12,16 @@ provider "azurerm" {
   storage_use_azuread = true
 }
 
-resource "random_string" "suffix" {
-  length  = 4
-  special = false
-  upper   = false
-}
 
 locals {
   resource_prefix = "stratus-red-team-lock"
   # Storage account names must be between 3 and 24 characters in length and use numbers and lower-case letters only
-  storage_account_name = "stratusredteam${random_string.suffix.result}"
+  storage_account_name = "stratusredteam${var.correlation.short}"
   container_name       = "private-data"
 }
 
 resource "azurerm_resource_group" "rg" {
-  name     = "${local.resource_prefix}-storage-${random_string.suffix.result}"
+  name     = "${local.resource_prefix}-storage-${var.correlation.short}"
   location = "West US"
 }
 
@@ -40,7 +35,7 @@ resource "azurerm_storage_account" "storage" {
 
 # Resource lock must be Resource Group level to prevent destruction race conditions
 resource "azurerm_management_lock" "rg_lock" {
-  name       = "stratus-storage-lock-${random_string.suffix.result}"
+  name       = "stratus-storage-lock-${var.correlation.short}"
   scope      = azurerm_resource_group.rg.id
   lock_level = "ReadOnly"
   notes      = "Stratus Storage resource lock"

--- a/v2/internal/attacktechniques/azure/persistence/backdoor-managed-identity-fic/main.tf
+++ b/v2/internal/attacktechniques/azure/persistence/backdoor-managed-identity-fic/main.tf
@@ -18,21 +18,16 @@ provider "azurerm" {
 data "azuread_client_config" "current" {}
 data "azurerm_subscription" "current" {}
 
-resource "random_string" "suffix" {
-  length  = 4
-  special = false
-  upper   = false
-}
 
 # Resource group for the OIDC storage account
 resource "azurerm_resource_group" "oidc" {
-  name     = "stratus-fic-mi-${random_string.suffix.result}"
+  name     = "stratus-fic-mi-${var.correlation.short}"
   location = "westus"
 }
 
 # Victim user-assigned managed identity
 resource "azurerm_user_assigned_identity" "victim" {
-  name                = "stratus-victim-mi-${random_string.suffix.result}"
+  name                = "stratus-victim-mi-${var.correlation.short}"
   resource_group_name = azurerm_resource_group.oidc.name
   location            = azurerm_resource_group.oidc.location
 }
@@ -49,7 +44,7 @@ resource "azuread_directory_role_assignment" "role" {
 
 # Storage account to host the malicious OIDC provider metadata
 resource "azurerm_storage_account" "oidc" {
-  name                            = "stratusficmi${random_string.suffix.result}"
+  name                            = "stratusficmi${var.correlation.short}"
   resource_group_name             = azurerm_resource_group.oidc.name
   location                        = azurerm_resource_group.oidc.location
   account_tier                    = "Standard"
@@ -86,7 +81,7 @@ output "blob_service_url" {
 }
 
 output "random_suffix" {
-  value = random_string.suffix.result
+  value = var.correlation.short
 }
 
 output "display" {

--- a/v2/internal/attacktechniques/azure/persistence/create-bastion-shareable-link/main.tf
+++ b/v2/internal/attacktechniques/azure/persistence/create-bastion-shareable-link/main.tf
@@ -22,11 +22,6 @@ data "azurerm_client_config" "current" {
 # Random
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 
-resource "random_string" "lab_name" {
-  length  = 4
-  special = false
-  upper   = false
-}
 
 resource "random_password" "password" {
   length           = 64
@@ -39,7 +34,7 @@ resource "random_password" "password" {
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 
 resource "azurerm_resource_group" "lab_environment" {
-  name     = "${local.resource_prefix}-rg-${random_string.lab_name.result}"
+  name     = "${local.resource_prefix}-rg-${var.correlation.short}"
   location = "West US"
 }
 
@@ -48,7 +43,7 @@ resource "azurerm_resource_group" "lab_environment" {
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 
 resource "azurerm_virtual_network" "lab_vnet" {
-  name                = "${local.resource_prefix}-vnet-${random_string.lab_name.result}"
+  name                = "${local.resource_prefix}-vnet-${var.correlation.short}"
   address_space       = ["10.0.0.0/24"]
   location            = azurerm_resource_group.lab_environment.location
   resource_group_name = azurerm_resource_group.lab_environment.name
@@ -63,14 +58,14 @@ resource "azurerm_subnet" "bastion_subnet" {
 }
 
 resource "azurerm_subnet" "lab_subnet" {
-  name                 = "${local.resource_prefix}-subnet-${random_string.lab_name.result}"
+  name                 = "${local.resource_prefix}-subnet-${var.correlation.short}"
   resource_group_name  = azurerm_resource_group.lab_environment.name
   virtual_network_name = azurerm_virtual_network.lab_vnet.name
   address_prefixes     = ["10.0.0.32/27"]
 }
 
 resource "azurerm_public_ip" "lab_pip" {
-  name                = "${local.resource_prefix}-pip-${random_string.lab_name.result}"
+  name                = "${local.resource_prefix}-pip-${var.correlation.short}"
   location            = azurerm_resource_group.lab_environment.location
   resource_group_name = azurerm_resource_group.lab_environment.name
   allocation_method   = "Static"
@@ -78,12 +73,12 @@ resource "azurerm_public_ip" "lab_pip" {
 }
 
 resource "azurerm_network_interface" "lab_nic" {
-  name                = "${local.resource_prefix}-nic-${random_string.lab_name.result}"
+  name                = "${local.resource_prefix}-nic-${var.correlation.short}"
   location            = azurerm_resource_group.lab_environment.location
   resource_group_name = azurerm_resource_group.lab_environment.name
 
   ip_configuration {
-    name                          = "${local.resource_prefix}-ip-${random_string.lab_name.result}"
+    name                          = "${local.resource_prefix}-ip-${var.correlation.short}"
     subnet_id                     = azurerm_subnet.lab_subnet.id
     private_ip_address_allocation = "Dynamic"
   }
@@ -99,7 +94,7 @@ resource "azurerm_windows_virtual_machine" "lab_windows_vm" {
   size                = "Standard_F2"
   admin_username      = "local_admin_user"
   admin_password      = random_password.password.result
-  user_data           = base64encode(random_string.lab_name.result)
+  user_data           = base64encode(var.correlation.short)
 
   network_interface_ids = [
     azurerm_network_interface.lab_nic.id,
@@ -124,7 +119,7 @@ resource "azurerm_windows_virtual_machine" "lab_windows_vm" {
 
 # Note: Creation/destruction of a Bastion can take 10 minutes each, see https://learn.microsoft.com/en-us/azure/bastion/tutorial-create-host-portal
 resource "azurerm_bastion_host" "bastion" {
-  name                = "${local.resource_prefix}-bastion-${random_string.lab_name.result}"
+  name                = "${local.resource_prefix}-bastion-${var.correlation.short}"
   location            = azurerm_resource_group.lab_environment.location
   resource_group_name = azurerm_resource_group.lab_environment.name
   # Required for shareable link feature
@@ -132,7 +127,7 @@ resource "azurerm_bastion_host" "bastion" {
   shareable_link_enabled = true
 
   ip_configuration {
-    name                 = "${local.resource_prefix}-ipconfig-${random_string.lab_name.result}"
+    name                 = "${local.resource_prefix}-ipconfig-${var.correlation.short}"
     subnet_id            = azurerm_subnet.bastion_subnet.id
     public_ip_address_id = azurerm_public_ip.lab_pip.id
   }

--- a/v2/internal/attacktechniques/azure/persistence/exfiltrate-foundry-key/main.tf
+++ b/v2/internal/attacktechniques/azure/persistence/exfiltrate-foundry-key/main.tf
@@ -12,25 +12,20 @@ provider "azurerm" {
 
 }
 
-resource "random_string" "suffix" {
-  length  = 6
-  special = false
-  upper   = false
-}
 
 resource "azurerm_resource_group" "rg" {
-  name     = "stratus-red-team-foundry-rg-${random_string.suffix.result}"
+  name     = "stratus-red-team-foundry-rg-${var.correlation.short}"
   location = "West US"
 }
 
 resource "azurerm_cognitive_account" "foundry" {
-  name                  = "stratus-rt-${random_string.suffix.result}"
+  name                  = "stratus-rt-${var.correlation.short}"
   location              = azurerm_resource_group.rg.location
   resource_group_name   = azurerm_resource_group.rg.name
   kind                  = "AIServices"
   sku_name              = "S0"
   local_auth_enabled    = false
-  custom_subdomain_name = "stratus-rt-${random_string.suffix.result}"
+  custom_subdomain_name = "stratus-rt-${var.correlation.short}"
 }
 
 output "cognitive_account_name" {

--- a/v2/internal/attacktechniques/eks/lateral-movement/create-access-entry/main.tf
+++ b/v2/internal/attacktechniques/eks/lateral-movement/create-access-entry/main.tf
@@ -13,7 +13,7 @@ provider "aws" {
 }
 
 locals {
-  resource_prefix = "stratus-red-team-eks-create-access-entry"
+  resource_prefix = "stratus-red-team-eks-cae-${var.correlation.short}"
 }
 
 data "aws_caller_identity" "current" {}

--- a/v2/internal/attacktechniques/eks/persistence/backdoor-aws-auth-configmap/main.tf
+++ b/v2/internal/attacktechniques/eks/persistence/backdoor-aws-auth-configmap/main.tf
@@ -13,7 +13,7 @@ provider "aws" {
 }
 
 locals {
-  resource_prefix = "stratus-red-team-eks-backdoor-aws-auth"
+  resource_prefix = "stratus-red-team-eks-baa-${var.correlation.short}"
 }
 
 data "aws_caller_identity" "current" {}

--- a/v2/internal/attacktechniques/entra-id/persistence/backdoor-application-fic/main.tf
+++ b/v2/internal/attacktechniques/entra-id/persistence/backdoor-application-fic/main.tf
@@ -18,14 +18,9 @@ provider "azurerm" {
 data "azuread_client_config" "current" {}
 data "azurerm_subscription" "current" {}
 
-resource "random_string" "suffix" {
-  length  = 4
-  special = false
-  upper   = false
-}
 
 resource "azuread_application" "app" {
-  display_name = "Stratus Red Team FIC application ${random_string.suffix.result}"
+  display_name = "Stratus Red Team FIC application ${var.correlation.short}"
 }
 
 resource "azuread_service_principal" "sp" {
@@ -44,13 +39,13 @@ resource "azuread_directory_role_assignment" "role" {
 
 # Resource group for the OIDC storage account
 resource "azurerm_resource_group" "oidc" {
-  name     = "stratus-fic-app-${random_string.suffix.result}"
+  name     = "stratus-fic-app-${var.correlation.short}"
   location = "westus"
 }
 
 # Storage account to host the malicious OIDC provider metadata
 resource "azurerm_storage_account" "oidc" {
-  name                            = "stratusficapp${random_string.suffix.result}"
+  name                            = "stratusficapp${var.correlation.short}"
   resource_group_name             = azurerm_resource_group.oidc.name
   location                        = azurerm_resource_group.oidc.location
   account_tier                    = "Standard"
@@ -87,7 +82,7 @@ output "blob_service_url" {
 }
 
 output "random_suffix" {
-  value = random_string.suffix.result
+  value = var.correlation.short
 }
 
 output "display" {

--- a/v2/internal/attacktechniques/entra-id/persistence/backdoor-application-sp/main.tf
+++ b/v2/internal/attacktechniques/entra-id/persistence/backdoor-application-sp/main.tf
@@ -7,14 +7,9 @@ terraform {
   }
 }
 
-resource "random_string" "suffix" {
-  length  = 4
-  special = false
-  upper   = false
-}
 
 resource "azuread_application" "app" {
-  display_name = "Stratus Red Team sample application ${random_string.suffix.result}"
+  display_name = "Stratus Red Team sample application ${var.correlation.short}"
 }
 
 resource "azuread_service_principal" "sp" {

--- a/v2/internal/attacktechniques/entra-id/persistence/backdoor-application/main.tf
+++ b/v2/internal/attacktechniques/entra-id/persistence/backdoor-application/main.tf
@@ -7,14 +7,9 @@ terraform {
   }
 }
 
-resource "random_string" "suffix" {
-  length  = 4
-  special = false
-  upper   = false
-}
 
 resource "azuread_application" "app" {
-  display_name = "Stratus Red Team sample application ${random_string.suffix.result}"
+  display_name = "Stratus Red Team sample application ${var.correlation.short}"
 }
 
 resource "azuread_service_principal" "sp" {

--- a/v2/internal/attacktechniques/entra-id/persistence/hidden-au/main.tf
+++ b/v2/internal/attacktechniques/entra-id/persistence/hidden-au/main.tf
@@ -19,11 +19,6 @@ locals {
   domain_name     = data.azuread_domains.default.domains.0.domain_name
 }
 
-resource "random_string" "suffix" {
-  length  = 4
-  special = false
-  upper   = false
-}
 
 resource "random_password" "password" {
   length           = 64
@@ -38,11 +33,11 @@ resource "random_password" "password" {
 resource "azuread_user" "target" {
   user_principal_name = format(
     "%s@%s",
-    "stratus-red-team-hidden-au-target-${random_string.suffix.result}",
+    "stratus-red-team-hidden-au-target-${var.correlation.short}",
     local.domain_name
   )
   password     = random_password.password.result
-  display_name = "Stratus Target User - ${random_string.suffix.result}"
+  display_name = "Stratus Target User - ${var.correlation.short}"
 }
 
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
@@ -80,7 +75,7 @@ output "paa_role_id" {
 }
 
 output "suffix" {
-  value = random_string.suffix.result
+  value = var.correlation.short
 }
 
 output "domain" {

--- a/v2/internal/attacktechniques/entra-id/persistence/restricted-au/main.tf
+++ b/v2/internal/attacktechniques/entra-id/persistence/restricted-au/main.tf
@@ -20,11 +20,6 @@ locals {
   domain_name = data.azuread_domains.default.domains.0.domain_name
 }
 
-resource "random_string" "suffix" {
-  length  = 4
-  special = false
-  upper   = false
-}
 
 resource "random_password" "password" {
   length           = 64
@@ -38,11 +33,11 @@ resource "random_password" "password" {
 resource "azuread_user" "backdoor" {
   user_principal_name = format(
     "%s@%s",
-    "stratus-red-team-restricted-au-backdoor-${random_string.suffix.result}",
+    "stratus-red-team-restricted-au-backdoor-${var.correlation.short}",
     local.domain_name
   )
   password     = random_password.password.result
-  display_name = "Stratus Backdoor User - ${random_string.suffix.result}"
+  display_name = "Stratus Backdoor User - ${var.correlation.short}"
 }
 
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
@@ -57,7 +52,7 @@ output "backdoor_user_name" {
 }
 
 output "suffix" {
-  value = random_string.suffix.result
+  value = var.correlation.short
 }
 
 output "display" {

--- a/v2/internal/attacktechniques/gcp/credential-access/secretmanager-retrieve-secrets/main.tf
+++ b/v2/internal/attacktechniques/gcp/credential-access/secretmanager-retrieve-secrets/main.tf
@@ -25,7 +25,7 @@ resource "random_string" "secrets" {
 
 resource "google_secret_manager_secret" "secrets" {
   count     = local.num_secrets
-  secret_id = "${local.resource_prefix}-${count.index}"
+  secret_id = "${local.resource_prefix}-${count.index}-${var.correlation.short}"
   replication {
     auto {}
   }

--- a/v2/internal/attacktechniques/gcp/defense-evasion/delete-dns-logs/main.tf
+++ b/v2/internal/attacktechniques/gcp/defense-evasion/delete-dns-logs/main.tf
@@ -15,14 +15,9 @@ locals {
   resource_prefix = "stratus-red-team-ddl" # stratus red team delete dns logs
 }
 
-resource "random_string" "suffix" {
-  length    = 8
-  special   = false
-  min_lower = 8
-}
 
 resource "google_dns_policy" "logging_policy" {
-  name           = "${local.resource_prefix}-policy-${random_string.suffix.result}"
+  name           = "${local.resource_prefix}-policy-${var.correlation.short}"
   enable_logging = true
 
   networks {
@@ -31,7 +26,7 @@ resource "google_dns_policy" "logging_policy" {
 }
 
 resource "google_compute_network" "vpc" {
-  name                    = "${local.resource_prefix}-vpc-${random_string.suffix.result}"
+  name                    = "${local.resource_prefix}-vpc-${var.correlation.short}"
   auto_create_subnetworks = false
 }
 

--- a/v2/internal/attacktechniques/gcp/defense-evasion/delete-logging-sink/main.tf
+++ b/v2/internal/attacktechniques/gcp/defense-evasion/delete-logging-sink/main.tf
@@ -15,20 +15,15 @@ locals {
   resource_prefix = "stratus-red-team-dls" # stratus red team delete logging sink
 }
 
-resource "random_string" "suffix" {
-  length    = 8
-  special   = false
-  min_lower = 8
-}
 
 resource "google_storage_bucket" "log_bucket" {
-  name          = "${local.resource_prefix}-bucket-${random_string.suffix.result}"
+  name          = "${local.resource_prefix}-bucket-${var.correlation.short}"
   location      = "US"
   force_destroy = true
 }
 
 resource "google_logging_project_sink" "audit_sink" {
-  name        = "${local.resource_prefix}-sink-${random_string.suffix.result}"
+  name        = "${local.resource_prefix}-sink-${var.correlation.short}"
   destination = "storage.googleapis.com/${google_storage_bucket.log_bucket.name}"
   filter      = "logName:\"cloudaudit.googleapis.com\""
 

--- a/v2/internal/attacktechniques/gcp/defense-evasion/disable-logging-sink/main.tf
+++ b/v2/internal/attacktechniques/gcp/defense-evasion/disable-logging-sink/main.tf
@@ -15,20 +15,15 @@ locals {
   resource_prefix = "stratus-red-team-dls2" # stratus red team disable logging sink
 }
 
-resource "random_string" "suffix" {
-  length    = 8
-  special   = false
-  min_lower = 8
-}
 
 resource "google_storage_bucket" "log_bucket" {
-  name          = "${local.resource_prefix}-bucket-${random_string.suffix.result}"
+  name          = "${local.resource_prefix}-bucket-${var.correlation.short}"
   location      = "US"
   force_destroy = true
 }
 
 resource "google_logging_project_sink" "audit_sink" {
-  name        = "${local.resource_prefix}-sink-${random_string.suffix.result}"
+  name        = "${local.resource_prefix}-sink-${var.correlation.short}"
   destination = "storage.googleapis.com/${google_storage_bucket.log_bucket.name}"
   filter      = "logName:\"cloudaudit.googleapis.com\""
 

--- a/v2/internal/attacktechniques/gcp/defense-evasion/reduce-sink-log-retention/main.tf
+++ b/v2/internal/attacktechniques/gcp/defense-evasion/reduce-sink-log-retention/main.tf
@@ -15,20 +15,15 @@ locals {
   resource_prefix = "stratus-red-team-rslr" # stratus red team reduce sink log retention
 }
 
-resource "random_string" "suffix" {
-  length    = 8
-  special   = false
-  min_lower = 8
-}
 
 resource "google_storage_bucket" "log_bucket" {
-  name          = "${local.resource_prefix}-bucket-${random_string.suffix.result}"
+  name          = "${local.resource_prefix}-bucket-${var.correlation.short}"
   location      = "US"
   force_destroy = true
 }
 
 resource "google_logging_project_sink" "audit_sink" {
-  name        = "${local.resource_prefix}-sink-${random_string.suffix.result}"
+  name        = "${local.resource_prefix}-sink-${var.correlation.short}"
   destination = "storage.googleapis.com/${google_storage_bucket.log_bucket.name}"
   filter      = "logName:\"cloudaudit.googleapis.com\""
 

--- a/v2/internal/attacktechniques/gcp/defense-evasion/remove-vpc-flow-logs/main.tf
+++ b/v2/internal/attacktechniques/gcp/defense-evasion/remove-vpc-flow-logs/main.tf
@@ -15,19 +15,14 @@ locals {
   resource_prefix = "stratus-red-team-rvfl" # stratus red team remove vpc flow logs
 }
 
-resource "random_string" "suffix" {
-  length    = 8
-  special   = false
-  min_lower = 8
-}
 
 resource "google_compute_network" "vpc" {
-  name                    = "${local.resource_prefix}-vpc-${random_string.suffix.result}"
+  name                    = "${local.resource_prefix}-vpc-${var.correlation.short}"
   auto_create_subnetworks = false
 }
 
 resource "google_compute_subnetwork" "subnet" {
-  name          = "${local.resource_prefix}-subnet-${random_string.suffix.result}"
+  name          = "${local.resource_prefix}-subnet-${var.correlation.short}"
   ip_cidr_range = "10.10.0.0/24"
   region        = "us-central1"
   network       = google_compute_network.vpc.id

--- a/v2/internal/attacktechniques/gcp/discovery/download-instance-metadata/main.tf
+++ b/v2/internal/attacktechniques/gcp/discovery/download-instance-metadata/main.tf
@@ -16,19 +16,14 @@ locals {
   zone            = "us-central1-a"
 }
 
-resource "random_string" "suffix" {
-  length    = 8
-  special   = false
-  min_lower = 8
-}
 
 resource "google_compute_network" "vpc" {
-  name                    = "${local.resource_prefix}-vpc-${random_string.suffix.result}"
+  name                    = "${local.resource_prefix}-vpc-${var.correlation.short}"
   auto_create_subnetworks = true
 }
 
 resource "google_compute_instance" "instance" {
-  name         = "${local.resource_prefix}-${random_string.suffix.result}"
+  name         = "${local.resource_prefix}-${var.correlation.short}"
   machine_type = "e2-micro"
   zone         = local.zone
 

--- a/v2/internal/attacktechniques/gcp/discovery/enumerate-permissions/main.tf
+++ b/v2/internal/attacktechniques/gcp/discovery/enumerate-permissions/main.tf
@@ -14,11 +14,11 @@ provider "google" {
 }
 
 locals {
-  resource_prefix = "stratus-red-team-ep" # stratus red team enumerate permissions
+  resource_prefix = "srt-ep" # stratus red team enumerate permissions
 }
 
 resource "google_service_account" "sa" {
-  account_id   = "${local.resource_prefix}-sa"
+  account_id   = "${local.resource_prefix}-sa-${var.correlation.short}"
   display_name = "Stratus Red Team - Permission Enumeration"
   description  = "Service account used by Stratus Red Team for gcp.discovery.enumerate-permissions"
 }

--- a/v2/internal/attacktechniques/gcp/execution/modify-vertex-notebook-startup/main.tf
+++ b/v2/internal/attacktechniques/gcp/execution/modify-vertex-notebook-startup/main.tf
@@ -15,19 +15,14 @@ locals {
   resource_prefix = "stratus-red-team-mvns" # modify vertex notebook startup
 }
 
-resource "random_string" "suffix" {
-  length    = 8
-  special   = false
-  min_lower = 8
-}
 
 resource "google_compute_network" "vpc" {
-  name                    = "${local.resource_prefix}-vpc-${random_string.suffix.result}"
+  name                    = "${local.resource_prefix}-vpc-${var.correlation.short}"
   auto_create_subnetworks = true
 }
 
 resource "google_workbench_instance" "notebook" {
-  name     = "${local.resource_prefix}-${random_string.suffix.result}"
+  name     = "${local.resource_prefix}-${var.correlation.short}"
   location = "us-central1-a"
 
   gce_setup {

--- a/v2/internal/attacktechniques/gcp/exfiltration/share-compute-disk/main.tf
+++ b/v2/internal/attacktechniques/gcp/exfiltration/share-compute-disk/main.tf
@@ -8,7 +8,7 @@ terraform {
 }
 
 locals {
-  disk-name = "stratus-red-team-victim-disk"
+  disk-name = "stratus-red-team-victim-disk-${var.correlation.short}"
 }
 
 

--- a/v2/internal/attacktechniques/gcp/exfiltration/share-compute-image/main.tf
+++ b/v2/internal/attacktechniques/gcp/exfiltration/share-compute-image/main.tf
@@ -8,7 +8,7 @@ terraform {
 }
 
 locals {
-  image-name = "stratus-red-team-victim-image"
+  image-name = "stratus-red-team-victim-image-${var.correlation.short}"
 }
 
 resource "google_compute_image" "this" {

--- a/v2/internal/attacktechniques/gcp/exfiltration/share-compute-snapshot/main.tf
+++ b/v2/internal/attacktechniques/gcp/exfiltration/share-compute-snapshot/main.tf
@@ -8,8 +8,8 @@ terraform {
 }
 
 locals {
-  disk-name     = "stratus-red-team-victim-disk"
-  snapshot-name = "stratus-red-team-victim-snapshot"
+  disk-name     = "stratus-red-team-victim-disk-${var.correlation.short}"
+  snapshot-name = "stratus-red-team-victim-snapshot-${var.correlation.short}"
   zone          = "us-central1-a"
 }
 

--- a/v2/internal/attacktechniques/gcp/impact/create-gpu-vm/main.tf
+++ b/v2/internal/attacktechniques/gcp/impact/create-gpu-vm/main.tf
@@ -7,14 +7,9 @@ terraform {
   }
 }
 
-resource "random_string" "suffix" {
-  length  = 6
-  special = false
-  upper   = false
-}
 
 output "suffix" {
-  value = random_string.suffix.result
+  value = var.correlation.short
 }
 
 output "display" {

--- a/v2/internal/attacktechniques/gcp/impact/create-instances-in-multiple-zones/main.tf
+++ b/v2/internal/attacktechniques/gcp/impact/create-instances-in-multiple-zones/main.tf
@@ -7,14 +7,9 @@ terraform {
   }
 }
 
-resource "random_string" "suffix" {
-  length  = 6
-  special = false
-  upper   = false
-}
 
 output "suffix" {
-  value = random_string.suffix.result
+  value = var.correlation.short
 }
 
 output "display" {

--- a/v2/internal/attacktechniques/gcp/impact/gcs-ransomware-client-side-encryption/main.tf
+++ b/v2/internal/attacktechniques/gcp/impact/gcs-ransomware-client-side-encryption/main.tf
@@ -7,15 +7,10 @@ terraform {
   }
 }
 
-resource "random_string" "suffix" {
-  length  = 6
-  special = false
-  upper   = false
-}
 
 locals {
   resource_prefix = "stratus-red-team-ransomware-bucket"
-  bucket_name     = format("%s-%s", local.resource_prefix, random_string.suffix.result)
+  bucket_name     = format("%s-%s", local.resource_prefix, var.correlation.short)
   num_files       = 51
   min_size_bytes  = 1
   max_size_bytes  = 200

--- a/v2/internal/attacktechniques/gcp/impact/gcs-ransomware-individual-deletion/main.tf
+++ b/v2/internal/attacktechniques/gcp/impact/gcs-ransomware-individual-deletion/main.tf
@@ -7,15 +7,10 @@ terraform {
   }
 }
 
-resource "random_string" "suffix" {
-  length  = 6
-  special = false
-  upper   = false
-}
 
 locals {
   resource_prefix = "stratus-red-team-ransomware-bucket"
-  bucket_name     = format("%s-%s", local.resource_prefix, random_string.suffix.result)
+  bucket_name     = format("%s-%s", local.resource_prefix, var.correlation.short)
   num_files       = 51
   min_size_bytes  = 1
   max_size_bytes  = 200

--- a/v2/internal/attacktechniques/gcp/initial-access/use-compute-sa-outside-gcp/main.tf
+++ b/v2/internal/attacktechniques/gcp/initial-access/use-compute-sa-outside-gcp/main.tf
@@ -9,14 +9,9 @@ terraform {
 
 data "google_compute_default_service_account" "default" {}
 
-resource "random_string" "suffix" {
-  length  = 6
-  special = false
-  upper   = false
-}
 
 resource "google_compute_instance" "target" {
-  name         = "stratus-red-team-csa-${random_string.suffix.result}"
+  name         = "stratus-red-team-csa-${var.correlation.short}"
   machine_type = "e2-micro"
   zone         = "us-east1-b"
 

--- a/v2/internal/attacktechniques/gcp/lateral-movement/add-sshkey-instance-metadata/main.tf
+++ b/v2/internal/attacktechniques/gcp/lateral-movement/add-sshkey-instance-metadata/main.tf
@@ -20,31 +20,26 @@ locals {
   image           = "debian-cloud/debian-11"
 }
 
-resource "random_string" "suffix" {
-  special   = false
-  length    = 16
-  min_lower = 16
-}
 
 data "google_compute_zones" "available" {
   region = local.region
 }
 
 resource "google_compute_network" "network" {
-  name                    = "${local.resource_prefix}-vpc-${random_string.suffix.result}"
+  name                    = "${local.resource_prefix}-vpc-${var.correlation.short}"
   routing_mode            = "REGIONAL"
   auto_create_subnetworks = false
 }
 
 resource "google_compute_subnetwork" "subnet" {
-  name          = "${local.resource_prefix}-subnet-${random_string.suffix.result}"
+  name          = "${local.resource_prefix}-subnet-${var.correlation.short}"
   ip_cidr_range = "10.10.1.0/24"
   network       = google_compute_network.network.id
   region        = local.region
 }
 
 resource "google_compute_firewall" "firewall" {
-  name    = "${local.resource_prefix}-firewall-${random_string.suffix.result}"
+  name    = "${local.resource_prefix}-firewall-${var.correlation.short}"
   network = google_compute_network.network.id
   allow {
     protocol = "tcp"
@@ -55,10 +50,10 @@ resource "google_compute_firewall" "firewall" {
 }
 
 resource "google_compute_instance" "target" {
-  name         = "${local.resource_prefix}-vm-${random_string.suffix.result}"
+  name         = "${local.resource_prefix}-vm-${var.correlation.short}"
   machine_type = local.instance_type
   zone         = data.google_compute_zones.available.names[0]
-  hostname     = "target-${random_string.suffix.result}.stratus.local"
+  hostname     = "target-${var.correlation.short}.stratus.local"
   tags         = ["ssh-access"]
 
   boot_disk {

--- a/v2/internal/attacktechniques/gcp/persistence/backdoor-service-account-policy/main.tf
+++ b/v2/internal/attacktechniques/gcp/persistence/backdoor-service-account-policy/main.tf
@@ -10,11 +10,11 @@ terraform {
 data "google_project" "current" {}
 
 locals {
-  resource_prefix = "stratus-red-team-bip" # stratus red team backdoor iam policy
+  resource_prefix = "srt-bip" # stratus red team backdoor iam policy
 }
 
 resource "google_service_account" "service_account" {
-  account_id = format("%s-sa", local.resource_prefix)
+  account_id = format("%s-sa-%s", local.resource_prefix, var.correlation.short)
 }
 
 resource "google_project_iam_member" "binding" {

--- a/v2/internal/attacktechniques/gcp/persistence/create-admin-service-account/main.tf
+++ b/v2/internal/attacktechniques/gcp/persistence/create-admin-service-account/main.tf
@@ -8,15 +8,10 @@ terraform {
 }
 
 locals {
-  resource_prefix = "stratus-red-team-casa" # stratus red team create admin service account
+  resource_prefix = "srt-casa" # stratus red team create admin service account
 }
 
-resource "random_string" "suffix" {
-  length    = 4
-  special   = false
-  min_lower = 4
-}
 
 output "service_account_name" {
-  value = format("%s-sa-%s", local.resource_prefix, random_string.suffix.result)
+  value = format("%s-sa-%s", local.resource_prefix, var.correlation.short)
 }

--- a/v2/internal/attacktechniques/gcp/persistence/create-service-account-key/main.tf
+++ b/v2/internal/attacktechniques/gcp/persistence/create-service-account-key/main.tf
@@ -8,11 +8,11 @@ terraform {
 }
 
 locals {
-  resource_prefix = "stratus-red-team-csak" # stratus red team create service account key
+  resource_prefix = "srt-csak" # stratus red team create service account key
 }
 
 resource "google_service_account" "service_account" {
-  account_id = format("%s-sa", local.resource_prefix)
+  account_id = format("%s-sa-%s", local.resource_prefix, var.correlation.short)
 }
 
 output "sa_email" {

--- a/v2/internal/attacktechniques/gcp/privilege-escalation/impersonate-service-accounts/main.tf
+++ b/v2/internal/attacktechniques/gcp/privilege-escalation/impersonate-service-accounts/main.tf
@@ -18,7 +18,7 @@ locals {
 // Create N service accounts
 resource "google_service_account" "service_account" {
   count       = local.num-service-accounts
-  account_id  = format("%s-sa-%s", local.resource_prefix, var.correlation.short)
+  account_id  = format("%s-sa-%s-%d", local.resource_prefix, var.correlation.short, count.index)
   description = "Service account used by Stratus Red Team for gcp.privilege-escalation.impersonate-service-accounts"
 }
 

--- a/v2/internal/attacktechniques/gcp/privilege-escalation/impersonate-service-accounts/main.tf
+++ b/v2/internal/attacktechniques/gcp/privilege-escalation/impersonate-service-accounts/main.tf
@@ -11,20 +11,14 @@ data "google_client_openid_userinfo" "whoami" {}
 
 locals {
   num-service-accounts = 10
-  resource_prefix      = "stratus-red-team-isa" # stratus red team impersonate service accounts
+  resource_prefix      = "srt-isa" # stratus red team impersonate service accounts
 }
 
-resource "random_string" "suffix" {
-  count     = local.num-service-accounts
-  length    = 4
-  special   = false
-  min_lower = 4
-}
 
 // Create N service accounts
 resource "google_service_account" "service_account" {
   count       = local.num-service-accounts
-  account_id  = format("%s-sa-%s", local.resource_prefix, random_string.suffix[count.index].result)
+  account_id  = format("%s-sa-%s", local.resource_prefix, var.correlation.short)
   description = "Service account used by Stratus Red Team for gcp.privilege-escalation.impersonate-service-accounts"
 }
 

--- a/v2/internal/attacktechniques/k8s/credential-access/steal-serviceaccount-token/main.tf
+++ b/v2/internal/attacktechniques/k8s/credential-access/steal-serviceaccount-token/main.tf
@@ -19,12 +19,12 @@ locals {
   labels        = merge(local.base_labels, local.custom_labels)
 
   create_namespace  = var.config.kubernetes.namespace == ""
-  generated_ns_name = format("stratus-red-team-%s", random_string.suffix.result)
+  generated_ns_name = format("stratus-red-team-%s", var.correlation.short)
   namespace         = local.create_namespace ? local.generated_ns_name : var.config.kubernetes.namespace
 
   image = var.config.kubernetes.pod.image != "" ? var.config.kubernetes.pod.image : "public.ecr.aws/docker/library/alpine:3.15.0"
 
-  resource_prefix = "stratus-red-team-ssat" # stratus red team steal service account token
+  resource_prefix = "stratus-red-team-ssat-${var.correlation.short}" # stratus red team steal service account token
 }
 
 # Use ~/.kube/config as a configuration file if it exists (with current context).
@@ -32,11 +32,6 @@ locals {
 # see https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs#authentication
 provider "kubernetes" {
   config_path = fileexists(local.kubeconfig_path) ? local.kubeconfig_path : null
-}
-
-resource "random_string" "suffix" {
-  length    = 8
-  min_lower = 8
 }
 
 resource "kubernetes_namespace" "namespace" {

--- a/v2/internal/attacktechniques/k8s/privilege-escalation/hostpath-volume/main.go
+++ b/v2/internal/attacktechniques/k8s/privilege-escalation/hostpath-volume/main.go
@@ -52,7 +52,7 @@ func detonate(params map[string]string, providers stratus.CloudProviders) error 
 	client := providers.K8s().GetClient()
 	namespace := params["namespace"]
 	correlationID := providers.K8s().UniqueCorrelationId.String()
-	podSpec := basePodSpec(namespace, correlationID)
+	podSpec := basePodSpec(namespace, correlationID, params["warmup_short_id"])
 
 	// Apply configuration overrides (image, tolerations, nodeSelector, securityContext)
 	providers.K8s().ApplyPodConfig(techniqueID, podSpec)
@@ -71,7 +71,7 @@ func revert(params map[string]string, providers stratus.CloudProviders) error {
 	client := providers.K8s().GetClient()
 	namespace := params["namespace"]
 	correlationID := providers.K8s().UniqueCorrelationId.String()
-	podSpec := basePodSpec(namespace, correlationID)
+	podSpec := basePodSpec(namespace, correlationID, params["warmup_short_id"])
 
 	log.Println("Removing malicious pod " + podSpec.ObjectMeta.Name)
 	deleteOptions := metav1.DeleteOptions{GracePeriodSeconds: ptr.Int64(0)}
@@ -83,10 +83,14 @@ func revert(params map[string]string, providers stratus.CloudProviders) error {
 	return nil
 }
 
-func basePodSpec(namespace string, correlationID string) *v1.Pod {
+func basePodSpec(namespace string, correlationID string, warmupShortID string) *v1.Pod {
+	podName := techniqueID
+	if warmupShortID != "" {
+		podName = techniqueID + "-" + warmupShortID
+	}
 	return &v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      techniqueID,
+			Name:      podName,
 			Namespace: namespace,
 			Labels: map[string]string{
 				"datadoghq.com/stratus-red-team":                "true",

--- a/v2/internal/attacktechniques/k8s/privilege-escalation/hostpath-volume/main.tf
+++ b/v2/internal/attacktechniques/k8s/privilege-escalation/hostpath-volume/main.tf
@@ -10,7 +10,7 @@ terraform {
 locals {
   kubeconfig_path   = pathexpand("~/.kube/config")
   create_namespace  = var.config.kubernetes.namespace == ""
-  generated_ns_name = format("stratus-red-team-hpns-%s", random_string.suffix.result)
+  generated_ns_name = format("stratus-red-team-hpns-%s", var.correlation.short)
   namespace         = local.create_namespace ? local.generated_ns_name : var.config.kubernetes.namespace
 }
 
@@ -19,11 +19,6 @@ locals {
 # see https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs#authentication
 provider "kubernetes" {
   config_path = fileexists(local.kubeconfig_path) ? local.kubeconfig_path : null
-}
-
-resource "random_string" "suffix" {
-  length    = 4
-  min_lower = 4
 }
 
 resource "kubernetes_namespace" "namespace" {
@@ -40,6 +35,10 @@ resource "kubernetes_namespace" "namespace" {
 
 output "namespace" {
   value = local.namespace
+}
+
+output "warmup_short_id" {
+  value = var.correlation.short
 }
 
 output "display" {

--- a/v2/internal/attacktechniques/k8s/privilege-escalation/nodes-proxy/main.tf
+++ b/v2/internal/attacktechniques/k8s/privilege-escalation/nodes-proxy/main.tf
@@ -10,9 +10,9 @@ terraform {
 locals {
   kubeconfig_path   = pathexpand("~/.kube/config")
   create_namespace  = var.config.kubernetes.namespace == ""
-  generated_ns_name = format("stratus-red-team-np-name-%s", random_string.suffix.result)
+  generated_ns_name = format("stratus-red-team-np-name-%s", var.correlation.short)
   namespace         = local.create_namespace ? local.generated_ns_name : var.config.kubernetes.namespace
-  resource_prefix   = "stratus-red-team-np"
+  resource_prefix   = "stratus-red-team-np-${var.correlation.short}"
 }
 
 # Use ~/.kube/config as a configuration file if it exists (with current context).
@@ -20,11 +20,6 @@ locals {
 # see https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs#authentication
 provider "kubernetes" {
   config_path = fileexists(local.kubeconfig_path) ? local.kubeconfig_path : null
-}
-
-resource "random_string" "suffix" {
-  length    = 8
-  min_lower = 8
 }
 
 resource "kubernetes_namespace" "namespace" {

--- a/v2/internal/attacktechniques/k8s/privilege-escalation/privileged-pod/main.go
+++ b/v2/internal/attacktechniques/k8s/privilege-escalation/privileged-pod/main.go
@@ -91,7 +91,7 @@ func detonate(params map[string]string, providers stratus.CloudProviders) error 
 	client := providers.K8s().GetClient()
 	namespace := params["namespace"]
 	correlationID := providers.K8s().UniqueCorrelationId.String()
-	podSpec := basePodSpec(namespace, correlationID)
+	podSpec := basePodSpec(namespace, correlationID, params["warmup_short_id"])
 
 	// Apply configuration overrides (image, tolerations, nodeSelector, securityContext)
 	providers.K8s().ApplyPodConfig(techniqueID, podSpec)
@@ -112,7 +112,7 @@ func revert(params map[string]string, providers stratus.CloudProviders) error {
 	// be passed through terraform, otherwise it's the created namespace.
 	namespace := params["namespace"]
 	correlationID := providers.K8s().UniqueCorrelationId.String()
-	podSpec := basePodSpec(namespace, correlationID)
+	podSpec := basePodSpec(namespace, correlationID, params["warmup_short_id"])
 
 	log.Println("Removing privileged pod " + podSpec.ObjectMeta.Name)
 	deleteOptions := metav1.DeleteOptions{GracePeriodSeconds: ptr.Int64(0)}
@@ -124,10 +124,14 @@ func revert(params map[string]string, providers stratus.CloudProviders) error {
 	return nil
 }
 
-func basePodSpec(namespace string, correlationID string) *v1.Pod {
+func basePodSpec(namespace string, correlationID string, warmupShortID string) *v1.Pod {
+	podName := techniqueID
+	if warmupShortID != "" {
+		podName = techniqueID + "-" + warmupShortID
+	}
 	return &v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      techniqueID,
+			Name:      podName,
 			Namespace: namespace,
 			Labels: map[string]string{
 				"datadoghq.com/stratus-red-team":                "true",

--- a/v2/internal/attacktechniques/k8s/privilege-escalation/privileged-pod/main.tf
+++ b/v2/internal/attacktechniques/k8s/privilege-escalation/privileged-pod/main.tf
@@ -10,7 +10,7 @@ terraform {
 locals {
   kubeconfig_path   = pathexpand("~/.kube/config")
   create_namespace  = var.config.kubernetes.namespace == ""
-  generated_ns_name = format("stratus-red-team-privileged-name-%s", random_string.suffix.result)
+  generated_ns_name = format("stratus-red-team-privileged-name-%s", var.correlation.short)
   namespace         = local.create_namespace ? local.generated_ns_name : var.config.kubernetes.namespace
 }
 
@@ -19,11 +19,6 @@ locals {
 # see https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs#authentication
 provider "kubernetes" {
   config_path = fileexists(local.kubeconfig_path) ? local.kubeconfig_path : null
-}
-
-resource "random_string" "suffix" {
-  length    = 8
-  min_lower = 8
 }
 
 resource "kubernetes_namespace" "namespace" {
@@ -40,6 +35,10 @@ resource "kubernetes_namespace" "namespace" {
 
 output "namespace" {
   value = local.namespace
+}
+
+output "warmup_short_id" {
+  value = var.correlation.short
 }
 
 output "display" {

--- a/v2/pkg/stratus/config/config.schema.json
+++ b/v2/pkg/stratus/config/config.schema.json
@@ -25,7 +25,7 @@
             "type": "object",
             "additionalProperties": false,
             "properties": {
-                "prefix": { "type": "string" },
+                "prefix": { "type": "string", "maxLength": 17 },
                 "tags": {
                     "type": "object",
                     "additionalProperties": { "type": "string" }

--- a/v2/pkg/stratus/config/validate_test.go
+++ b/v2/pkg/stratus/config/validate_test.go
@@ -62,7 +62,7 @@ kubernetes:
 			yaml: `
 aws:
   default:
-    prefix: "team-<% .CorrelationID %>-"
+    prefix: "security-testing-"
     tags:
       Environment: test
       ExecutionID: "<% .CorrelationID %>"
@@ -159,6 +159,24 @@ kubernetes:
     "k8s.tactic.procedure":
       pod:
         img: wrong-key
+`,
+			wantError: true,
+		},
+		{
+			name: "aws-prefix-at-max-length",
+			yaml: `
+aws:
+  default:
+    prefix: "security-testing-"
+`,
+			wantError: false,
+		},
+		{
+			name: "aws-prefix-over-max-length",
+			yaml: `
+aws:
+  default:
+    prefix: "security-testing-extra"
 `,
 			wantError: true,
 		},


### PR DESCRIPTION
### What does this PR do?

<!--
* New attack technique
* Bug fix
* Enhancement
-->

Enhancement: Add the short correlation ID introduced in #931 to the names/identifier of the resources created by terraform at warmup, allowing for concurrent execution in the same environments

Modified the agents.md to reflect the changes.

Also made the AWS prefix max length 17: reduced existing techniques names as much as possible to fit both the correlation id (8 chars) and prefix.
17 allows fort the 16 chars + a separation char (`-`), so the example of `security-testing-` fits just fine

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

Allow multiple users to work in the same environment without interfering with each other

### Checklist

<!--
For new attack techniques
-->

All terraform-based techniques were tested by running each twice concurrently with different correlation IDs (warmup → detonate → cleanup). Results:
| Platform | Techniques | Both runs passed| Sandbox limitations                                                                                              | Notes |
|----------|------------------|-----------------|------------------------------------------------------------------------------------------------------------------|-------|
| K8s      | 4                | 3               | 1 blocked by cluster RBAC (cluster-scoped resource creation denied)                                              | |
| AWS      | 40               | 35              | 4 blocked by CloudTrail SCP (sandbox limitation), 1 blocked by S3 SSE-C account default (issue #946)             | Some failures in the tf init when running commands too fast, but mostly pass. Remaining failures not related to concurrency. |
| GCP      | 23               | 18              | 3 missing default VPC network, 1 removed source image, 1 provider bug                                            | Same |
| Azure    | 14               | 9               | 2 VM SKU unavailable, 1 missing Entra ID role, 2 Key Vault role requirement       | Same |
| EKS      | 2                | —               | Not tested                                                                                          | Validated via terraform validate  |
| Entra ID | 7                | —               | Not tested                                                                                          | Validated via terraform validate  |
 
 