### PR TITLE
fix(CI): Pin staticcheck to a version compatible with our go version

### DIFF
--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -44,5 +44,6 @@ jobs:
           go-version-file: v2/go.mod
       - uses: dominikh/staticcheck-action@9716614d4101e79b4340dd97b10e54d68234e431 # v1.4.1
         with:
+          version: v0.7.0 # Above, requires go 1.26
           install-go: false
           working-directory: "./v2"


### PR DESCRIPTION
### What does this PR do?

<!--
* New attack technique
* Bug fix
* Enhancement
-->

Bug fix: 
```
  go: downloading honnef.co/go/tools v0.8.1
  go: honnef.co/go/tools/cmd/staticcheck@latest: honnef.co/go/tools@v0.8.1 requires go >= 1.26.0 (running go 1.25.8; GOTOOLCHAIN=local)
  Error: Process completed with exit code 1.
```

Pin staticcheck to v0.7.0

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

Have a working CI
