### PR TITLE
Bump azurerm Terraform provider from 3.8.0 to 4.81.0

### DIFF
--- a/.claude/skills/create-attack-technique/references/provider-configs.md
+++ b/.claude/skills/create-attack-technique/references/provider-configs.md
@@ -36,7 +36,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "3.8.0"
+      version = "4.81.0"
     }
   }
 }

--- a/v2/internal/attacktechniques/azure/credential-access/app-service-publishing-credentials/main.tf
+++ b/v2/internal/attacktechniques/azure/credential-access/app-service-publishing-credentials/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "3.8.0"
+      version = "4.81.0"
     }
   }
 }

--- a/v2/internal/attacktechniques/azure/execution/vm-custom-script-extension/main.tf
+++ b/v2/internal/attacktechniques/azure/execution/vm-custom-script-extension/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "3.8.0"
+      version = "4.81.0"
     }
   }
 }

--- a/v2/internal/attacktechniques/azure/execution/vm-run-command/main.tf
+++ b/v2/internal/attacktechniques/azure/execution/vm-run-command/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "3.8.0"
+      version = "4.81.0"
     }
   }
 }

--- a/v2/internal/attacktechniques/azure/exfiltration/disk-export/main.tf
+++ b/v2/internal/attacktechniques/azure/exfiltration/disk-export/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "3.8.0"
+      version = "4.81.0"
     }
   }
 }

--- a/v2/internal/attacktechniques/azure/exfiltration/storage-public-access/main.tf
+++ b/v2/internal/attacktechniques/azure/exfiltration/storage-public-access/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "3.8.0"
+      version = "4.81.0"
     }
   }
 }

--- a/v2/internal/attacktechniques/azure/exfiltration/storage-sas-export/main.tf
+++ b/v2/internal/attacktechniques/azure/exfiltration/storage-sas-export/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "3.8.0"
+      version = "4.81.0"
     }
   }
 }

--- a/v2/internal/attacktechniques/azure/impact/blob-ransomware-client-encryption-scope/main.tf
+++ b/v2/internal/attacktechniques/azure/impact/blob-ransomware-client-encryption-scope/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "3.8.0"
+      version = "4.81.0"
     }
   }
 }

--- a/v2/internal/attacktechniques/azure/impact/blob-ransomware-cpek/main.tf
+++ b/v2/internal/attacktechniques/azure/impact/blob-ransomware-cpek/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "3.8.0"
+      version = "4.81.0"
     }
   }
 }

--- a/v2/internal/attacktechniques/azure/impact/blob-ransomware-individual-file-deletion/main.tf
+++ b/v2/internal/attacktechniques/azure/impact/blob-ransomware-individual-file-deletion/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "3.8.0"
+      version = "4.81.0"
     }
   }
 }

--- a/v2/internal/attacktechniques/azure/impact/blob-ransomware-service-storage-cmk/main.tf
+++ b/v2/internal/attacktechniques/azure/impact/blob-ransomware-service-storage-cmk/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "3.8.0"
+      version = "4.81.0"
     }
   }
 }

--- a/v2/internal/attacktechniques/azure/impact/resource-lock/main.tf
+++ b/v2/internal/attacktechniques/azure/impact/resource-lock/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "3.8.0"
+      version = "4.81.0"
     }
   }
 }

--- a/v2/internal/attacktechniques/azure/persistence/backdoor-managed-identity-fic/main.tf
+++ b/v2/internal/attacktechniques/azure/persistence/backdoor-managed-identity-fic/main.tf
@@ -6,7 +6,7 @@ terraform {
     }
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "3.8.0"
+      version = "4.81.0"
     }
   }
 }

--- a/v2/internal/attacktechniques/azure/persistence/create-bastion-shareable-link/main.tf
+++ b/v2/internal/attacktechniques/azure/persistence/create-bastion-shareable-link/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "3.8.0"
+      version = "4.81.0"
     }
   }
 }

--- a/v2/internal/attacktechniques/azure/persistence/exfiltrate-foundry-key/main.tf
+++ b/v2/internal/attacktechniques/azure/persistence/exfiltrate-foundry-key/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "4.80.0"
+      version = "4.81.0"
     }
   }
 }

--- a/v2/internal/attacktechniques/entra-id/persistence/backdoor-application-fic/main.tf
+++ b/v2/internal/attacktechniques/entra-id/persistence/backdoor-application-fic/main.tf
@@ -6,7 +6,7 @@ terraform {
     }
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "3.8.0"
+      version = "4.81.0"
     }
   }
 }


### PR DESCRIPTION
### What does this PR do?

Enhancement — upgrades the `hashicorp/azurerm` Terraform provider from `3.8.0`
to the latest 4.x release (`4.81.0`) across all Azure and Entra ID attack
techniques, plus the `create-attack-technique` scaffold reference so new
techniques are generated on 4.x.

### Motivation

The azurerm 3.x provider is incompatible with federated (OIDC) authentication
and forces a local `az` CLI dependency to resolve the subscription. The 4.x
provider supports OIDC and resolves the subscription from the
`ARM_SUBSCRIPTION_ID` environment variable — which Stratus Red Team already
sets at runtime (mapped from `AZURE_SUBSCRIPTION_ID` in
`v2/pkg/stratus/runner/terraform.go`). As a result no provider block or resource
argument had to change: the bare `provider "azurerm" { features {} }` blocks
work as-is against 4.x.

**Details**
- 15 techniques bumped `3.8.0` → `4.81.0`; `exfiltrate-foundry-key` (already on
  `4.80.0`) bumped to `4.81.0` for consistency — 16 files, one version string each.
- The `azuread` provider (`2.53.1`, used by `backdoor-application-fic` and
  `backdoor-managed-identity-fic`) is intentionally left untouched — out of scope.
- Deprecation cleanups flagged for a future v5.0-readiness pass, deliberately
  **not** included here to keep this a pure version bump:
  `enable_rbac_authorization` → `rbac_authorization_enabled`, and
  `storage_account_name`/`storage_container_name` → `storage_account_id`/
  `storage_container_id`.

### Verification

- [x] `terraform fmt -recursive -check` passes (matches `terraform-lint.yml` CI)
- [x] `terraform init` + `terraform validate` against azurerm 4.81.0 succeeds for
      every changed technique (only non-blocking v5.0 deprecation warnings)
- [x] `go test ./...` passes (matches `test.yml` CI)
- [x] No provider-block or resource-argument changes required — diff is version
      strings only (16 insertions / 16 deletions)

### Checklist

_The new-attack-technique checklist does not apply — this is a dependency upgrade,
not a new technique._

🤖 Generated with [Claude Code](https://claude.com/claude-code)
