### PR TITLE
Add Entra access package group-based privilege escalation technique

### DIFF
--- a/docs/attack-techniques/azure/azure.persistence.backdoor-managed-identity-fic.md
+++ b/docs/attack-techniques/azure/azure.persistence.backdoor-managed-identity-fic.md
@@ -57,7 +57,7 @@ Using [Azure Activity Logs](https://learn.microsoft.com/en-us/azure/azure-monito
 
 Sample Azure Activity Log event to monitor:
 
-```json hl_lines="2 10"
+```json hl_lines="3 11"
 {
     "operationName": {
         "value": "Microsoft.ManagedIdentity/userAssignedIdentities/federatedIdentityCredentials/write",

--- a/docs/attack-techniques/entra-id/entra-id.persistence.backdoor-application-fic.md
+++ b/docs/attack-techniques/entra-id/entra-id.persistence.backdoor-application-fic.md
@@ -58,7 +58,7 @@ Using [Entra ID audit logs](https://learn.microsoft.com/en-us/entra/identity/mon
 
 Sample Entra ID audit log event to monitor:
 
-```json hl_lines="3 15 22"
+```json hl_lines="4 16 23"
 {
   "category": "ApplicationManagement",
   "result": "success",

--- a/docs/attack-techniques/entra-id/entra-id.persistence.hidden-au.md
+++ b/docs/attack-techniques/entra-id/entra-id.persistence.hidden-au.md
@@ -38,6 +38,7 @@ The backdoor user can now perform privileged operations over any user in the adm
 References:
 
 - https://learn.microsoft.com/en-us/entra/identity/role-based-access-control/administrative-units
+- https://securitylabs.datadoghq.com/articles/abusing-entra-id-administrative-units/
 
 
 

--- a/docs/attack-techniques/entra-id/entra-id.persistence.restricted-au.md
+++ b/docs/attack-techniques/entra-id/entra-id.persistence.restricted-au.md
@@ -34,6 +34,7 @@ References:
 
 - https://learn.microsoft.com/en-us/entra/identity/role-based-access-control/administrative-units
 - https://learn.microsoft.com/en-us/entra/identity/role-based-access-control/admin-units-restricted-management
+- https://securitylabs.datadoghq.com/articles/abusing-entra-id-administrative-units/
 
 Note: When cleaning up the technique, you might have to wait a few minutes for the user status to update before retrying the cleanup. This is a limitation of Entra ID.
 

--- a/docs/attack-techniques/entra-id/entra-id.privilege-escalation.access-package-group.md
+++ b/docs/attack-techniques/entra-id/entra-id.privilege-escalation.access-package-group.md
@@ -1,0 +1,103 @@
+---
+title: Escalate to Entra ID role-assignable group using access package
+---
+
+# Escalate to Entra ID role-assignable group using access package
+
+
+ <span class="smallcaps w3-badge w3-blue w3-round w3-text-white" title="This attack technique can be detonated multiple times">idempotent</span> 
+
+Platform: Entra ID
+
+## Mappings
+
+- MITRE ATT&CK
+    - Privilege Escalation
+
+
+
+## Description
+
+
+Escalates a user to the Global Administrator Entra ID role using eligible group membership through an access package that does not require approvals.
+
+Roles allowing Entra ID administration are generally not available for assignment in access packages. However, role-assignable security groups allowing Entra ID administrative role assignment are still allowed.
+
+**Licensing:** This technique requires Entra ID Governance licensing.
+
+Requirements:
+Before running this technique, you will need to create an SP as a Global Administrator account and designate an account you will make the access request from:
+1. [Create an app registration and service principal](https://learn.microsoft.com/en-us/entra/identity-platform/quickstart-register-app) (SP)
+2. [Add the following](https://learn.microsoft.com/en-us/entra/identity-platform/howto-add-app-roles-in-apps#assign-app-roles-to-applications) Microsoft Graph application permissions to the app registration:
+- EntitlementManagement.ReadWrite.All
+- Group.ReadWrite.All
+- User.ReadWrite.All
+- RoleAssignmentSchedule.ReadWrite.Directory
+3. Select "Grant consent for [Directory Name]" to consent to all permissions
+4. [Add a secret](https://learn.microsoft.com/en-us/entra/identity-platform/how-to-add-credentials?tabs=client-secret) to the application
+5. Log the Azure CLI out of your current user account:
+<code>
+az logout
+</code>
+6. Copy the app registration's secret, client ID, and your tenant ID and sign in as the SP on the command line:
+<code>
+az login \
+  --service-principal \
+  --allow-no-subscriptions \
+  --username "$APP_ID" \
+  --password "$CLIENT_SECRET" \
+  --tenant "$TENANT_ID"
+</code>
+7. Configure the STRATUS_RED_TEAM_ATTACKER_ACCOUNT variable:
+<code>
+export STRATUS_RED_TEAM_ATTACKER_ACCOUNT="[USER@DOMAIN.ONMICROSOFT.COM]"
+</code>
+8. Delete the app registration once testing has completed
+
+Warmup:
+- Create a role-assignable security group
+- Assign the "Global Administrator" role to the group
+- Create an Entra ID catalog and access package with group membership assignment
+- Configure the access package policy to allow the configured user (<code>STRATUS_RED_TEAM_ATTACKER_ACCOUNT</code>) to request assignment and not require approval
+
+<span style="font-variant: small-caps;">Detonation</span>:
+- Provide the MyAccess Portal URL where the configured user can request the access package to demonstrate group membership assignment and escalation to Global Administrator
+
+References:
+- https://learn.microsoft.com/en-us/entra/id-governance/entitlement-management-overview
+- https://github.com/hashicorp/terraform-provider-azuread/issues/1069
+
+
+## Instructions
+
+```bash title="Detonate with Stratus Red Team"
+stratus detonate entra-id.privilege-escalation.access-package-group
+```
+## Detection
+
+
+Sample [Entra ID audit logs](https://learn.microsoft.com/en-us/entra/identity/monitoring-health/concept-audit-logs) to monitor:
+
+```json hl_lines="4 14"
+{
+  "category": "EntitlementManagement",
+  "result": "success",
+  "activityDisplayName": "User requests access package assignment",
+  "activityDateTime": "2026-08-27T13:36:36.512743Z",
+  "loggedByService": "Entitlement Management",
+  "operationType": "CreateEntitlementGrantUserAddRequest",
+  "targetResources": [REMOVED]
+}
+
+{
+  "category": "EntitlementManagement",
+  "result": "success",
+  "activityDisplayName": "Auto approve access package assignment request",
+  "activityDateTime": "2026-08-27T13:28:45.223011Z",
+  "loggedByService": "Entitlement Management",
+  "operationType": "AutoApproveEntitlementGrantRequest",
+  "targetResources": [REMOVED]
+}
+```
+
+

--- a/docs/attack-techniques/entra-id/entra-id.privilege-escalation.access-package-group.md
+++ b/docs/attack-techniques/entra-id/entra-id.privilege-escalation.access-package-group.md
@@ -32,7 +32,7 @@ Before running this technique, you will need to create an SP as a Global Adminis
 - EntitlementManagement.ReadWrite.All
 - Group.ReadWrite.All
 - User.ReadWrite.All
-- RoleAssignmentSchedule.ReadWrite.Directory
+- RoleManagement.ReadWrite.Directory
 3. Select "Grant consent for [Directory Name]" to consent to all permissions
 4. [Add a secret](https://learn.microsoft.com/en-us/entra/identity-platform/how-to-add-credentials?tabs=client-secret) to the application
 5. Log the Azure CLI out of your current user account:

--- a/docs/attack-techniques/entra-id/index.md
+++ b/docs/attack-techniques/entra-id/index.md
@@ -31,3 +31,5 @@ Note that some Stratus attack techniques may correspond to more than a single AT
   
   - [Create Application](./entra-id.persistence.new-application.md)
   
+  - [Escalate to Entra ID role-assignable group using access package](./entra-id.privilege-escalation.access-package-group.md)
+  

--- a/docs/attack-techniques/list.md
+++ b/docs/attack-techniques/list.md
@@ -77,6 +77,7 @@ This page contains the list of all Stratus Attack Techniques.
 | [Create Hidden Scoped Role Assignment Through HiddenMembership AU](./entra-id/entra-id.persistence.hidden-au.md) | [Entra ID](./entra-id/index.md) | Persistence |
 | [Create Application](./entra-id/entra-id.persistence.new-application.md) | [Entra ID](./entra-id/index.md) | Persistence, Privilege Escalation |
 | [Create Sticky Backdoor User Through Restricted Management AU](./entra-id/entra-id.persistence.restricted-au.md) | [Entra ID](./entra-id/index.md) | Persistence |
+| [Escalate to Entra ID role-assignable group using access package](./entra-id/entra-id.privilege-escalation.access-package-group.md) | [Entra ID](./entra-id/index.md) | Privilege Escalation |
 | [Delete a Cloud DNS Logging Policy](./GCP/gcp.defense-evasion.delete-dns-logs.md) | [GCP](./GCP/index.md) | Defense Evasion |
 | [Disable Data Access Audit Logs for a GCP Service](./GCP/gcp.defense-evasion.disable-audit-logs.md) | [GCP](./GCP/index.md) | Defense Evasion |
 | [Attempt to Remove a GCP Project from its Organization](./GCP/gcp.defense-evasion.remove-project-from-organization.md) | [GCP](./GCP/index.md) | Defense Evasion |

--- a/docs/attack-techniques/mitre-attack-coverage-matrices.md
+++ b/docs/attack-techniques/mitre-attack-coverage-matrices.md
@@ -86,7 +86,7 @@ This provides coverage matrices of MITRE ATT&CK tactics and techniques currently
 <tr><td><a href="../Entra ID/entra-id.persistence.backdoor-application-sp">Backdoor Entra ID application through service principal</a></td><td><a href="../Entra ID/entra-id.persistence.backdoor-application-sp">Backdoor Entra ID application through service principal</a></td></tr>
 <tr><td><a href="../Entra ID/entra-id.persistence.backdoor-application">Backdoor Entra ID application</a></td><td><a href="../Entra ID/entra-id.persistence.backdoor-application">Backdoor Entra ID application</a></td></tr>
 <tr><td><a href="../Entra ID/entra-id.persistence.guest-user">Create Guest User</a></td><td><a href="../Entra ID/entra-id.persistence.new-application">Create Application</a></td></tr>
-<tr><td><a href="../Entra ID/entra-id.persistence.hidden-au">Create Hidden Scoped Role Assignment Through HiddenMembership AU</a></td><td></td></tr>
+<tr><td><a href="../Entra ID/entra-id.persistence.hidden-au">Create Hidden Scoped Role Assignment Through HiddenMembership AU</a></td><td><a href="../Entra ID/entra-id.privilege-escalation.access-package-group">Escalate to Entra ID role-assignable group using access package</a></td></tr>
 <tr><td><a href="../Entra ID/entra-id.persistence.new-application">Create Application</a></td><td></td></tr>
 <tr><td><a href="../Entra ID/entra-id.persistence.restricted-au">Create Sticky Backdoor User Through Restricted Management AU</a></td><td></td></tr>
 </tbody>

--- a/docs/index.yaml
+++ b/docs/index.yaml
@@ -1003,6 +1003,13 @@ Entra ID:
             - Privilege Escalation
           platform: Entra ID
           isIdempotent: false
+        - id: entra-id.privilege-escalation.access-package-group
+          name: Escalate to Entra ID role-assignable group using access package
+          isSlow: false
+          mitreAttackTactics:
+            - Privilege Escalation
+          platform: Entra ID
+          isIdempotent: true
 Kubernetes:
     Credential Access:
         - id: k8s.credential-access.dump-secrets

--- a/v2/internal/attacktechniques/azure/persistence/backdoor-managed-identity-fic/main.go
+++ b/v2/internal/attacktechniques/azure/persistence/backdoor-managed-identity-fic/main.go
@@ -93,7 +93,7 @@ Using [Azure Activity Logs](https://learn.microsoft.com/en-us/azure/azure-monito
 
 Sample Azure Activity Log event to monitor:
 
-` + codeBlock + `json hl_lines="2 10"
+` + codeBlock + `json hl_lines="3 11"
 {
     "operationName": {
         "value": "Microsoft.ManagedIdentity/userAssignedIdentities/federatedIdentityCredentials/write",

--- a/v2/internal/attacktechniques/entra-id/persistence/backdoor-application-fic/main.go
+++ b/v2/internal/attacktechniques/entra-id/persistence/backdoor-application-fic/main.go
@@ -94,7 +94,7 @@ Using [Entra ID audit logs](https://learn.microsoft.com/en-us/entra/identity/mon
 
 Sample Entra ID audit log event to monitor:
 
-` + codeBlock + `json hl_lines="3 15 22"
+` + codeBlock + `json hl_lines="4 16 23"
 {
   "category": "ApplicationManagement",
   "result": "success",

--- a/v2/internal/attacktechniques/entra-id/persistence/hidden-au/main.go
+++ b/v2/internal/attacktechniques/entra-id/persistence/hidden-au/main.go
@@ -40,6 +40,7 @@ The backdoor user can now perform privileged operations over any user in the adm
 References:
 
 - https://learn.microsoft.com/en-us/entra/identity/role-based-access-control/administrative-units
+- https://securitylabs.datadoghq.com/articles/abusing-entra-id-administrative-units/
 
 `,
 		Detection: `

--- a/v2/internal/attacktechniques/entra-id/persistence/restricted-au/main.go
+++ b/v2/internal/attacktechniques/entra-id/persistence/restricted-au/main.go
@@ -35,6 +35,7 @@ References:
 
 - https://learn.microsoft.com/en-us/entra/identity/role-based-access-control/administrative-units
 - https://learn.microsoft.com/en-us/entra/identity/role-based-access-control/admin-units-restricted-management
+- https://securitylabs.datadoghq.com/articles/abusing-entra-id-administrative-units/
 
 Note: When cleaning up the technique, you might have to wait a few minutes for the user status to update before retrying the cleanup. This is a limitation of Entra ID.
 `,

--- a/v2/internal/attacktechniques/entra-id/privilege-escalation/access-package-group/main.go
+++ b/v2/internal/attacktechniques/entra-id/privilege-escalation/access-package-group/main.go
@@ -1,0 +1,232 @@
+package entra_id
+
+import (
+	"context"
+	_ "embed"
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/datadog/stratus-red-team/v2/pkg/stratus"
+	"github.com/datadog/stratus-red-team/v2/pkg/stratus/mitreattack"
+	msgraphsdk "github.com/microsoftgraph/msgraph-sdk-go"
+	graphcore "github.com/microsoftgraph/msgraph-sdk-go-core"
+	graphidentitygovernance "github.com/microsoftgraph/msgraph-sdk-go/identitygovernance"
+	graphmodels "github.com/microsoftgraph/msgraph-sdk-go/models"
+)
+
+const (
+	assignmentRemovalPollInterval = 5 * time.Second
+	assignmentRemovalTimeout      = 3 * time.Minute
+)
+
+//go:embed main.tf
+var tf []byte
+
+func init() {
+	const codeBlock = "```"
+	stratus.GetRegistry().RegisterAttackTechnique(&stratus.AttackTechnique{
+		ID:           "entra-id.privilege-escalation.access-package-group",
+		FriendlyName: "Escalate to Entra ID role-assignable group using access package",
+		Description: `
+Escalates a user to the Global Administrator Entra ID role using eligible group membership through an access package that does not require approvals.
+
+Roles allowing Entra ID administration are generally not available for assignment in access packages. However, role-assignable security groups allowing Entra ID administrative role assignment are still allowed.
+
+**Licensing:** This technique requires Entra ID Governance licensing.
+
+Requirements:
+Before running this technique, you will need to create an SP as a Global Administrator account and designate an account you will make the access request from:
+1. [Create an app registration and service principal](https://learn.microsoft.com/en-us/entra/identity-platform/quickstart-register-app) (SP)
+2. [Add the following](https://learn.microsoft.com/en-us/entra/identity-platform/howto-add-app-roles-in-apps#assign-app-roles-to-applications) Microsoft Graph application permissions to the app registration:
+- EntitlementManagement.ReadWrite.All
+- Group.ReadWrite.All
+- User.ReadWrite.All
+- RoleAssignmentSchedule.ReadWrite.Directory
+3. Select "Grant consent for [Directory Name]" to consent to all permissions
+4. [Add a secret](https://learn.microsoft.com/en-us/entra/identity-platform/how-to-add-credentials?tabs=client-secret) to the application
+5. Log the Azure CLI out of your current user account:
+<code>
+az logout
+</code>
+6. Copy the app registration's secret, client ID, and your tenant ID and sign in as the SP on the command line:
+<code>
+az login \
+  --service-principal \
+  --allow-no-subscriptions \
+  --username "$APP_ID" \
+  --password "$CLIENT_SECRET" \
+  --tenant "$TENANT_ID"
+</code>
+7. Configure the STRATUS_RED_TEAM_ATTACKER_ACCOUNT variable:
+<code>
+export STRATUS_RED_TEAM_ATTACKER_ACCOUNT="[USER@DOMAIN.ONMICROSOFT.COM]"
+</code>
+8. Delete the app registration once testing has completed
+
+Warmup:
+- Create a role-assignable security group
+- Assign the "Global Administrator" role to the group
+- Create an Entra ID catalog and access package with group membership assignment
+- Configure the access package policy to allow the configured user (<code>STRATUS_RED_TEAM_ATTACKER_ACCOUNT</code>) to request assignment and not require approval
+
+Detonation:
+- Provide the MyAccess Portal URL where the configured user can request the access package to demonstrate group membership assignment and escalation to Global Administrator
+
+References:
+- https://learn.microsoft.com/en-us/entra/id-governance/entitlement-management-overview
+- https://github.com/hashicorp/terraform-provider-azuread/issues/1069
+`,
+		Detection: `
+Sample [Entra ID audit logs](https://learn.microsoft.com/en-us/entra/identity/monitoring-health/concept-audit-logs) to monitor:
+
+` + codeBlock + `json hl_lines="4 14"
+{
+  "category": "EntitlementManagement",
+  "result": "success",
+  "activityDisplayName": "User requests access package assignment",
+  "activityDateTime": "2026-08-27T13:36:36.512743Z",
+  "loggedByService": "Entitlement Management",
+  "operationType": "CreateEntitlementGrantUserAddRequest",
+  "targetResources": [REMOVED]
+}
+
+{
+  "category": "EntitlementManagement",
+  "result": "success",
+  "activityDisplayName": "Auto approve access package assignment request",
+  "activityDateTime": "2026-08-27T13:28:45.223011Z",
+  "loggedByService": "Entitlement Management",
+  "operationType": "AutoApproveEntitlementGrantRequest",
+  "targetResources": [REMOVED]
+}
+` + codeBlock + `
+`,
+		Platform:                   stratus.EntraID,
+		IsIdempotent:               true,
+		IsSlow:                     false,
+		MitreAttackTactics:         []mitreattack.Tactic{mitreattack.PrivilegeEscalation},
+		PrerequisitesTerraformCode: tf,
+		Detonate:                   detonate,
+		Revert:                     revert,
+	})
+}
+
+func detonate(params map[string]string, providers stratus.CloudProviders) error {
+	log.Println("Starting technique execution")
+
+	domain := params["domain"]
+	accessPackageID := params["access_package_id"]
+	targetUserName := params["target_user_name"]
+	requestURL := fmt.Sprintf("https://myaccess.microsoft.com/@%s#/access-packages/%s", domain, accessPackageID)
+
+	log.Printf("Request the access package as %s to demonstrate escalation to Global Administrator via group membership:\n\n  %s", targetUserName, requestURL)
+
+	log.Println("Technique execution completed")
+	return nil
+}
+
+func revert(params map[string]string, providers stratus.CloudProviders) error {
+	ctx := context.Background()
+	accessPackageID := params["access_package_id"]
+	graphClient := providers.EntraId().GetGraphClient()
+
+	log.Printf("Listing active assignments for access package %s", accessPackageID)
+	assignments, err := listActiveAssignments(ctx, graphClient, accessPackageID)
+	if err != nil {
+		return fmt.Errorf("failed to list active access package assignments: %w", err)
+	}
+
+	if len(assignments) == 0 {
+		log.Println("No active access package assignments found")
+		return nil
+	}
+
+	for _, assignment := range assignments {
+		assignmentID := assignment.GetId()
+		if assignmentID == nil || *assignmentID == "" {
+			return fmt.Errorf("failed to remove access package assignment: assignment has no ID")
+		}
+
+		log.Printf("Removing access package assignment %s", *assignmentID)
+		requestBody := graphmodels.NewAccessPackageAssignmentRequest()
+		requestType := graphmodels.ADMINREMOVE_ACCESSPACKAGEREQUESTTYPE
+		requestBody.SetRequestType(&requestType)
+
+		assignmentToRemove := graphmodels.NewAccessPackageAssignment()
+		assignmentToRemove.SetId(assignmentID)
+		requestBody.SetAssignment(assignmentToRemove)
+
+		_, err = graphClient.IdentityGovernance().EntitlementManagement().AssignmentRequests().Post(ctx, requestBody, nil)
+		if err != nil {
+			return fmt.Errorf("failed to request removal of access package assignment %s: %w", *assignmentID, err)
+		}
+	}
+
+	log.Println("Waiting for active access package assignments to be removed")
+	waitCtx, cancel := context.WithTimeout(ctx, assignmentRemovalTimeout)
+	defer cancel()
+
+	for {
+		assignments, err = listActiveAssignments(waitCtx, graphClient, accessPackageID)
+		if err != nil {
+			return fmt.Errorf("failed to check active access package assignments: %w", err)
+		}
+		if len(assignments) == 0 {
+			log.Println("All active access package assignments removed")
+			return nil
+		}
+
+		select {
+		case <-waitCtx.Done():
+			return fmt.Errorf("timed out waiting for %d active access package assignment(s) to be removed: %w. Try reverting again.", len(assignments), waitCtx.Err())
+		case <-time.After(assignmentRemovalPollInterval):
+		}
+	}
+}
+
+func listActiveAssignments(ctx context.Context, graphClient *msgraphsdk.GraphServiceClient, accessPackageID string) ([]*graphmodels.AccessPackageAssignment, error) {
+	filter := fmt.Sprintf("accessPackage/id eq '%s'", accessPackageID)
+	response, err := graphClient.IdentityGovernance().EntitlementManagement().Assignments().Get(ctx, &graphidentitygovernance.EntitlementManagementAssignmentsRequestBuilderGetRequestConfiguration{
+		QueryParameters: &graphidentitygovernance.EntitlementManagementAssignmentsRequestBuilderGetQueryParameters{
+			Filter: &filter,
+		},
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	iterator, err := graphcore.NewPageIterator[*graphmodels.AccessPackageAssignment](response, graphClient.GetAdapter(), graphmodels.CreateAccessPackageAssignmentCollectionResponseFromDiscriminatorValue)
+	if err != nil {
+		return nil, err
+	}
+
+	activeAssignments := make([]*graphmodels.AccessPackageAssignment, 0)
+	err = iterator.Iterate(ctx, func(assignment *graphmodels.AccessPackageAssignment) bool {
+		if isActiveAssignment(assignment) {
+			activeAssignments = append(activeAssignments, assignment)
+		}
+		return true
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return activeAssignments, nil
+}
+
+func isActiveAssignment(assignment *graphmodels.AccessPackageAssignment) bool {
+	state := assignment.GetState()
+	if state == nil {
+		return false
+	}
+
+	switch *state {
+	case graphmodels.DELIVERING_ACCESSPACKAGEASSIGNMENTSTATE,
+		graphmodels.PARTIALLYDELIVERED_ACCESSPACKAGEASSIGNMENTSTATE,
+		graphmodels.DELIVERED_ACCESSPACKAGEASSIGNMENTSTATE:
+		return true
+	default:
+		return false
+	}
+}

--- a/v2/internal/attacktechniques/entra-id/privilege-escalation/access-package-group/main.go
+++ b/v2/internal/attacktechniques/entra-id/privilege-escalation/access-package-group/main.go
@@ -42,7 +42,7 @@ Before running this technique, you will need to create an SP as a Global Adminis
 - EntitlementManagement.ReadWrite.All
 - Group.ReadWrite.All
 - User.ReadWrite.All
-- RoleAssignmentSchedule.ReadWrite.Directory
+- RoleManagement.ReadWrite.Directory
 3. Select "Grant consent for [Directory Name]" to consent to all permissions
 4. [Add a secret](https://learn.microsoft.com/en-us/entra/identity-platform/how-to-add-credentials?tabs=client-secret) to the application
 5. Log the Azure CLI out of your current user account:

--- a/v2/internal/attacktechniques/entra-id/privilege-escalation/access-package-group/main.go
+++ b/v2/internal/attacktechniques/entra-id/privilege-escalation/access-package-group/main.go
@@ -179,7 +179,7 @@ func revert(params map[string]string, providers stratus.CloudProviders) error {
 
 		select {
 		case <-waitCtx.Done():
-			return fmt.Errorf("timed out waiting for %d active access package assignment(s) to be removed: %w. Try reverting again.", len(assignments), waitCtx.Err())
+			return fmt.Errorf("timed out waiting for %d active access package assignment(s) to be removed: %w, try reverting again", len(assignments), waitCtx.Err())
 		case <-time.After(assignmentRemovalPollInterval):
 		}
 	}

--- a/v2/internal/attacktechniques/entra-id/privilege-escalation/access-package-group/main.tf
+++ b/v2/internal/attacktechniques/entra-id/privilege-escalation/access-package-group/main.tf
@@ -1,0 +1,154 @@
+terraform {
+  required_providers {
+    azuread = {
+      source  = "hashicorp/azuread"
+      version = "2.53.1"
+    }
+    external = {
+      source = "hashicorp/external"
+    }
+  }
+}
+
+# # # # # # # # # # # # # # # # # # # # # # # # # # # # #
+# Initialize + Random
+# # # # # # # # # # # # # # # # # # # # # # # # # # # # #
+data "azuread_domains" "default" {
+  only_initial = true
+}
+
+data "azuread_client_config" "current" {}
+
+locals {
+  resource_prefix = "srt-eapg" # stratus red team entra access package group
+  domain_name     = data.azuread_domains.default.domains.0.domain_name
+}
+
+resource "random_string" "suffix" {
+  length  = 4
+  special = false
+  upper   = false
+}
+
+# # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
+# User Data
+# NOTE: If the STRATUS_RED_TEAM_ATTACKER_ACCOUNT env var is unset during execution,
+# this may cause an error in cleanup. However, this does not seem likely to be frequent.
+# # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
+
+# Fetch user to apply policy to
+data "external" "stratus_account" {
+  program = [
+    "bash", "-c",
+    "if [ -z \"$STRATUS_RED_TEAM_ATTACKER_ACCOUNT\" ]; then echo 'STRATUS_RED_TEAM_ATTACKER_ACCOUNT must be set to the UPN of an existing Entra ID user. Use export STRATUS_RED_TEAM_ATTACKER_ACCOUNT=[ACCOUNT NAME] to set.' >&2; exit 1; fi; jq -n --arg upn \"$STRATUS_RED_TEAM_ATTACKER_ACCOUNT\" '{upn: $upn}'"
+  ]
+}
+
+# Fetch details from Entra
+data "azuread_user" "user" {
+  user_principal_name = data.external.stratus_account.result.upn
+}
+
+# # # # # # # # # # # # # # # # # # # # # # # # # # # # #
+# Role-Assignable Group + Role Assignment
+# # # # # # # # # # # # # # # # # # # # # # # # # # # # #
+
+# Role-assignable security group that will hold the Global Administrator role
+resource "azuread_group" "target" {
+  display_name       = "${local.resource_prefix}-group-${random_string.suffix.result}"
+  security_enabled   = true
+  assignable_to_role = true
+}
+
+resource "azuread_directory_role" "ga" {
+  display_name = "Global Administrator"
+}
+
+# Assign the Global Administrator role to the group
+resource "azuread_directory_role_assignment" "group_ga" {
+  role_id             = azuread_directory_role.ga.id
+  principal_object_id = azuread_group.target.object_id
+}
+
+# # # # # # # # # # # # # # # # # # # # # # # # # # # # #
+# Catalog + Access Package (group membership assignment)
+# # # # # # # # # # # # # # # # # # # # # # # # # # # # #
+
+resource "azuread_access_package_catalog" "catalog" {
+  display_name = "${local.resource_prefix}-catalog-${random_string.suffix.result}"
+  description  = "Stratus Red Team access package catalog"
+}
+
+resource "azuread_access_package" "package" {
+  catalog_id   = azuread_access_package_catalog.catalog.id
+  display_name = "${local.resource_prefix}-access-package-${random_string.suffix.result}"
+  description  = "Stratus Red Team access package granting role-assignable group membership"
+}
+
+# Add the role-assignable group to the catalog as an assignable resource
+resource "azuread_access_package_resource_catalog_association" "group" {
+  catalog_id             = azuread_access_package_catalog.catalog.id
+  resource_origin_id     = azuread_group.target.object_id
+  resource_origin_system = "AadGroup"
+}
+
+# Grant membership of the group through the access package
+resource "azuread_access_package_resource_package_association" "group" {
+  access_package_id               = azuread_access_package.package.id
+  catalog_resource_association_id = azuread_access_package_resource_catalog_association.group.id
+  access_type                     = "Member"
+}
+
+# # # # # # # # # # # # # # # # # # # # # # # # # # # # #
+# Assignment Policy (current user may request, no approval)
+# # # # # # # # # # # # # # # # # # # # # # # # # # # # #
+
+resource "azuread_access_package_assignment_policy" "policy" {
+  access_package_id = azuread_access_package.package.id
+  display_name      = "${local.resource_prefix}-policy-${random_string.suffix.result}"
+  description       = "Allows the current user to request assignment without approval"
+  duration_in_days  = 365
+
+  requestor_settings {
+    requests_accepted = true
+    scope_type        = "SpecificDirectorySubjects"
+
+    requestor {
+      object_id    = data.azuread_user.user.object_id
+      subject_type = "singleUser"
+    }
+  }
+
+  approval_settings {
+    approval_required = false
+  }
+}
+
+# # # # # # # # # # # # # # # # # # # # # # # # # # # # #
+# Output
+# # # # # # # # # # # # # # # # # # # # # # # # # # # # #
+
+output "group_id" {
+  value = azuread_group.target.object_id
+}
+
+output "access_package_id" {
+  value = azuread_access_package.package.id
+}
+
+output "target_user_name" {
+  value = data.azuread_user.user.user_principal_name
+}
+
+output "domain" {
+  value = data.azuread_domains.default.domains.0.domain_name
+}
+
+output "display" {
+  value = format(
+    "Existing user %s is eligible to request membership in role-assignable group %s (Global Administrator) through access package %s without approval.",
+    data.azuread_user.user.user_principal_name,
+    azuread_group.target.display_name,
+    azuread_access_package.package.display_name
+  )
+}

--- a/v2/internal/attacktechniques/main.go
+++ b/v2/internal/attacktechniques/main.go
@@ -69,6 +69,7 @@ import (
 	_ "github.com/datadog/stratus-red-team/v2/internal/attacktechniques/entra-id/persistence/hidden-au"
 	_ "github.com/datadog/stratus-red-team/v2/internal/attacktechniques/entra-id/persistence/new-application"
 	_ "github.com/datadog/stratus-red-team/v2/internal/attacktechniques/entra-id/persistence/restricted-au"
+	_ "github.com/datadog/stratus-red-team/v2/internal/attacktechniques/entra-id/privilege-escalation/access-package-group"
 	_ "github.com/datadog/stratus-red-team/v2/internal/attacktechniques/gcp/credential-access/secretmanager-retrieve-secrets"
 	_ "github.com/datadog/stratus-red-team/v2/internal/attacktechniques/gcp/defense-evasion/delete-dns-logs"
 	_ "github.com/datadog/stratus-red-team/v2/internal/attacktechniques/gcp/defense-evasion/delete-logging-sink"


### PR DESCRIPTION
### What does this PR do?

* Adds technique "Escalate to Entra ID role-assignable group using access package"
* Fixes documentation lines that are highlighted incorrectly in previous Entra techniques (azure.persistence.backdoor-managed-identity-fic, entra-id.persistence.backdoor-application-fic, entra-id.persistence.hidden-au, entra-id.persistence.restricted-au)
* Documentation fixes can be split off if technique is too complex to commit at present (see below)

### Motivation

* **Technique:** Create a role-assignable group with Global Admin assigned, and add membership in this group to an access package. Make a target user eligible for the access package, and share a link the user can request as the user to demonstrate escalation.
* **Motivation:** While this has not been detailed in the wild, it illustrates use of access packages in a manner similar to role-assignment or privileged identity management (PIM) methods that are commonly abused. This will help illustrate what the technique looks like and what logs to look for.
* Entra role assignments through access packages are not officially supported yet in Terraform + Microsoft Graph API & do not work yet as the feature is in preview. This technique provides an alternative approach to illustrate a similar risk of escalation.

### Design limitations
Due to Azure CLI limiting assignable scopes (https://github.com/Azure/azure-cli/issues/22775, https://github.com/hashicorp/terraform-provider-azuread/issues/1069), it's not currently possible to deploy this technique with a user account. An SP must be created and used for this technique.

Technique Description includes details on how to create this SP under "Requirements". There's no pre-warmup validation check to validate running as an SP with the right scopes before this, but I could add one in Terraform if we think it's not over-engineering.

This may make the technique a poor fit for Stratus at this time, but I feel it can still illustrate a technique that's otherwise difficult to set up.

### Checklist

- [x] The attack technique emulates a single attack step, not a full attack chain
- [ ] We have factual evidence & references that the attack technique was used by real malware, pentesters, or attackers
- [x] The attack technique makes no assumption about the state of the environment prior to warming it up